### PR TITLE
fix(types): Add typecheck for getSpaces query params skip and limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     },
     {
       "path": "./dist/contentful-management.browser.min.js",
-      "maxSize": "18Kb"
+      "maxSize": "19Kb"
     },
     {
       "path": "./dist/contentful-management.legacy.js",
@@ -133,7 +133,7 @@
     },
     {
       "path": "./dist/contentful-management.node.js",
-      "maxSize": "72Kb"
+      "maxSize": "73Kb"
     },
     {
       "path": "./dist/contentful-management.node.min.js",

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -307,6 +307,7 @@ test('Logs request and response with custom loggers', (t) => {
     .then((response) => {
       t.equal(responseLoggerStub.callCount, 1, 'responseLogger is called')
       t.equal(requestLoggerStub.callCount, 1, 'requestLogger is called')
-      t.equal(requestLoggerStub.args[0][0].url, 'https://api.contentful.com:443/spaces/ezs1swce23xe', 'requestLogger is called with correct url')
+      const {baseURL, url} = requestLoggerStub.args[0][0]
+      t.equal(`${baseURL}${url}`, 'https://api.contentful.com:443/spaces/ezs1swce23xe', 'requestLogger is called with correct url')
     })
 })

--- a/typings/contentfulManagement.d.ts
+++ b/typings/contentfulManagement.d.ts
@@ -33,6 +33,11 @@ export interface ClientParams {
 
 export interface UsageFilter {filters: {metric: 'cda' | 'cma' | 'cpa' | 'all_apis', usagePeriod: string}, orderBy?: {metricUsage?: string}}
 
+export interface getSpacesParams {
+  limit?: number,
+  skip?: number  
+}
+
 export interface ClientAPI {
   createPersonalAccessToken(data: PersonalAccessTokenProp): Promise<PersonalAccessToken>,
   createSpace(data: SpaceProps, organizationId: string): Promise<Space>,
@@ -41,7 +46,7 @@ export interface ClientAPI {
   getPersonalAccessToken(data: PersonalAccessTokenProp): Promise<void>,
   getPersonalAccessTokens(): Promise<Collection<PersonalAccessToken>>,
   getSpace(id: string): Promise<Space>,
-  getSpaces(): Promise<Collection<Space>>
+  getSpaces(params?: getSpacesParams): Promise<Collection<Space>>
   getUsagePeriods(organizationId: string): Promise<Collection<UsagePeriod>>
   getUsages(organizationId: string, type: 'organization' | 'space', query: UsageFilter): Promise<Collection<Usage>>
   rawRequest(Opts: AxiosRequestConfig): Promise<AxiosResponse>


### PR DESCRIPTION
Make the params `limit` and `skip` available for TypeScript users.