### PR TITLE
Use the real method names for unpublish and unarchive in jsdoc

### DIFF
--- a/lib/entities/asset.js
+++ b/lib/entities/asset.js
@@ -38,10 +38,10 @@ const ASSET_PROCESSING_CHECK_RETRIES = 5
  * @property {boolean} isDraft - Checks if the asset is in draft mode. This means it is not published.
  * @property {function(): Promise<Asset>} update - Updates an asset
  * @property {function(): Promise<Asset>} delete - Deletes an asset
- * @property {function(): Promise<Asset>} publish - publish an asset
- * @property {function(): Promise<Asset>} unPublish - unPublish an asset
- * @property {function(): Promise<Asset>} archive - archive an asset
- * @property {function(): Promise<Asset>} unArchive - unArchive an asset
+ * @property {function(): Promise<Asset>} publish - Publishes an asset
+ * @property {function(): Promise<Asset>} unpublish - Unpublishes an asset
+ * @property {function(): Promise<Asset>} archive - Archives an asset
+ * @property {function(): Promise<Asset>} unarchive - Unarchives an asset
  * @property {function(locale: string, options: {processingCheckWait: number, processingCheckRetries: number}): Promise<Asset>} processForLocale - Triggers asset processing after an upload, for the file uploaded to a specific locale.
  * @property {function(options: {processingCheckWait: number, processingCheckRetries: number}): Promise<Asset>} processForAllLocales - Triggers asset processing after an upload, for the files uploaded to all locales of an asset.
  * @property {function(): Object} toPlainObject - Returns this Asset as a plain JS object

--- a/lib/entities/entry.js
+++ b/lib/entities/entry.js
@@ -28,9 +28,9 @@ import {
  * @property {function(): Promise<Entry>} update - Updates an entry in the server 
  * @property {function(): Promise<Entry>} delete - Deletes an entry on the server
  * @property {function(): Promise<Entry>} publish - Publishes an entry
- * @property {function(): Promise<Entry>} unPublish - Un-publishes an entry
+ * @property {function(): Promise<Entry>} unpublish - Unpublishes an entry
  * @property {function(): Promise<Entry>} archive - Archives an entry
- * @property {function(): Promise<Entry>} unArchive - Un-archives an entry
+ * @property {function(): Promise<Entry>} unarchive - Unarchives an entry
  * @property {function(): Object} toPlainObject - Returns this Entry as a plain JS object
  * @example
  * // require contentful-management


### PR DESCRIPTION
### Why this change

Because the docs at https://contentful.github.io/contentful-management.js/contentful-management/1.3.0/typedef/index.html#static-typedef-Entry mention methods that do not exist: `unArchive` and `unPublish`