### PR TITLE
feat(rateLimit): Adapt to the new ratelimit api

### DIFF
--- a/lib/contentful-management.js
+++ b/lib/contentful-management.js
@@ -7,7 +7,7 @@
 
 import cloneDeep from 'lodash/cloneDeep'
 import assign from 'lodash/assign'
-import { createHttpClient, rateLimit } from 'contentful-sdk-core'
+import {createHttpClient} from 'contentful-sdk-core'
 import version from '../version'
 import createContentfulApi from './create-contentful-api'
 
@@ -45,7 +45,6 @@ export default function createClient (axios, params) {
   params.headers = assign(params.headers || {}, requiredHeaders)
 
   const http = createHttpClient(axios, params)
-  rateLimit(http, params.maxRetries)
   const api = createContentfulApi({
     http: http
   })

--- a/lib/entities/asset.js
+++ b/lib/entities/asset.js
@@ -16,8 +16,8 @@ import {
   createArchivedChecker
 } from '../instance-actions'
 
-const ASSET_PROCESSING_CHECK_WAIT = 500
-const ASSET_PROCESSING_CHECK_RETRIES = 5
+const ASSET_PROCESSING_CHECK_WAIT = 2000
+const ASSET_PROCESSING_CHECK_RETRIES = 10
 
 /**
  * @typedef {Asset} Asset

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   ],
   "dependencies": {
     "axios": "~0.15.3",
-    "contentful-sdk-core": "^3.6.1",
+    "contentful-sdk-core": "^3.7.0",
     "es6-promise": "^4.0.5",
     "lodash": "^4.17.4"
   },

--- a/test/unit/contentful-management-test.js
+++ b/test/unit/contentful-management-test.js
@@ -14,13 +14,10 @@ test('Throws if no accessToken is defined', (t) => {
 test('Passes along HTTP client parameters', (t) => {
   createClient.__Rewire__('version', 'version')
   const createHttpClientStub = sinon.stub()
-  const rateLimitStub = sinon.stub()
   createClient.__Rewire__('createHttpClient', createHttpClientStub)
-  createClient.__Rewire__('rateLimit', rateLimitStub)
   createClient.__Rewire__('createContentfulApi', sinon.stub().returns({}))
 
   const client = createClient(axios, {accessToken: 'accesstoken'})
-  t.ok(rateLimitStub.called, 'wraps http client')
   t.ok(createHttpClientStub.args[0][1].headers['Content-Type'], 'sets the content type')
   t.equals(createHttpClientStub.args[0][1].headers['X-Contentful-User-Agent'], 'contentful-management.js/version', 'sets the user agent header')
   t.ok(client, 'returns a client')


### PR DESCRIPTION
The new sdk-core version which is [here](https://github.com/contentful/contentful-sdk-core/pull/14) will the remove the export of the ratelimit function as it will be inside the `creaHttpClient` so no need to use outside