### PR TITLE
fix(typings): add retryLimit to client opts

### DIFF
--- a/typings/contentfulManagement.d.ts
+++ b/typings/contentfulManagement.d.ts
@@ -29,6 +29,7 @@ export interface ClientParams {
   application?: null | string,
   integration?: null | string,
   timeout?: number,
+  retryLimit?: number,
 }
 
 export interface UsageFilter {filters: {metric: 'cda' | 'cma' | 'cpa' | 'all_apis', usagePeriod: string}, orderBy?: {metricUsage?: string}}


### PR DESCRIPTION
The `retryLimit` option is present in the documentation and appears to work correctly in the implementation but is missing from the type declaration file, causing a type error when trying to use it in TS.