### PR TITLE
fix(build): fix umd filename

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,7 +37,7 @@ module.exports = {
     path: path.join(__dirname, 'dist'),
     filename: 'contentful-management.js',
     libraryTarget: 'umd',
-    library: 'contentful-management'
+    library: 'contentfulManagement'
   },
   module: {
     loaders: [


### PR DESCRIPTION
the library name in the browser was `contentful-management` but it should be `contentfulManagement` for easy access, this is not a breaking change.