### PR TITLE
fix(organizationApi): correct getTeam() and getTeams() documentation

### DIFF
--- a/lib/create-organization-api.js
+++ b/lib/create-organization-api.js
@@ -67,6 +67,9 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<OrganizationMembership.OrganizationMembership>} Promise for an Organization Membership
    * @example
    * const contentful = require('contentful-management')
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
    *
    * client.getOrganization('organization_id')
    * .then((organization) => organization.getOrganizationMembership('organizationMembership_id'))
@@ -86,6 +89,9 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<OrganizationMembership.OrganizationMembershipCollection>} Promise for a collection of Organization Memberships
    * @example
    * const contentful = require('contentful-management')
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
    *
    * client.getOrganization('organization_id')
    * .then((organization) => organization.getOrganizationMemberships({'limit': 100})) // you can add more queries as 'key': 'value'
@@ -105,6 +111,9 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<SpaceMembership>} Promise for a Space Membership in an organization
    * @example
    * const contentful = require('contentful-management')
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
    *
    * client.getOrganization('organization_id')
    * .then((organization) => organization.getOrganizationSpaceMembership('organizationSpaceMembership_id'))
@@ -124,6 +133,9 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<SpaceMembership[]>} Promise for a Space Membership collection across all spaces in the organization
    * @example
    * const contentful = require('contentful-management')
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
    *
    * client.getOrganization('organization_id')
    * .then((organization) => organization.getOrganizationSpaceMemberships()) // you can add queries like 'limit': 100
@@ -144,7 +156,6 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<TeamMembership.TeamMembership>} Promise for the newly created TeamMembership
    * @example
    * const contentful = require('contentful-management')
-   *
    * const client = contentful.createClient({
    *   accessToken: '<content_management_api_key>'
    * })
@@ -171,6 +182,9 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<TeamMembership>} Promise for an Team Membership
    * @example
    * const contentful = require('contentful-management')
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
    *
    * client.getOrganization('organizationId')
    * .then((organization) => organization.getTeamMembership('teamId', 'teamMembership_id'))
@@ -192,6 +206,9 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<TeamMembership[]>} Promise for a Team Membership Collection
    * @example
    * const contentful = require('contentful-management')
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
    *
    * client.getOrganization('organizationId')
    * .then((organization) => organization.getTeamMemberships('teamId'))
@@ -217,6 +234,9 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<TeamMembership>} Promise for a Team Space Membership
    * @example
    * const contentful = require('contentful-management')
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
    *
    * client.getOrganization('organizationId')
    * .then((organization) => organization.getTeamSpaceMembership('teamSpaceMembershipId'))
@@ -238,6 +258,9 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<TeamSpaceMembership[]>} Promise for a Team Space Membership Collection
    * @example
    * const contentful = require('contentful-management')
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
    *
    * client.getOrganization('organizationId')
    * .then((organization) => organization.getTeamSpaceMemberships('teamId'))
@@ -262,7 +285,6 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<TeamMembership.TeamMembership>} Promise for the newly created Team
    * @example
    * const contentful = require('contentful-management')
-   *
    * const client = contentful.createClient({
    *   accessToken: '<content_management_api_key>'
    * })
@@ -286,6 +308,9 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<Team>} Promise for an Team
    * @example
    * const contentful = require('contentful-management')
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
    *
    * client.getOrganization('orgId')
    * .then((organization) => organization.getTeam('teamId'))
@@ -305,6 +330,9 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<Team[]>} Promise for a Team Collection
    * @example
    * const contentful = require('contentful-management')
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
    *
    * client.getOrganization('orgId')
    * .then((organization) => organization.getTeams())
@@ -324,6 +352,9 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<OrganizationInvitation>} Promise for a OrganizationInvitation in an organization
    * @example
    * const contentful = require('contentful-management')
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
    *
    * client.getOrganization('<org_id>')
    * .then((organization) => organization.getOrganizationInvitation('invitation_id'))
@@ -345,7 +376,6 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<OrganizationInvitation>} Promise for a OrganizationInvitation in an organization
    * @example
    * const contentful = require('contentful-management')
-   *
    * const client = contentful.createClient({
    *   accessToken: '<content_management_api_key>'
    * })
@@ -375,7 +405,6 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<AppDefinition.AppDefinitionCollection>} Promise for a collection of App Definitions
    * @example
    * const contentful = require('contentful-management')
-   *
    * const client = contentful.createClient({
    *   accessToken: '<content_management_api_key>'
    * })
@@ -397,7 +426,6 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<AppDefinition.AppDefinition>} Promise for an App Definition
    * @example
    * const contentful = require('contentful-management')
-   *
    * const client = contentful.createClient({
    *   accessToken: '<content_management_api_key>'
    * })
@@ -421,7 +449,6 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<AppDefinition.AppDefinition>} Promise for the newly created AppDefinition
    * @example
    * const contentful = require('contentful-management')
-   *
    * const client = contentful.createClient({
    *   accessToken: '<content_management_api_key>'
    * })
@@ -448,6 +475,9 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<User.User>} Promise for a User
    * @example
    * const contentful = require('contentful-management')
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
    *
    * client.getOrganization('<organization_id>')
    * .then((organization) => organization.getUser('id'))
@@ -465,6 +495,9 @@ export default function createOrganizationApi({ http }) {
    * @return {Promise<User.UserCollection>} Promise a collection of Users in organization
    * @example
    * const contentful = require('contentful-management')
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
    *
    * client.getOrganization('<organization_id>')
    * .then((organization) => organization.getUsers())

--- a/lib/create-organization-api.js
+++ b/lib/create-organization-api.js
@@ -287,7 +287,7 @@ export default function createOrganizationApi({ http }) {
    * @example
    * const contentful = require('contentful-management')
    *
-   * client.getOrganizations()
+   * client.getOrganization('orgId')
    * .then((organization) => organization.getTeam('teamId'))
    * .then((team) => console.log(team))
    * .catch(console.error)
@@ -306,7 +306,7 @@ export default function createOrganizationApi({ http }) {
    * @example
    * const contentful = require('contentful-management')
    *
-   * client.getOrganizations()
+   * client.getOrganization('orgId')
    * .then((organization) => organization.getTeams())
    * .then((teams) => console.log(teams))
    * .catch(console.error)


### PR DESCRIPTION
Small docs fix to resolve this github issue: https://github.com/contentful/contentful-management.js/issues/332

working example:

const contentful = require('contentful-management')
const client = contentful.createClient({ accessToken: '<content_management_api_key>' })

client
  .getOrganization(orgId)
  .then((organization) => organization.getTeams())
  .then((teams) => console.log(teams))
  .catch(console.error)