### PR TITLE
fix(typings): Include filename, contentType assetFileProp typings

### DIFF
--- a/typings/asset.d.ts
+++ b/typings/asset.d.ts
@@ -25,7 +25,9 @@ export interface AssetFileProp {
     description: { [key: string]: string },
     file: {
       [key: string]: {
-        file: string | ArrayBuffer | Stream
+        file: string | ArrayBuffer | Stream,
+        contentType: string,
+        fileName: string
       }
     }
   }


### PR DESCRIPTION
fixes #241 