### PR TITLE
Removal of the alpha header

### DIFF
--- a/lib/create-organization-api.js
+++ b/lib/create-organization-api.js
@@ -26,7 +26,6 @@ export default function createOrganizationApi ({
   orgId
 }) {
   const {wrapOrganizationMembership, wrapOrganizationMembershipCollection} = entities.organizationMembership
-  const headers = {'x-contentful-enable-alpha-feature': 'organization-user-management-api'}
   const baseURL = http.defaults.baseURL.replace('/spaces/', `/organizations/${orgId}`)
 
   /**
@@ -49,8 +48,7 @@ export default function createOrganizationApi ({
    */
   function getOrganizationMembership (id) {
     return http.get('organization_memberships/' + id, {
-      baseURL,
-      headers
+      baseURL
     })
       .then(response => wrapOrganizationMembership(http, response.data, orgId), errorHandler)
   }
@@ -71,7 +69,6 @@ export default function createOrganizationApi ({
   function getOrganizationMemberships (query = {}) {
     return http.get('organization_memberships', {
       baseURL,
-      headers,
       query
     })
       .then(response => wrapOrganizationMembershipCollection(http, response.data), errorHandler)

--- a/lib/entities/organization-membership.js
+++ b/lib/entities/organization-membership.js
@@ -91,9 +91,6 @@ function createOrganizationMembershipApi (http, orgId) {
 
     delete: function () {
       return http.delete('organization_memberships' + '/' + this.sys.id, {
-        headers: {
-          'x-contentful-enable-alpha-feature': 'organization-user-management-api'
-        },
         baseURL
       })
         .then((response) => {}, errorHandler)

--- a/test/unit/entities/organization-membership-test.js
+++ b/test/unit/entities/organization-membership-test.js
@@ -52,7 +52,7 @@ test('OrganizationMembership update fails', (t) => {
 })
 
 test('OrganizationMembership delete', (t) => {
-  t.plan(4)
+  t.plan(3)
   const { httpMock, entityMock } = setup()
   entityMock.sys.version = 2
   const entity = wrapOrganizationMembership(httpMock, entityMock, 'org1')
@@ -60,7 +60,6 @@ test('OrganizationMembership delete', (t) => {
     .then((response) => {
       t.pass('entity was deleted')
       t.equals(httpMock.delete.args[0][0], `organization_memberships/${entityMock.sys.id}`, 'url is correct')
-      t.equals(httpMock.delete.args[0][1].headers['x-contentful-enable-alpha-feature'], 'organization-user-management-api', 'version header is sent')
       t.match(httpMock.delete.args[0][1].baseURL, /\/organizations\/org1/, 'baseURL is correct')
       return {httpMock, entityMock, response}
     })


### PR DESCRIPTION
This is the follow up after the PR in the gatekeeper https://github.com/contentful/gatekeeper/pull/3887.
As the alpha header is not required any more, this is just a small update to the current implementation.