### PR TITLE
chore: documentation release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,13 +44,6 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run semantic-release
-  publish-docs:
-    docker:
-      - image: circleci/node:12
-    steps:
-      - checkout
-      - run: npm install
-      - run: npm run docs:publish
 workflows:
   version: 2
   build_and_test:
@@ -65,10 +58,3 @@ workflows:
           requires:
             - unit
             - integration
-      - publish-docs:
-          requires:
-            - release
-          filters:
-            branches:
-              only:
-                - master

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "presemantic-release": "npm run build",
     "semantic-release": "semantic-release",
     "precommit": "npm run lint",
+    "postpublish": "if [ \"$(git rev-parse --abbrev-ref HEAD)\" = master ] ; then npm run docs:publish && npm run clean ; else exit 0 ; fi",
     "prepush": "npm run test:prepush",
     "prepare": "npm run build"
   },


### PR DESCRIPTION
Rolls back to previous publishing workflow but with additional branch check (only for master branch)