### PR TITLE
Add  getSpaceUser and getSpaceUsers endpoint in space api

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Both of these test environments are setup to deal with Babel and code transpilin
 Code is documented using JSDoc 3, and reference documentation is published automatically with each new version.
 
 - `npm run docs:watch` watches code directory, and rebuilds documentation when anything changes. Useful for documentation writing and development.
-- `npm run docs:dev` builds code and builds docs afterwards. Used by `npm run docs:watch`. Code building is required as the documentation is generated from the unminified ES5 compiled sources, rather than the original ES6 sources. You should then open the generated `out/contentful/index.html` in your browser.
+- `npm run docs:dev` builds code and builds docs afterwards. Used by `npm run docs:watch`. Code building is required as the documentation is generated from the unminified ES5 compiled sources, rather than the original ES6 sources. You should then open the generated `out/index.html` in your browser.
 - `npm run docs:build` builds documentation.
 - `npm run docs:publish` builds documentation and publishes it to github pages.
 

--- a/lib/create-space-api.js
+++ b/lib/create-space-api.js
@@ -41,6 +41,8 @@ import entities from './entities'
  * @prop {function} getRoles
  * @prop {function} createRole
  * @prop {function} createRoleWithId
+ * @prop {function} getSpaceUser
+ * @prop {function} getSpaceUsers
  * @prop {function} getSpaceMembership
  * @prop {function} getSpaceMemberships
  * @prop {function} createSpaceMembership
