### PR TITLE
fix(asset): safely handle case where file is null

### DIFF
--- a/lib/entities/asset.js
+++ b/lib/entities/asset.js
@@ -102,7 +102,7 @@ function createAssetApi (http) {
 
   function processForAllLocales (options = {}) {
     const self = this
-    const locales = Object.keys(this.fields.file)
+    const locales = Object.keys(this.fields.file || {})
     return Promise.all(locales.map((locale) => processForLocale.call(self, locale, options)))
     .then((assets) => assets[0])
   }


### PR DESCRIPTION
when doing bulk export/import I encountered a rare but possible scenario where the `this.fields.file` variable was not set. rather than letting the script fail from calling `Object.keys` on a null or undefined object, this change will simply default to an empty object. Thus, locales will be an empty array and gracefully exit the function.