### PR TITLE
fix(build): use release-ci.sh from sdk-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ install:
   - npm install
 language: node_js
 node_js:
-  - "7.5"
   - "6.9"
   - "4.7"
 script: npm run test:ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script: npm run test:ci
 after_success:
   - cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
   - export $(cat .to_export_back) &> /dev/null
-  - npm run semantic-release
+  - ./node_modules/contentful-sdk-jsdoc/bin/release-ci.sh 
 addons:
   sauce_connect: true
 branches:

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   ],
   "dependencies": {
     "axios": "~0.15.3",
-    "contentful-sdk-core": "^3.5.9",
+    "contentful-sdk-core": "^3.5.10",
     "es6-promise": "^4.0.5",
     "lodash": "^4.17.4"
   },


### PR DESCRIPTION
Instead of running `npm run semantic-release` and make semantic-release on which platform to release which will be always the leader version of the test. We call it only once in the spefic version we want.

This PR depends on https://github.com/contentful/contentful-sdk-core/pull/12