@@ -91,6 +93,7 @@ export default function createSpaceApi ({
   const {wrapLocale, wrapLocaleCollection} = entities.locale
   const {wrapWebhook, wrapWebhookCollection} = entities.webhook
   const {wrapRole, wrapRoleCollection} = entities.role
+  const { wrapUser, wrapUserCollection } = entities.user
   const {wrapSpaceMembership, wrapSpaceMembershipCollection} = entities.spaceMembership
   const {wrapApiKey, wrapApiKeyCollection} = entities.apiKey
   const {wrapPreviewApiKey, wrapPreviewApiKeyCollection} = entities.previewApiKey
@@ -959,6 +962,43 @@ export default function createSpaceApi ({
   }
 
   /**
+   * Gets a User
+   * @memberof ContentfulSpaceAPI
+   * @param {string} id - User ID
+   * @return {Promise<User.User>} Promise for a User
+   * @example
+   * const contentful = require('contentful-management')
+   *
+   * client.getSpace('<space_id>')
+   * .then((space) => space.getSpaceUser('id'))
+   * .then((user) => console.log(user))
+   * .catch(console.error)
+   */
+  function getSpaceUser (id) {
+    return http
+      .get('users/' + id)
+      .then(response => wrapUser(http, response.data), errorHandler)
+  }
+
+  /**
+   * Gets a collection of Users in a space
+   * @memberof ContentfulSpaceAPI
+   * @param {object=} query - Object with search parameters. Check the <a href="https://www.contentful.com/developers/docs/javascript/tutorials/using-js-cda-sdk/#retrieving-entries-with-search-parameters">JS SDK tutorial</a> and the <a href="https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters">REST API reference</a> for more details.
+   * @return {Promise<User.UserCollection>} Promise a collection of Users in a space
+   * @example
+   * const contentful = require('contentful-management')
+   *
+   * client.getSpace('<space_id>')
+   * .then((space) => space.getSpaceUsers(query))
+   * .then((data) => console.log(data))
+   * .catch(console.error)
+   */
+  function getSpaceUsers (query = {}) {
+    return http.get('users/', createRequestConfig({query: query}))
+      .then((response) => wrapUserCollection(http, response.data), errorHandler)
+  }
+
+  /**
    * Gets a Space Membership
    * @memberof ContentfulSpaceAPI
    * @param {string} id - Space Membership ID
@@ -1638,6 +1678,8 @@ export default function createSpaceApi ({
     getRoles,
     createRole,
     createRoleWithId,
+    getSpaceUser,
+    getSpaceUsers,
     getSpaceMembership,
     getSpaceMemberships,
     createSpaceMembership,

--- a/lib/entities/user.js
+++ b/lib/entities/user.js
@@ -49,6 +49,7 @@ export function wrapUser (http, data) {
  * @return {User.UserCollection} Normalized usage collection
  */
 export function wrapUserCollection (http, data) {
-  const usage = toPlainObject(cloneDeep(data))
-  return freezeSys(usage)
+  const users = toPlainObject(cloneDeep(data))
+  users.items = users.items.map(entity => wrapUser(http, entity))
+  return freezeSys(users)
 }

--- a/lib/entities/user.js
+++ b/lib/entities/user.js
@@ -17,6 +17,17 @@ import cloneDeep from 'lodash/cloneDeep'
  * @prop {function(): Object} toPlainObject() - Returns this User as a plain JS object
  */
 
+/**
+ * @memberof User
+ * @typedef UserCollection
+ * @prop {number} total
+ * @prop {number} limit
+ * @prop {number} skip
+ * @prop {Object<{type: "Array"}>} sys
+ * @prop {Array<User.User>} items
+ * @prop {function(): Object} toPlainObject() - Returns the collection as a plain JS object
+ */
+
 /*
  *
  * @private
@@ -25,4 +36,15 @@ export function wrapUser (http, data) {
   const user = toPlainObject(cloneDeep(data))
   enhanceWithMethods(user, {})
   return freezeSys(user)
+}
+
+/**
+ * @private
+ * @param {Object} http - HTTP client instance
+ * @param {Object} data - Raw data collection
+ * @return {User.UserCollection} Normalized usage collection
+ */
+export function wrapUserCollection (http, data) {
+  const usage = toPlainObject(cloneDeep(data))
+  return freezeSys(usage)
 }

--- a/lib/entities/user.js
+++ b/lib/entities/user.js
@@ -1,3 +1,7 @@
+/**
+ * @namespace User
+ */
+
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import cloneDeep from 'lodash/cloneDeep'

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -8,6 +8,7 @@ import {assetReadOnlyTests, assetWriteTests} from './asset-integration'
 import webhookTests from './webhook-integration'
 import spaceMembershipTests from './space-membership-integration'
 import roleTests from './role-integration'
+import userTests from './user-integration'
 import apiKeyTests from './api-key-integration'
 import uiExtensionTests from './ui-extension-integration'
 import generateRandomId from './generate-random-id'
@@ -223,6 +224,7 @@ test('Create space for tests which create, change and delete data', (t) => {
         webhookTests(t, space),
         spaceMembershipTests(t, space),
         roleTests(t, space),
+        userTests(t, space),
         apiKeyTests(t, space),
         uiExtensionTests(t, space),
         environmentTests(t, space, waitForEnvironmentToBeReady),

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -192,6 +192,7 @@ test('Gets v2 space for read only tests', (t) => {
         })
       })
       environmentAliasReadOnlyTests(t, space) // v2 space with alias feature enabled and opted-in
+      userTests(t, space)
     })
 })
 
