### PR TITLE
feat(isUpdated): now returns boolean false instead of undefined

### DIFF
--- a/lib/instance-actions.js
+++ b/lib/instance-actions.js
@@ -86,7 +86,7 @@ export function createUpdatedChecker () {
   return function () {
     // The act of publishing an entity increases its version by 1, so any entry which has
     // 2 versions higher or more than the publishedVersion has unpublished changes.
-    return this.sys.publishedVersion && this.sys.version > this.sys.publishedVersion + 1
+    return !!(this.sys.publishedVersion && this.sys.version > this.sys.publishedVersion + 1)
   }
 }
 


### PR DESCRIPTION
This is actually a bugfix but marked as feature to avoid issues with semantic-release. (I accidentally released the beta version as 3.9.3 which would now collide with the bugfix. I'll push further beta's with as 4.0 so this won't happen again)