### PR TITLE
fix: Add typings folder in files section

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "files": [
     "dist",
+    "typings",
     "tonic-example.js"
   ],
   "dependencies": {


### PR DESCRIPTION
The typings are missing in the NPM package 