### PR TITLE
fix: correct toPlainObject typings for content type and app definition

### DIFF
--- a/typings/appDefinition.d.ts
+++ b/typings/appDefinition.d.ts
@@ -46,7 +46,7 @@ export interface AppDefinitionProps {
 export interface AppDefinition
   extends AppDefinitionProps,
     MetaSys<MetaSysProps>,
-    DefaultElements<AppDefinitionProps & MetaSysProps> {
+    DefaultElements<AppDefinitionProps & MetaSys<MetaSysProps>> {
   delete(): Promise<void>,
   update(): Promise<AppDefinition>
 }

--- a/typings/contentType.d.ts
+++ b/typings/contentType.d.ts
@@ -14,7 +14,7 @@ export interface ContentTypeProps {
 export interface ContentType
   extends ContentTypeProps,
     MetaSys<MetaSysProps>,
-    DefaultElements<ContentTypeProps & MetaSysProps> {
+    DefaultElements<ContentTypeProps & MetaSys<MetaSysProps>> {
   delete(): Promise<void>,
   isDraft(): boolean,
   isPublished(): boolean,


### PR DESCRIPTION
There are two errors in type definitions for `.toPlainObject` functions.

`MetaSys` scopes MetaSysProps to be in `sys` object.