### PR TITLE
fix(asset): Pass processingCheckWait and processingCheckWait to the next call

### DIFF
--- a/lib/entities/asset.js
+++ b/lib/entities/asset.js
@@ -68,7 +68,9 @@ function createAssetApi (http) {
             reject: reject,
             id: id,
             locale: locale,
-            checkCount: checkCount
+            checkCount: checkCount,
+            processingCheckWait,
+            processingCheckRetries
           }),
           processingCheckWait
         )


### PR DESCRIPTION
The bug is that after the first setTimeout both parameters are reset to their default values (5 &
500) because they are not passed further down the setTimeout chain.

closes #64