### PR TITLE
chore(ts): Add missing ContentFields properties

### DIFF
--- a/typings/contentFields.d.ts
+++ b/typings/contentFields.d.ts
@@ -1,19 +1,49 @@
+export interface NumRange {
+  min: number
+  max: number
+}
+
+export interface DateRange {
+  min: string
+  max: string
+}
+
+export interface RegExp {
+  pattern: string
+  flags: string
+}
+
 export interface Validation {
-  linkContentType: string[],
+  linkContentType?: string[]
+  in?: string[]
+  linkMimetypeGroup?: string[]
+  enabledNodeTypes?: string[]
+  enabledMarks?: string[]
+  unique?: boolean
+  size?: NumRange
+  range?: NumRange
+  dateRange?: DateRange
+  regexp?: RegExp
+  prohibitRegexp?: RegExp
+  assetImageDimensions?: {
+    width?: NumRange
+    height?: NumRange
+  }
+  assetFileSize?: NumRange
 }
 
 export interface Item {
-  type: string,
-  linkType: string,
-  validations: Validation[],
+  type: string
+  linkType?: string
+  validations?: Validation[]
 }
 
 export interface ContentFields extends Item {
-  id: string,
-  name: string,
-  required: boolean,
-  localized: boolean,
-  disabled: boolean,
-  omitted: boolean,
-  items: Item
+  id: string
+  name: string
+  required: boolean
+  localized: boolean
+  disabled?: boolean
+  omitted?: boolean
+  items?: Item
 }

--- a/typings/contentFields.d.ts
+++ b/typings/contentFields.d.ts
@@ -1,11 +1,11 @@
 export interface NumRange {
-  min: number
-  max: number
+  min?: number
+  max?: number
 }
 
 export interface DateRange {
-  min: string
-  max: string
+  min?: string
+  max?: string
 }
 
 export interface RegExp {

--- a/typings/contentFields.d.ts
+++ b/typings/contentFields.d.ts
@@ -1,8 +1,19 @@
-export interface ContentFields {
+export interface Validation {
+  linkContentType: string[],
+}
+
+export interface Item {
+  type: string,
+  linkType: string,
+  validations: Validation[],
+}
+
+export interface ContentFields extends Item {
   id: string,
   name: string,
   required: boolean,
   localized: boolean,
-  type: string,
-
+  disabled: boolean,
+  omitted: boolean,
+  items: Item
 }


### PR DESCRIPTION
Add missing ContentFields properties to typescript definition file `contentFields.d.ts`

Resolves #238 