### PR TITLE
feat(environments): do not send source header if sourceEnvId is not provided

### DIFF
--- a/lib/create-space-api.js
+++ b/lib/create-space-api.js
@@ -242,9 +242,9 @@ export default function createSpaceApi ({
    * .then((environment) => console.log(environment))
    * .catch(console.error)
    */
-  function createEnvironmentWithId (id, data = {}, sourceEnvironmentId = 'master') {
+  function createEnvironmentWithId (id, data = {}, sourceEnvironmentId) {
     return http.put('environments/' + id, data, {
-      headers: { 'X-Contentful-Source-Environment': sourceEnvironmentId }
+      headers: sourceEnvironmentId ? { 'X-Contentful-Source-Environment': sourceEnvironmentId } : {}
     })
       .then((response) => wrapEnvironment(http, response.data), errorHandler)
   }

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -161,7 +161,7 @@ test('Fails to get space', (t) => {
     })
 })
 
-test.only('Creates, updates and deletes a space', (t) => {
+test('Creates, updates and deletes a space', (t) => {
   t.plan(2)
   return client.createSpace({
     name: 'spacename'

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -161,7 +161,7 @@ test('Fails to get space', (t) => {
     })
 })
 
-test('Creates, updates and deletes a space', (t) => {
+test.only('Creates, updates and deletes a space', (t) => {
   t.plan(2)
   return client.createSpace({
     name: 'spacename'


### PR DESCRIPTION
This PR updates the createEnvironmentWithId method to only send the source header if the source has been provided. This behavior is desired because of future feature flagging.