### PR TITLE
chore: add missing type definitions for Space and User

### DIFF
--- a/typings/space.d.ts
+++ b/typings/space.d.ts
@@ -19,6 +19,7 @@ import { Snapshot } from './snapshot'
 import { EditorInterface } from './editorInterface'
 import { WebhookProps, WebHooks } from './webhook'
 import { PreviewApiKey } from './previewApiKey'
+import { User } from './user'
 
 export interface SpaceProps {
   name: string
@@ -81,6 +82,7 @@ export interface ContentfulSpaceAPI {
   getWebhook(): Promise<Collection<WebHooks>>,
   getSpaceMember(id: string): Promise<SpaceMember>,
   getSpaceMembers(): Promise<Collection<SpaceMember>>,
+  getSpaceUsers: (query: QueryOptions) => Promise<Collection<User>>,
   getTeamSpaceMembership(id: string): Promise<TeamSpaceMembership>,
   getTeamSpaceMemberships(): Promise<Collection<TeamSpaceMembership>>,
 }

--- a/typings/user.d.ts
+++ b/typings/user.d.ts
@@ -1,6 +1,7 @@
 import { MetaSys, MetaSysProps } from './meta'
+import { DefaultElements } from './defaultElements';
 
-export interface User extends MetaSys<MetaSysProps> {
+export interface UserProps {
   firstName: string,
   lastName: string,
   avatarUrl: string,
@@ -9,3 +10,7 @@ export interface User extends MetaSys<MetaSysProps> {
   signInCount: number,
   confirmed: boolean,
 }
+
+export interface User extends UserProps,
+  MetaSys<MetaSysProps>,
+  DefaultElements<UserProps & MetaSys<MetaSysProps>> {}


### PR DESCRIPTION
* Adds missing `getSpaceUsers` definition to Space type
* Adds missing `toPlainObject` definition to User type
