### PR TITLE
fix(instance-actions): do not send default 0 for sys.version

### DIFF
--- a/lib/instance-actions.js
+++ b/lib/instance-actions.js
@@ -12,7 +12,7 @@ export function createUpdateEntity ({http, entityPath, wrapperMethod, headers}) 
     delete data.sys
     return http.put(entityPath + '/' + this.sys.id, data, {
       headers: {
-        'X-Contentful-Version': this.sys.version || 0, // if there is no sys.version, just send 0
+        'X-Contentful-Version': this.sys.version,
         ...headers
       }
     })


### PR DESCRIPTION
Now that env aliases always have a sys.version, send it and remove the safeguard (since this is what alerted me to the sys.version inconsistency in the first place).