### PR TITLE
feat(user): add `user/me` endpoint

### DIFF
--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -52,7 +52,8 @@ import entities from './entities'
  * @return {ClientAPI}
  */
 export default function createClientApi ({ http }) {
-  const {wrapSpace, wrapUser, wrapSpaceCollection} = entities.space
+  const {wrapSpace, wrapSpaceCollection} = entities.space
+  const {wrapUser} = entities.user
   const {wrapOrganizationCollection} = entities.organization
 
   /**

--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -41,7 +41,7 @@
 import { createRequestConfig } from 'contentful-sdk-core'
 import errorHandler from './error-handler'
 import entities from './entities'
-
+import {wrapUser} from './entities/user'
 /**
  * Creates API object with methods to access functionality from Contentful's
  * Management API
@@ -53,7 +53,6 @@ import entities from './entities'
  */
 export default function createClientApi ({ http }) {
   const {wrapSpace, wrapSpaceCollection} = entities.space
-  const {wrapUser} = entities.user
   const {wrapOrganizationCollection} = entities.organization
 
   /**

--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -157,7 +157,7 @@ export default function createClientApi ({ http }) {
     return http.get('', {
       baseURL
     })
-    .then((response) => wrapUser(http, response.data), errorHandler)
+      .then((response) => wrapUser(http, response.data), errorHandler)
   }
   /**
    * Make a custom request to the Contentful management API's /spaces endpoint

--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -41,7 +41,6 @@
 import { createRequestConfig } from 'contentful-sdk-core'
 import errorHandler from './error-handler'
 import entities from './entities'
-import {wrapUser} from './entities/user'
 /**
  * Creates API object with methods to access functionality from Contentful's
  * Management API
@@ -53,6 +52,7 @@ import {wrapUser} from './entities/user'
  */
 export default function createClientApi ({ http }) {
   const {wrapSpace, wrapSpaceCollection} = entities.space
+  const {wrapUser} = entities.user
   const {wrapOrganizationCollection} = entities.organization
 
   /**

--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -52,7 +52,7 @@ import entities from './entities'
  * @return {ClientAPI}
  */
 export default function createClientApi ({ http }) {
-  const {wrapSpace, wrapSpaceCollection} = entities.space
+  const {wrapSpace, wrapUser, wrapSpaceCollection} = entities.space
   const {wrapOrganizationCollection} = entities.organization
 
   /**
@@ -143,6 +143,23 @@ export default function createClientApi ({ http }) {
   }
 
   /**
+   * Gets the authenticated user
+   * @return {Promise<User>} Promise for a User
+   * @example
+   * const contentful = require('contentful-management')
+   *
+   * space.getCurrentUser()
+   * .then(user => console.log(user.firstName))
+   * .catch(console.error)
+   */
+  function getCurrentUser () {
+    const baseURL = http.defaults.baseURL.replace('/spaces/', '/users/me/')
+    return http.get('', {
+      baseURL
+    })
+    .then((response) => wrapUser(http, response.data), errorHandler)
+  }
+  /**
    * Make a custom request to the Contentful management API's /spaces endpoint
    * @memberof ContentfulClientAPI
    * @param {Object} opts - axios request options (https://github.com/mzabriskie/axios)
@@ -170,6 +187,7 @@ export default function createClientApi ({ http }) {
     getSpace: getSpace,
     createSpace: createSpace,
     getOrganizations: getOrganizations,
+    getCurrentUser: getCurrentUser,
     rawRequest: rawRequest
   }
 }

--- a/lib/entities/index.js
+++ b/lib/entities/index.js
@@ -12,6 +12,7 @@ import * as upload from './upload'
 import * as organization from './organization'
 import * as uiExtension from './ui-extension'
 import * as snapshot from './snapshot'
+import * as user from './user'
 
 export default {
   space,
@@ -27,5 +28,6 @@ export default {
   upload,
   organization,
   uiExtension,
-  snapshot
+  snapshot,
+  user
 }

--- a/lib/entities/user.js
+++ b/lib/entities/user.js
@@ -1,0 +1,29 @@
+import { freezeSys, toPlainObject } from 'contentful-sdk-core'
+import enhanceWithMethods from '../enhance-with-methods'
+import cloneDeep from 'lodash/cloneDeep'
+/**
+ * @memberof User
+ * @typedef User
+ * @prop {Object} sys - System metadata
+ * @prop {string} sys.id - User id
+ * @prop {string} sys.type - Entity type
+ * @prop {string} firstName - User first name
+ * @prop {string} lastName - User last name
+ * @prop {string} avatarUrl - User avatar url
+ * @prop {string} email - User email
+ * @prop {boolean} activated - User activated
+ * @prop {number} signInCount - User sign in count
+ * @prop {boolean} confirmed - User confirmed
+ * @prop {function(): Object} toPlainObject() - Returns this User as a plain JS object
+ */
+
+/*
+ *
+ * @private
+ * */
+export function wrapUser (http, data) {
+  const user = toPlainObject(cloneDeep(data))
+  enhanceWithMethods(user, {})
+  return freezeSys(user)
+}
+

--- a/lib/entities/user.js
+++ b/lib/entities/user.js
@@ -26,4 +26,3 @@ export function wrapUser (http, data) {
   enhanceWithMethods(user, {})
   return freezeSys(user)
 }
-

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "docs:watch": "nodemon --exec npm run docs:dev -w lib",
     "docs:publish": "npm run docs:build && ./node_modules/contentful-sdk-jsdoc/bin/publish-docs.sh contentful-management.js contentful-management",
     "lint": "eslint lib test",
+    "format": "eslint --fix lib test",
     "pretest": "rimraf coverage && npm run lint",
     "test": "npm run test:cover && npm run test:integration && npm run test:browser-local && npm run test:size",
     "test:ci": "./node_modules/contentful-sdk-core/bin/test-ci.sh",

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -44,10 +44,10 @@ test('Gets organizations', (t) => {
 test('Gets User', (t) => {
   t.plan(2)
   return client.getCurrentUser()
-  .then((user) => {
-    t.ok(user, 'user')
-    t.ok(user.sys, 'user.sys')
-  })
+    .then((user) => {
+      t.ok(user, 'user')
+      t.ok(user.sys, 'user.sys')
+    })
 })
 
 test('Gets space', (t) => {

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -41,6 +41,15 @@ test('Gets organizations', (t) => {
     })
 })
 
+test('Gets User', (t) => {
+  t.plan(2)
+  return client.getCurrentUser()
+  .then((user) => {
+    t.ok(user, 'user')
+    t.ok(user.sys, 'user.sys')
+  })
+})
+
 test('Gets space', (t) => {
   t.plan(2)
   return client.getSpace('cfexampleapi')

--- a/test/unit/create-contentful-api-test.js
+++ b/test/unit/create-contentful-api-test.js
@@ -1,6 +1,7 @@
 import test from 'blue-tape'
+import sinon from 'sinon'
 
-import {spaceMock, setupEntitiesMock, organizationMock} from './mocks/entities'
+import {spaceMock, setupEntitiesMock, organizationMock, userMock} from './mocks/entities'
 import setupHttpMock from './mocks/http'
 import createContentfulApi, {__RewireAPI__ as createContentfulApiRewireApi} from '../../lib/create-contentful-api'
 import {makeGetEntityTest, makeGetCollectionTest, makeEntityMethodFailingTest} from './test-creators/static-entity-methods'
@@ -84,4 +85,38 @@ test('API call createSpace fails', (t) => {
   makeEntityMethodFailingTest(t, setup, teardown, {
     methodToTest: 'createSpace'
   })
+})
+
+test('API call getCurrentUser', (t) => {
+  makeGetEntityTest(t, setup, teardown, {
+    entityType: 'user',
+    mockToReturn: userMock,
+    methodToTest: 'getCurrentUser'
+  })
+})
+
+test('API call getCurrentUser fails', (t) => {
+  makeEntityMethodFailingTest(t, setup, teardown, {
+    methodToTest: 'getCurrentUser'
+  })
+})
+
+test('API call rawRequest', (t) => {
+  const httpMock = sinon.stub().resolves({
+    data: {
+      response: true
+    }
+  })
+
+  const api = createContentfulApi({ http: httpMock })
+
+  return api.rawRequest({ opts: true })
+    .then((response) => {
+      t.looseEqual(response, {
+        response: true
+      }, 'returns plain response')
+      t.looseEqual(httpMock.args[0][0], {
+        opts: true
+      }, 'passes opts to http client')
+    })
 })

--- a/test/unit/entities/user-test.js
+++ b/test/unit/entities/user-test.js
@@ -1,0 +1,18 @@
+import test from 'tape'
+import {cloneMock} from '../mocks/entities'
+import setupHttpMock from '../mocks/http'
+import {wrapUser} from '../../../lib/entities/user'
+import {entityWrappedTest} from '../test-creators/instance-entity-methods'
+
+function setup (promise) {
+  return {
+    httpMock: setupHttpMock(promise),
+    entityMock: cloneMock('user')
+  }
+}
+
+test('User is wrapped', (t) => {
+  entityWrappedTest(t, setup, {
+    wrapperMethod: wrapUser
+  })
+})

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -25,7 +25,7 @@ const spaceMock = {
 }
 
 const userMock = {
-  sys: assign(cloneDeep(sysMock), {
+  sys: Object.assign(cloneDeep(sysMock), {
     type: 'User'
   }),
   firstName: 'Dwight',

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -281,6 +281,9 @@ function setupEntitiesMock (rewiredModuleApi) {
     uiExtension: {
       wrapUiExtension: sinon.stub(),
       wrapUiExtensionCollection: sinon.stub()
+    },
+    user: {
+      wrapUser: sinon.stub()
     }
   }
   rewiredModuleApi.__Rewire__('entities', entitiesMock)

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -24,6 +24,19 @@ const spaceMock = {
   locales: [ 'en-US' ]
 }
 
+const userMock = {
+  sys: assign(cloneDeep(sysMock), {
+    type: 'User'
+  }),
+  firstName: 'Dwight',
+  lastName: 'Schrute',
+  avatarUrl: 'https://images.contentful.com/abcd1234',
+  email: 'dwight@dundermifflin.com',
+  activated: true,
+  signInCount: 1,
+  confirmed: true
+}
+
 const contentTypeMock = {
   sys: Object.assign(cloneDeep(sysMock), {
     type: 'ContentType'
@@ -197,7 +210,8 @@ const mocks = {
   error: errorMock,
   upload: uploadMock,
   organization: organizationMock,
-  uiExtension: uiExtensionMock
+  uiExtension: uiExtensionMock,
+  user: userMock
 }
 
 function cloneMock (name) {
@@ -295,5 +309,6 @@ export {
   uploadMock,
   organizationMock,
   uiExtensionMock,
-  snapShotMock
+  snapShotMock,
+  userMock
 }


### PR DESCRIPTION
This PR adds the `/user/me/` endpoint to be able to get the currently authenticated user.

- [x] Unit test
- [x] Integration test ??