### PR TITLE
update JSDOC comments for specific environment entry publish

### DIFF
--- a/lib/entities/asset.js
+++ b/lib/entities/asset.js
@@ -170,9 +170,10 @@ function createAssetApi (http) {
      * })
      *
      * client.getSpace('<space_id>')
-     * .then((space) => space.getAsset('<asset_id>'))
-     * .then((asset) => asset.publish())
-     * .then((asset) => console.log(`Asset ${asset.sys.id} published.`)
+     * .then((space) => space.getEnvironment('<environment_id>'))
+     * .then((environment) => environment.getEntry('<entry_id>'))
+     * .then((entry) => entry.publish())
+     * .then((entry) => console.log(`Entry ${entry.sys.id} published.`))
      * .catch(console.error)
    */
     publish: createPublishEntity({


### PR DESCRIPTION
Generated docs for Javascript SDK don't accurately show an example of publishing an entry to a specific environment.

https://github.com/contentful/contentful-management.js/issues/200