### PR TITLE
fix: ensure to return the most recent version when processing multiple asset locales

### DIFF
--- a/lib/entities/asset.js
+++ b/lib/entities/asset.js
@@ -102,8 +102,22 @@ function createAssetApi (http) {
   function processForAllLocales (options = {}) {
     const self = this
     const locales = Object.keys(this.fields.file || {})
-    return Promise.all(locales.map((locale) => processForLocale.call(self, locale, options)))
-      .then((assets) => assets[0])
+
+    let mostUpToDateAssetVersion
+
+    // Let all the locales process
+    // Since they all resolve at different times,
+    // we need to pick the last resolved value
+    // to reflect the most recent state
+    const allProcessingLocales = locales.map((locale) => processForLocale.call(self, locale, options).then((result) => {
+      // Side effect of always setting the most up to date asset version
+      // The last one to call this will be the last one that finished
+      // and thus the most up to date
+      mostUpToDateAssetVersion = result
+    }))
+
+    return Promise.all(allProcessingLocales)
+      .then(() => mostUpToDateAssetVersion)
   }
 
   return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-management",
-  "version": "5.2.1",
+  "version": "5.12.0",
   "description": "Client for Contentful's Content Management API",
   "homepage": "https://www.contentful.com/developers/documentation/content-management-api/",
   "main": "./dist/contentful-management.node.js",


### PR DESCRIPTION
Currently when an asset has multiple locales, we trigger processing for them all individually in parallel, but when they finish we only return the result of the first triggered task.

This leads to a race condition where sometimes the version number is off, and subsequent publishing fails.

Change this logic to always return the last successfully processed asset state, which should then have the correct version for publishing.