### PR TITLE
chore(types): Add missing typings for env alias and env delete

### DIFF
--- a/typings/apiKey.d.ts
+++ b/typings/apiKey.d.ts
@@ -14,7 +14,8 @@ export interface ApiKey
   policies: { effect: string; action: string }[],
   preview_api_key: MetaSys<MetaLinkProps>,
   delete(): Promise<void>,
-  update(): Promise<ApiKey>
+  update(): Promise<ApiKey>,
+  environments: MetaSys<MetaLinkProps>[]
 }
 
 export interface CreateApiKeyProps extends ApiKeyProps {

--- a/typings/environment.d.ts
+++ b/typings/environment.d.ts
@@ -31,6 +31,7 @@ export interface Environment extends DefaultElements<EnvironmentProps>, MetaSys<
   createUpload(data: {
     file: string | ArrayBuffer | Stream
   }): Promise<Upload>,
+  delete(): Promise<{}>,
   getAsset(id: string, query?: Object): Promise<Asset>,
   getAssets(query?: Object): Promise<Collection<Asset>>,
   getContentTypes(object?: QueryOptions): Promise<Collection<ContentType>>,

--- a/typings/space.d.ts
+++ b/typings/space.d.ts
@@ -1,5 +1,5 @@
 import { DefaultElements } from './defaultElements'
-import { MetaSys } from './meta'
+import { MetaSys, MetaSysProps } from './meta'
 import { ApiKey, CreateApiKeyProps } from './apiKey'
 import { Collection } from './collection'
 import { Environment, EnvironmentProps } from './environment'
@@ -20,6 +20,11 @@ import { PreviewApiKey } from './previewApiKey'
 
 export interface SpaceProps {
   name: string
+}
+
+export interface EnvironmentAlias extends MetaSys<MetaSysProps> {
+  environment: Environment
+  update(): Promise<EnvironmentAlias>
 }
 
 export interface ContentfulSpaceAPI {
@@ -59,6 +64,7 @@ export interface ContentfulSpaceAPI {
   getEntry(id: string): Promise<Entry>,
   getEntries(object?: QueryOptions): Promise<Collection<Entry>>,
   getEntrySnapshots(id: string): Promise<Collection<Snapshot<EntryProp>>>,
+  getEnvironmentAlias(name: string): Promise<EnvironmentAlias>,
   getLocale(id: string): Promise<Locale>,
   getLocales(): Promise<Collection<Locale>>,
   getUiExtension(id: string): Promise<UIExtension>,


### PR DESCRIPTION
These are probably not complete, just the things I found when moving the ideas from https://www.contentful.com/developers/docs/tutorials/general/continuous-integration-with-circleci/
into TypeScript.

Biggest caveat is that I expect this isn't actually where you want to export `EnvironmentAlias` from. Feel free to edit away or toss this out and do it a different way, but I wanted to make sure I at least got it submitted upstream.

I have a workaround in the meantime, that I put in my own project's `src/@types/patches/contentful/index.d.ts` - sharing in case it helps others before this or similar gets merged: https://gist.github.com/trptcolin/618214a5f22500131885b6fb89202696

refs #257