### PR TITLE
Token error handling

### DIFF
--- a/lib/error-handler.ts
+++ b/lib/error-handler.ts
@@ -13,6 +13,12 @@ export default function errorHandler(errorResponse: AxiosError): never {
   const { config, response } = errorResponse
   let errorName
 
+  // Obscure the Management token
+  if (config.headers && config.headers['Authorization']) {
+    const token = `...${config.headers['Authorization'].substr(-5)}`
+    config.headers['Authorization'] = `Bearer ${token}`
+  }
+
   if (!isPlainObject(response) || !isPlainObject(config)) {
     throw errorResponse
   }
@@ -33,11 +39,6 @@ export default function errorHandler(errorResponse: AxiosError): never {
     details: {},
   }
 
-  // Obscure the Management token
-  if (config.headers && config.headers['Authorization']) {
-    const token = `...${config.headers['Authorization'].substr(-5)}`
-    config.headers['Authorization'] = `Bearer ${token}`
-  }
   if (isPlainObject(config)) {
     errorData.request = {
       url: config.url,

--- a/lib/error-handler.ts
+++ b/lib/error-handler.ts
@@ -36,7 +36,7 @@ export default function errorHandler(errorResponse: AxiosError): never {
     status: response?.status,
     statusText: response?.statusText,
     message: '',
-    details: {}
+    details: {},
   }
 
   if (isPlainObject(config)) {
@@ -44,7 +44,7 @@ export default function errorHandler(errorResponse: AxiosError): never {
       url: config.url,
       headers: config.headers,
       method: config.method,
-      payloadData: config.data
+      payloadData: config.data,
     }
   }
   if (data && isPlainObject(data)) {

--- a/lib/error-handler.ts
+++ b/lib/error-handler.ts
@@ -36,7 +36,7 @@ export default function errorHandler(errorResponse: AxiosError): never {
     status: response?.status,
     statusText: response?.statusText,
     message: '',
-    details: {},
+    details: {}
   }
 
   if (isPlainObject(config)) {
@@ -44,7 +44,7 @@ export default function errorHandler(errorResponse: AxiosError): never {
       url: config.url,
       headers: config.headers,
       method: config.method,
-      payloadData: config.data,
+      payloadData: config.data
     }
   }
   if (data && isPlainObject(data)) {

--- a/test/unit/error-handler-test.js
+++ b/test/unit/error-handler-test.js
@@ -70,23 +70,20 @@ test('Throws error without additional detail', (t) => {
   t.end()
 })
 
-test('Obscures management token in error message', (t) => {
-  const error = cloneMock('error')
-  error.config.headers = {
+test('Obscures management token in any error message', (t) => {
+  const responseError = cloneMock('error')
+  responseError.config.headers = {
     Authorization: 'Bearer secret-management-token'
   }
 
   try {
-    errorHandler(error)
+    errorHandler(responseError)
   } catch (err) {
     const parsedMessage = JSON.parse(err.message)
     t.equals(parsedMessage.request.headers.Authorization, 'Bearer ...token', 'Obscures management token')
   }
-  t.end()
-})
 
-test('Obscures token even for request errors', (t) => {
-  const error = {
+  const requestError = {
     config: {
       url: 'requesturl',
       headers: {},
@@ -98,12 +95,12 @@ test('Obscures token even for request errors', (t) => {
     },
   }
 
-  error.config.headers = {
+  requestError.config.headers = {
     Authorization: 'Bearer secret-management-token'
   }
 
   try {
-    errorHandler(error)
+    errorHandler(requestError)
   } catch (err) {
     t.equals(err.config.headers.Authorization, 'Bearer ...token', 'Obscures management token')
   }

--- a/test/unit/error-handler-test.js
+++ b/test/unit/error-handler-test.js
@@ -69,3 +69,19 @@ test('Throws error without additional detail', (t) => {
   }
   t.end()
 })
+
+test('Obscures secret management token in error message', (t) => {
+  const error = cloneMock('error')
+  error.config.headers = {
+    Authorization: 'Bearer secret-management-token'
+  }
+
+  try {
+    errorHandler(error)
+  } catch (err) {
+    const parsedMessage = JSON.parse(err.message)
+    t.equals(parsedMessage.request.headers.Authorization, 'Bearer ...token', 'Obscures management token')
+  }
+  t.end()
+})
+

--- a/test/unit/error-handler-test.js
+++ b/test/unit/error-handler-test.js
@@ -70,7 +70,7 @@ test('Throws error without additional detail', (t) => {
   t.end()
 })
 
-test('Obscures secret management token in error message', (t) => {
+test('Obscures management token in error message', (t) => {
   const error = cloneMock('error')
   error.config.headers = {
     Authorization: 'Bearer secret-management-token'
@@ -81,6 +81,31 @@ test('Obscures secret management token in error message', (t) => {
   } catch (err) {
     const parsedMessage = JSON.parse(err.message)
     t.equals(parsedMessage.request.headers.Authorization, 'Bearer ...token', 'Obscures management token')
+  }
+  t.end()
+})
+
+test('Obscures token even for request errors', (t) => {
+  const error = {
+    config: {
+      url: 'requesturl',
+      headers: {},
+    },
+    data: {},
+    request: {
+      status: 404,
+      statusText: 'Not Found',
+    },
+  }
+
+  error.config.headers = {
+    Authorization: 'Bearer secret-management-token'
+  }
+
+  try {
+    errorHandler(error)
+  } catch (err) {
+    t.equals(err.config.headers.Authorization, 'Bearer ...token', 'Obscures management token')
   }
   t.end()
 })

--- a/test/unit/error-handler-test.js
+++ b/test/unit/error-handler-test.js
@@ -4,16 +4,16 @@ import { cloneMock } from './mocks/entities'
 
 // Best case scenario where an error is a known and expected situation and the
 // server returns an error with a JSON payload with all the information possible
-test('Throws well formed error with details from server', (t) => {
+test('Throws well formed error with details from server', t => {
   const error = cloneMock('error')
   error.response.data = {
     sys: {
       id: 'SpecificError',
-      type: 'Error',
+      type: 'Error'
     },
     message: 'datamessage',
     requestId: 'requestid',
-    details: 'errordetails',
+    details: 'errordetails'
   }
 
   try {
@@ -31,14 +31,14 @@ test('Throws well formed error with details from server', (t) => {
 
 // Second best case scenario, where we'll still get a JSON payload from the server
 // but only with an Unknown error type and no additional details
-test('Throws unknown error received from server', (t) => {
+test('Throws unknown error received from server', t => {
   const error = cloneMock('error')
   error.response.data = {
     sys: {
       id: 'Unknown',
-      type: 'Error',
+      type: 'Error'
     },
-    requestId: 'requestid',
+    requestId: 'requestid'
   }
   error.response.status = 500
   error.response.statusText = 'Internal'
@@ -55,7 +55,7 @@ test('Throws unknown error received from server', (t) => {
 })
 
 // Wurst case scenario, where we have no JSON payload and only HTTP status information
-test('Throws error without additional detail', (t) => {
+test('Throws error without additional detail', t => {
   const error = cloneMock('error')
   error.response.status = 500
   error.response.statusText = 'Everything is on fire'
@@ -70,7 +70,7 @@ test('Throws error without additional detail', (t) => {
   t.end()
 })
 
-test('Obscures management token in any error message', (t) => {
+test('Obscures management token in any error message', t => {
   const responseError = cloneMock('error')
   responseError.config.headers = {
     Authorization: 'Bearer secret-management-token'
@@ -80,19 +80,23 @@ test('Obscures management token in any error message', (t) => {
     errorHandler(responseError)
   } catch (err) {
     const parsedMessage = JSON.parse(err.message)
-    t.equals(parsedMessage.request.headers.Authorization, 'Bearer ...token', 'Obscures management token')
+    t.equals(
+      parsedMessage.request.headers.Authorization,
+      'Bearer ...token',
+      'Obscures management token'
+    )
   }
 
   const requestError = {
     config: {
       url: 'requesturl',
-      headers: {},
+      headers: {}
     },
     data: {},
     request: {
       status: 404,
-      statusText: 'Not Found',
-    },
+      statusText: 'Not Found'
+    }
   }
 
   requestError.config.headers = {
@@ -106,4 +110,3 @@ test('Obscures management token in any error message', (t) => {
   }
   t.end()
 })
-

--- a/test/unit/error-handler-test.js
+++ b/test/unit/error-handler-test.js
@@ -4,16 +4,16 @@ import { cloneMock } from './mocks/entities'
 
 // Best case scenario where an error is a known and expected situation and the
 // server returns an error with a JSON payload with all the information possible
-test('Throws well formed error with details from server', t => {
+test('Throws well formed error with details from server', (t) => {
   const error = cloneMock('error')
   error.response.data = {
     sys: {
       id: 'SpecificError',
-      type: 'Error'
+      type: 'Error',
     },
     message: 'datamessage',
     requestId: 'requestid',
-    details: 'errordetails'
+    details: 'errordetails',
   }
 
   try {
@@ -31,14 +31,14 @@ test('Throws well formed error with details from server', t => {
 
 // Second best case scenario, where we'll still get a JSON payload from the server
 // but only with an Unknown error type and no additional details
-test('Throws unknown error received from server', t => {
+test('Throws unknown error received from server', (t) => {
   const error = cloneMock('error')
   error.response.data = {
     sys: {
       id: 'Unknown',
-      type: 'Error'
+      type: 'Error',
     },
-    requestId: 'requestid'
+    requestId: 'requestid',
   }
   error.response.status = 500
   error.response.statusText = 'Internal'
@@ -55,7 +55,7 @@ test('Throws unknown error received from server', t => {
 })
 
 // Wurst case scenario, where we have no JSON payload and only HTTP status information
-test('Throws error without additional detail', t => {
+test('Throws error without additional detail', (t) => {
   const error = cloneMock('error')
   error.response.status = 500
   error.response.statusText = 'Everything is on fire'
@@ -70,10 +70,10 @@ test('Throws error without additional detail', t => {
   t.end()
 })
 
-test('Obscures management token in any error message', t => {
+test('Obscures management token in any error message', (t) => {
   const responseError = cloneMock('error')
   responseError.config.headers = {
-    Authorization: 'Bearer secret-management-token'
+    Authorization: 'Bearer secret-management-token',
   }
 
   try {
@@ -90,17 +90,17 @@ test('Obscures management token in any error message', t => {
   const requestError = {
     config: {
       url: 'requesturl',
-      headers: {}
+      headers: {},
     },
     data: {},
     request: {
       status: 404,
-      statusText: 'Not Found'
-    }
+      statusText: 'Not Found',
+    },
   }
 
   requestError.config.headers = {
-    Authorization: 'Bearer secret-management-token'
+    Authorization: 'Bearer secret-management-token',
   }
 
   try {


### PR DESCRIPTION
This pr restructures the `errorHandler` logic so that it always obscures the management token instead of doing so only for response errors.