### PR TITLE
Fix: remove browser field in package.json as contentful-sdk-core has been fixed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "homepage": "https://www.contentful.com/developers/documentation/content-management-api/",
   "main": "./dist/contentful-management.node.js",
   "module": "./dist/es-modules/contentful-management.js",
-  "browser": "./dist/contentful-management.browser.js",
   "engines": {
     "node": ">=6"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@contentful/axios": "^0.18.0",
-    "contentful-sdk-core": "^6.0.0",
+    "contentful-sdk-core": "^6.0.1",
     "lodash": "^4.17.10"
   },
   "devDependencies": {


### PR DESCRIPTION
We can safely remove the browser field now thus fixing the webpack tree shaking. See relevant issue:
https://github.com/contentful/contentful.js/issues/260
