### PR TITLE
fix(access_token): Use correct HTTP method (#223)

### DIFF
--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -295,7 +295,7 @@ export default function createClientApi ({ http }) {
    */
   function getPersonalAccessToken (tokenId) {
     const baseURL = http.defaults.baseURL.replace('/spaces/', '/users/me/access_tokens')
-    return http.post(tokenId, {
+    return http.get(tokenId, {
       baseURL
     })
       .then((response) => wrapPersonalAccessToken(http, response.data), errorHandler)


### PR DESCRIPTION
Fixes an issue with 404 HTTP error always returned when calling `.getPersonalAccessToken('tokenId')`