### PR TITLE
fix(ContentType): Use vanilla js find instead of lodash with shorthand.

### DIFF
--- a/lib/entities/content-type.js
+++ b/lib/entities/content-type.js
@@ -4,7 +4,6 @@
  */
 
 import cloneDeep from 'lodash/cloneDeep'
-import find from 'lodash/find'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import {
@@ -251,7 +250,7 @@ function createContentTypeApi (http) {
      * @return {Promise<ContentType>}
      */
     findAndUpdateField: function (id, key, value) {
-      const field = find(this.fields, {'id': id})
+      const field = this.fields.find((field) => field.id === id)
       if (!field) {
         return Promise.reject(new Error(`Tried to omitAndDeleteField on a nonexistent field, ${id}, on the content type ${this.name}.`))
       }


### PR DESCRIPTION
Our lodash-webpack plugin removes some parts of lodash, including _.matches shorthand, which we were using in contentType omitAndDelete helper. It didn't fail for unit tests but broke integration tests.

This PR removes using lodash _.find altogether and replaces it with vanilla js find.