### PR TITLE
chore: change semantic-release configuration for experimental releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,16 @@
     }
   },
   "release": {
+    "branches": [
+      "master",
+      "next",
+      "next-major",
+      {
+        "name": "experimental",
+        "channel": "experimental",
+        "prerelease": true
+      }
+    ],
     "plugins": [
       [
         "@semantic-release/commit-analyzer",


### PR DESCRIPTION
Allow prerelease experimental builds from the `experimental` branch.