### PR TITLE
Move bluebird from devDep to regular dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
   "author": "Stephan Seidt <stephan@contentful.com>",
   "license": "MIT",
   "dependencies": {
+    "bluebird": "~2.1.2",
     "redefine": "~0.2.0",
     "questor": "1.0.0",
     "inherits": "^2.0.1",
     "underscore-contrib": "0.2.2"
   },
   "devDependencies": {
-    "bluebird": "~2.1.2",
     "browserify": "~3.20.0",
     "browserstack-cli": "~0.3.1",
     "buster": "~0.7.6",


### PR DESCRIPTION
Hi,

I ran into some issues when using this library inside another project, [sprout-static-cms](https://github.com/carrot/sprout-static-cms). This project is a template that is then consumed by [sprout](https://github.com/carrot/sprout), a CLI tool for generating projects from templates. Sprout `require`s this [init.coffee](https://github.com/carrot/sprout-static-cms/blob/master/init.coffee) file to allow interactive setup through the CLI as well as providing some hooks each template can tap into to run custom code. I'm trying to integrate `contentful-management` into one of these hooks in order to do some account setup for the user.

Currently when I'm requiring in the init file, I get the following error stack:

```
Error: Cannot find module 'bluebird'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/Users/josh/code/sprout-static-cms/node_modules/contentful-management/rate-limit.js:7:16)
```

which appears to come from [this line](https://github.com/contentful/contentful-management.js/blob/872298611a1fbd71de6ae982fdc1283f50c897e7/rate-limit.js#L7) in the code. On further inspection, it appears that `bluebird` isn't being installed when using npm because it is listed under `devDependencies` instead of a regular `dependencies`. When I make this fix, `contentful-management` works perfectly with `sprout`.
