### PR TITLE
fix: allow methods to be configurable

### DIFF
--- a/lib/enhance-with-methods.js
+++ b/lib/enhance-with-methods.js
@@ -13,7 +13,7 @@ export default function enhanceWithMethods (baseObject, methodsObject) {
   return Object.keys(methodsObject).reduce((enhancedObject, methodName) => {
     Object.defineProperty(enhancedObject, methodName, {
       enumerable: false,
-      configurable: false,
+      configurable: true,
       writable: false,
       value: methodsObject[methodName]
     })


### PR DESCRIPTION
Where there any good reasons why we disable `configurable` attribute for all additional methods? 

> Configurable. If false, any attempts to delete the property or change its attributes (Writable, Configurable, or Enumerable) will fail.

We're using https://overmindjs.org/ with contentful-management and it requires wrapping sdk object with `Proxy` object. 

`configurable: false` restricts us from doing this. 