### PR TITLE
Update Asset typings

### DIFF
--- a/typings/asset.d.ts
+++ b/typings/asset.d.ts
@@ -12,7 +12,8 @@ export interface AssetProps {
         contentType: string,
         upload?: string,
         url?: string,
-        details: Object,
+        details?: Object,
+        uploadFrom?: Object
       }
     }
   }


### PR DESCRIPTION
Added upload from field to the asset typings. Made details optional. (Relates to issue #235 )

This fix is needed for when you are updating an asset with a new uploaded file.