### PR TITLE
feat(environments): add environment source parameter

### DIFF
--- a/lib/create-space-api.js
+++ b/lib/create-space-api.js
@@ -223,11 +223,12 @@ export default function createSpaceApi ({
   }
 
   /**
-   * Creates an Environement with a custom id
+   * Creates an Environment with a custom id
    * @memberof ContentfulSpaceAPI
    * @see {Environment}
    * @param id string - custom id
    * @param {object} [data] - Object representation of the Environment to be created
+   * @param sourceEnvironmentId - (Optional) ID of the source environment that will be copied to create the new environment. Default is "master"
    * @return {Promise<Environment.Environment>} Promise for the newly created Environment
    * @example
    * const contentful = require('contentful-management')
@@ -237,12 +238,14 @@ export default function createSpaceApi ({
    * })
    *
    * client.getSpace('<space_id>')
-   * .then((space) => space.createEnvironment('<custom-id>', { name: 'Staging' }))
+   * .then((space) => space.createEnvironmentWithId('<custom-id>', { name: 'Staging'}, 'master'))
    * .then((environment) => console.log(environment))
    * .catch(console.error)
    */
-  function createEnvironmentWithId (id, data = {}) {
-    return http.put('environments/' + id, data)
+  function createEnvironmentWithId (id, data = {}, sourceEnvironmentId = 'master') {
+    return http.put('environments/' + id, data, {
+      headers: { 'X-Contentful-Source-Environment': sourceEnvironmentId }
+    })
       .then((response) => wrapEnvironment(http, response.data), errorHandler)
   }
 

--- a/test/integration/environment-integration.js
+++ b/test/integration/environment-integration.js
@@ -1,0 +1,64 @@
+export function environmentTests (t, space, waitForEnvironmentToBeReady) {
+  t.test('creates an environment', (t) => {
+    t.plan(2)
+    return space.createEnvironment({name: 'test-env'})
+      .then((response) => {
+        t.ok(response.sys.type, 'Environment', 'env is created')
+        t.ok(response.name, 'test-env', 'env is created with name')
+      })
+  })
+
+  t.test('creates an enviroment with an id', (t) => {
+    t.plan(2)
+    return space.createEnvironmentWithId('myId', {name: 'myId'})
+      .then((response) => {
+        t.equals(response.name, 'myId', 'env was created with correct name')
+        t.equals(response.sys.id, 'myId', 'env was created with id')
+      })
+  })
+
+  t.test('env is created with master as source when no source id is provided', (t) => {
+    t.plan(4)
+    return space.createContentTypeWithId('testEntity', {name: 'testEntity'})
+      .then((contentType) => contentType.publish())
+      .then(() => space.createEnvironmentWithId('newEnv', {name: 'newEnv'}))
+      .then((environment) => {
+        t.equals(environment.name, 'newEnv', 'env is created with correct name')
+        t.equals(environment.sys.id, 'newEnv', 'env is created with correct id')
+        return waitForEnvironmentToBeReady(space, environment)
+      })
+      .then((readyEnv) => readyEnv.getContentType('testEntity'))
+      .then((testCts) => {
+        t.ok(testCts)
+        t.equals(testCts.sys.id, 'testEntity', 'new env still has content type, created from master')
+      })
+  })
+
+  t.test('creates environment from given source environment', (t) => {
+    t.plan(2)
+    let fromMasterCtCount = 0
+    // create an env from master, note how many contentTypes it has
+    return space.createEnvironmentWithId('fromMaster', {name: 'fromMaster'})
+      .then((environment) => waitForEnvironmentToBeReady(space, environment))
+      .then((readyEnvironment) => readyEnvironment.getContentTypes())
+      .then((contentTypes) => {
+        fromMasterCtCount = contentTypes.items.length
+      })
+      // write something to master
+      .then(() => space.createContentTypeWithId('myNewEntity', {name: 'myNewEntity'}))
+      .then((contentType) => contentType.publish())
+      // confirm num cts in master
+      .then(() => space.getContentTypes())
+      .then((masterCts) => {
+        t.notEquals(masterCts, fromMasterCtCount, 'master has more content types than "fromMaster" env')
+      })
+      // create a new env with "fromMaster" as the source
+      .then(() => space.createEnvironmentWithId('newEmptyEnv', {name: 'newEmptyEnv'}, 'fromMaster'))
+      .then((newEnv) => waitForEnvironmentToBeReady(space, newEnv))
+      .then((readyNewEnv) => readyNewEnv.getContentTypes())
+      // expect cts to be same as "fromMaster"
+      .then((cts) => {
+        t.equals(cts.items.length, fromMasterCtCount, 'new env with non-master source has correct num content types')
+      })
+  })
+}

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -12,6 +12,7 @@ import apiKeyTests from './api-key-integration'
 import uiExtensionTests from './ui-extension-integration'
 import generateRandomId from './generate-random-id'
 import { createClient } from '../../'
+import { environmentTests } from './environment-integration'
 
 const params = {
   accessToken: process.env.CONTENTFUL_ACCESS_TOKEN
@@ -153,7 +154,8 @@ test('Create space for tests which create, change and delete data', (t) => {
         spaceMembershipTests(t, space),
         roleTests(t, space),
         apiKeyTests(t, space),
-        uiExtensionTests(t, space)
+        uiExtensionTests(t, space),
+        environmentTests(t, space, waitForEnvironmentToBeReady)
       ])
     })
 })


### PR DESCRIPTION
currently, the beta version of contentful-management.js points to a beta version of axios. The contentful-cli needs this beta version of axios because of the way it handles proxy args being passed around (for the recorded integration tests).

In order to add env branching to the cli, i need it to be in the beta version of the cma sdk.

This PR just cherry picks the env branching from `master` and puts it into "next".