### PR TITLE
improve deprecation message

### DIFF
--- a/lib/create-space-api.js
+++ b/lib/create-space-api.js
@@ -57,6 +57,18 @@ import entities from './entities'
  * @prop {function} getContentTypeSnapshots
  */
 
+function raiseDeprecationWarning (method) {
+  console.warn(
+    [
+      `Deprecated: Space.${method}() will be removed in future major versions.`,
+      null,
+      `Please migrate your code to use Environment.${method}():`,
+      `https://contentful.github.io/contentful-management.js/contentful-management/latest/ContentfulEnvironmentAPI.html#.${method}`,
+      null
+    ].join('\n')
+  )
+}
+
 /**
  * Creates API object with methods to access the Space API
  * @private
@@ -253,7 +265,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function getContentType (id) {
-    console.warn('Deprecated: Space.getContentType() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('getContentType')
     return http.get('content_types/' + id)
       .then((response) => wrapContentType(http, response.data), errorHandler)
   }
@@ -277,7 +289,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function getEditorInterfaceForContentType (contentTypeId) {
-    console.warn('Deprecated: Space.getEditorInterfaceForContentType() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('getEditorInterfaceForContentType')
     return http.get('content_types/' + contentTypeId + '/editor_interface')
       .then((response) => wrapEditorInterface(http, response.data), errorHandler)
   }
@@ -301,7 +313,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
   */
   function getContentTypes (query = {}) {
-    console.warn('Deprecated: Space.getContentTypes() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('getContentTypes')
     return http.get('content_types', createRequestConfig({query: query}))
       .then((response) => wrapContentTypeCollection(http, response.data), errorHandler)
   }
@@ -337,7 +349,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function createContentType (data) {
-    console.warn('Deprecated: Space.createContentType() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('createContentType')
     return http.post('content_types', data)
       .then((response) => wrapContentType(http, response.data), errorHandler)
   }
@@ -374,7 +386,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function createContentTypeWithId (id, data) {
-    console.warn('Deprecated: Space.createContentTypeWithId() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('createContentTypeWithId')
     return http.put('content_types/' + id, data)
       .then((response) => wrapContentType(http, response.data), errorHandler)
   }
@@ -401,7 +413,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function getEntry (id, query = {}) {
-    console.warn('Deprecated: Space.getEntry() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('getEntry')
     normalizeSelect(query)
     return http.get('entries/' + id, createRequestConfig({query: query}))
       .then((response) => wrapEntry(http, response.data), errorHandler)
@@ -428,7 +440,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function getEntries (query = {}) {
-    console.warn('Deprecated: Space.getEntries() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('getEntries')
     normalizeSelect(query)
     return http.get('entries', createRequestConfig({query: query}))
       .then((response) => wrapEntryCollection(http, response.data), errorHandler)
@@ -461,7 +473,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function createEntry (contentTypeId, data) {
-    console.warn('Deprecated: Space.createEntry() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('createEntry')
     return http.post('entries', data, {
       headers: {
         'X-Contentful-Content-Type': contentTypeId
@@ -499,7 +511,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function createEntryWithId (contentTypeId, id, data) {
-    console.warn('Deprecated: Space.createEntryWithId() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('createEntryWithId')
     return http.put('entries/' + id, data, {
       headers: {
         'X-Contentful-Content-Type': contentTypeId
@@ -530,7 +542,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
   */
   function getAsset (id, query = {}) {
-    console.warn('Deprecated: Space.getAsset() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('getAsset')
     normalizeSelect(query)
     return http.get('assets/' + id, createRequestConfig({query: query}))
       .then((response) => wrapAsset(http, response.data), errorHandler)
@@ -557,7 +569,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
   */
   function getAssets (query = {}) {
-    console.warn('Deprecated: Space.getAssets() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('getAssets')
     normalizeSelect(query)
     return http.get('assets', createRequestConfig({query: query}))
       .then((response) => wrapAssetCollection(http, response.data), errorHandler)
@@ -632,7 +644,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function createAssetWithId (id, data) {
-    console.warn('Deprecated: Space.createAssetWithId() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('createAssetWithId')
     return http.put('assets/' + id, data)
       .then((response) => wrapAsset(http, response.data), errorHandler)
   }
@@ -670,7 +682,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function createAssetFromFiles (data) {
-    console.warn('Deprecated: Space.createAssetFromFiles() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('createAssetFromFiles')
     const { file } = data.fields
     return Promise.all(
       Object.keys(file).map((locale) => {
@@ -723,7 +735,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function createUpload (data) {
-    console.warn('Deprecated: Space.createUpload() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('createUpload')
     const { file } = data
     if (!file) {
       return Promise.reject(new Error('Unable to locate a file to upload.'))
@@ -756,7 +768,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function getUpload (id) {
-    console.warn('Deprecated: Space.getUpload() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('getUpload')
     return httpUpload.get('uploads/' + id)
       .then((response) => wrapUpload(http, response.data))
       .catch(errorHandler)
@@ -781,7 +793,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
   */
   function getLocale (id) {
-    console.warn('Deprecated: Space.getLocale() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('getLocale')
     return http.get('locales/' + id)
       .then((response) => wrapLocale(http, response.data), errorHandler)
   }
@@ -804,7 +816,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
   */
   function getLocales () {
-    console.warn('Deprecated: Space.getLocales() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('getLocales')
     return http.get('locales')
       .then((response) => wrapLocaleCollection(http, response.data), errorHandler)
   }
@@ -835,7 +847,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function createLocale (data) {
-    console.warn('Deprecated: Space.createLocale() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('createLocale')
     return http.post('locales', data)
       .then((response) => wrapLocale(http, response.data), errorHandler)
   }
@@ -1372,7 +1384,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function getUiExtension (id) {
-    console.warn('Deprecated: Space.getUiExtension() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('getUiExtension')
     return http.get('extensions/' + id)
       .then((response) => wrapUiExtension(http, response.data), errorHandler)
   }
@@ -1395,7 +1407,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function getUiExtensions () {
-    console.warn('Deprecated: Space.getUiExtensions() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('getUiExtensions')
     return http.get('extensions')
       .then((response) => wrapUiExtensionCollection(http, response.data), errorHandler)
   }
@@ -1434,7 +1446,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function createUiExtension (data) {
-    console.warn('Deprecated: Space.createUiExtension() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('createUiExtension')
     return http.post('extensions', data)
       .then((response) => wrapUiExtension(http, response.data), errorHandler)
   }
@@ -1474,7 +1486,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function createUiExtensionWithId (id, data) {
-    console.warn('Deprecated: Space.createUiExtensionWithId() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('createUiExtensionWithId')
     return http.put('extensions/' + id, data)
       .then((response) => wrapUiExtension(http, response.data), errorHandler)
   }
@@ -1498,7 +1510,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function getEntrySnapshots (entryId) {
-    console.warn('Deprecated: Space.getEntrySnapshots() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('getEntrySnapshots')
     return http.get(`entries/${entryId}/snapshots`)
       .then((response) => wrapSnapshotCollection(http, response.data), errorHandler)
   }
@@ -1522,7 +1534,7 @@ export default function createSpaceApi ({
    * .catch(console.error)
    */
   function getContentTypeSnapshots (contentTypeId) {
-    console.warn('Deprecated: Space.getContentTypeSnapshots() will be removed in version 6.0. Please migrate your code to use the new environments API.')
+    raiseDeprecationWarning('getContentTypeSnapshots')
     return http.get(`content_types/${contentTypeId}/snapshots`)
       .then((response) => wrapSnapshotCollection(http, response.data), errorHandler)
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-management",
-  "version": "5.0.0-beta2",
+  "version": "0.0.0-determined-by-semantic-release",
   "description": "Client for Contentful's Content Management API",
   "homepage": "https://www.contentful.com/developers/documentation/content-management-api/",
   "main": "./dist/contentful-management.node.js",


### PR DESCRIPTION
Turns 

```
Deprecated: Space.getContentTypes() will be removed in version 6.0. Please migrate your code to use the new environments API.
```

into

```
Deprecated: Space.getContentTypes() will be removed in future major versions.

Please migrate your code to use Environment.getContentTypes():
https://contentful.github.io/contentful-management.js/contentful-management/latest/ContentfulEnvironmentAPI.html#.getContentTypes
```