@@ -224,7 +225,6 @@ test('Create space for tests which create, change and delete data', (t) => {
         webhookTests(t, space),
         spaceMembershipTests(t, space),
         roleTests(t, space),
-        userTests(t, space),
         apiKeyTests(t, space),
         uiExtensionTests(t, space),
         environmentTests(t, space, waitForEnvironmentToBeReady),

--- a/test/integration/user-integration.js
+++ b/test/integration/user-integration.js
@@ -1,10 +1,20 @@
 export default function userTests (t, space) {
   t.test('Gets users', (t) => {
-    t.plan(2)
+    t.plan(3)
     return space.getSpaceUsers()
       .then((response) => {
         t.ok(response.sys, 'sys')
-        t.ok(response.items, 'fields')
+        t.ok(response.items, 'items')
+        t.ok(response.items[0].sys.type, 'User')
+      })
+  })
+  t.test('Gets user by id', (t) => {
+    t.plan(3)
+    return space.getSpaceUser('4grQr6pMEy51ppQTRoQQDz')
+      .then((response) => {
+        t.ok(response.sys, 'sys')
+        t.ok(response.sys.id, '4grQr6pMEy51ppQTRoQQDz')
+        t.ok(response.sys.type, 'User')
       })
   })
 }

--- a/test/integration/user-integration.js
+++ b/test/integration/user-integration.js
@@ -1,0 +1,10 @@
+export default function userTests (t, space) {
+  t.test('Gets users', (t) => {
+    t.plan(2)
+    return space.getSpaceUsers()
+      .then((response) => {
+        t.ok(response.sys, 'sys')
+        t.ok(response.items, 'fields')
+      })
+  })
+}

--- a/test/unit/create-space-api-test.js
+++ b/test/unit/create-space-api-test.js
@@ -14,6 +14,7 @@ import {
   spaceMembershipMock,
   roleMock,
   apiKeyMock,
+  userMock,
   setupEntitiesMock,
   cloneMock,
   uiExtensionMock,
@@ -568,6 +569,34 @@ test('API call createSpaceMembershipWithId', (t) => {
 test('API call createSpaceMembershipWithId fails', (t) => {
   makeEntityMethodFailingTest(t, setup, teardown, {
     methodToTest: 'createSpaceMembershipWithId'
+  })
+})
+
+test('API call getSpaceUser', (t) => {
+  makeGetEntityTest(t, setup, teardown, {
+    entityType: 'user',
+    mockToReturn: userMock,
+    methodToTest: 'getSpaceUser'
+  })
+})
+
+test('API call getSpaceUser fails', (t) => {
+  makeEntityMethodFailingTest(t, setup, teardown, {
+    methodToTest: 'getSpaceUser'
+  })
+})
+
+test('API call getSpaceUsers', (t) => {
+  makeGetCollectionTest(t, setup, teardown, {
+    entityType: 'user',
+    mockToReturn: userMock,
+    methodToTest: 'getSpaceUsers'
+  })
+})
+
+test('API call getSpaceUsers fails', (t) => {
+  makeEntityMethodFailingTest(t, setup, teardown, {
+    methodToTest: 'getSpaceUsers'
   })
 })
 

--- a/test/unit/entities/user-test.js
+++ b/test/unit/entities/user-test.js
@@ -1,8 +1,8 @@
 import test from 'blue-tape'
 import {cloneMock} from '../mocks/entities'
 import setupHttpMock from '../mocks/http'
-import {wrapUser} from '../../../lib/entities/user'
-import {entityWrappedTest} from '../test-creators/instance-entity-methods'
+import {wrapUser, wrapUserCollection} from '../../../lib/entities/user'
+import {entityWrappedTest, entityCollectionWrappedTest} from '../test-creators/instance-entity-methods'
 
 function setup (promise) {
   return {
@@ -14,5 +14,11 @@ function setup (promise) {
 test('User is wrapped', (t) => {
   entityWrappedTest(t, setup, {
     wrapperMethod: wrapUser
+  })
+})
+
+test('User collection is wrapped', (t) => {
+  return entityCollectionWrappedTest(t, setup, {
+    wrapperMethod: wrapUserCollection
   })
 })

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -333,7 +333,8 @@ function setupEntitiesMock (rewiredModuleApi) {
       wrapUiExtensionCollection: sinon.stub()
     },
     user: {
-      wrapUser: sinon.stub()
+      wrapUser: sinon.stub(),
+      wrapUserCollection: sinon.stub()
     },
     personalAccessToken: {
       wrapPersonalAccessToken: sinon.stub(),


### PR DESCRIPTION
We want to add user management endpoints to the api and document them.
This pull request adds the get `/space/{spaceId}/users` endpoints.