### PR TITLE
chore: publish docs only from master branch releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,13 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run semantic-release
+  publish-docs:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - checkout
+      - run: npm install
+      - run: npm run docs:publish
 workflows:
   version: 2
   build_and_test:
@@ -58,3 +65,10 @@ workflows:
           requires:
             - unit
             - integration
+      - publish-docs:
+          requires:
+            - release
+          filters:
+            branches:
+              only:
+                - master

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "prettier:check": "prettier --check '**/*.{jsx,js,ts,tsx}'",
     "presemantic-release": "npm run build",
     "semantic-release": "semantic-release",
-    "postpublish": "npm run docs:publish && npm run clean",
     "precommit": "npm run lint",
     "prepush": "npm run test:prepush",
     "prepare": "npm run build"


### PR DESCRIPTION
Prevent docs being updated with non-master (latest) NPM releases