### PR TITLE
fix: add browser entry point to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://www.contentful.com/developers/documentation/content-management-api/",
   "main": "./dist/contentful-management.node.js",
   "module": "./dist/es-modules/contentful-management.js",
+  "browser": "./dist/contentful-management.browser.js",
   "engines": {
     "node": ">=6"
   },


### PR DESCRIPTION
With the release of Webpack 4, there's a [`resolve.mainFields` configuration](https://webpack.js.org/configuration/resolve/#resolve-mainfields), which defines which `package.json` fields are checked in which order to determine the entry point of a package import.

Without a `target`(or `target` being `web` / `webworker`) the order is the following:
```js
mainFields: ["browser", "module", "main"]
```

Angular 6 for example seems to have not altered such main fields or targets, causing https://github.com/contentful/contentful.js/issues/243.
I used the example project Khaled created here: https://github.com/contentful/contentful.js/issues/243#issuecomment-390141336

I could remove the manual `paths` mapping, and the type was correctly inferred again.

