### PR TITLE
fix(locale): fix fallBackCode update

### DIFF
--- a/lib/entities/locale.js
+++ b/lib/entities/locale.js
@@ -49,6 +49,7 @@ function createLocaleApi (http) {
      */
     update: function () {
       const locale = this
+      delete locale.default // we should not send this back
       return createUpdateEntity({
         http: http,
         entityPath: 'locales',

--- a/lib/entities/locale.js
+++ b/lib/entities/locale.js
@@ -49,10 +49,6 @@ function createLocaleApi (http) {
      */
     update: function () {
       const locale = this
-      // this property shouldn't be sent back if it exists
-      delete locale.default
-      delete locale.fallback_code
-      delete locale.fallbackCode
       return createUpdateEntity({
         http: http,
         entityPath: 'locales',

--- a/test/integration/locale-integration.js
+++ b/test/integration/locale-integration.js
@@ -9,7 +9,7 @@ export function localeTests (t, space) {
   })
 
   t.test('Creates, gets, updates and deletes a locale', (t) => {
-    t.plan(3)
+    t.plan(4)
     return space.createLocale({
       name: 'German (Austria)',
       code: 'de-AT'
@@ -22,9 +22,11 @@ export function localeTests (t, space) {
               .then((locale) => {
                 t.equals(locale.code, 'de-AT', 'locale code after getting')
                 locale.name = 'Deutsch (Österreich)'
+                locale.fallbackCode = 'en-US'
                 return locale.update()
                   .then((updatedLocale) => {
                     t.equals(updatedLocale.name, 'Deutsch (Österreich)', 'locale name after update')
+                    t.equals(updatedLocale.fallbackCode, 'en-US', 'locale fallbackCode after update')
                     return updatedLocale.delete()
                   })
               }))


### PR DESCRIPTION
There was a workaround for an API bug for `fallbackCode` but now it is fixed and this transformed into a bug in the SDK not being able to update a fallback locale for a given locale.
This PR fix the issue