### PR TITLE
[Fixed] Add runtime dep on es6-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "axios": "^0.8.1",
     "inherits": "^2.0.1",
     "redefine": "^0.2.0",
-    "underscore-contrib": "0.2.2"
+    "underscore-contrib": "0.2.2",
+    "es6-promise": "^2.3.0"
   },
   "devDependencies": {
-    "es6-promise": "^2.3.0",
     "browserify": "~3.20.0",
     "browserstack-cli": "~0.3.1",
     "buster": "~0.7.6",


### PR DESCRIPTION
`es6-promise` is used throughout the code (https://github.com/contentful/contentful-management.js/search?utf8=%E2%9C%93&q=es6-promise)  but it's not exported as a runtime dep.