### PR TITLE
feat: add asset endpoint and update headers to plain cma client

### DIFF
--- a/lib/entities/asset.ts
+++ b/lib/entities/asset.ts
@@ -46,6 +46,8 @@ export type AssetProps = {
   }
 }
 
+export type CreateAssetProps = Omit<AssetProps, 'sys'>
+
 export interface AssetFileProp {
   sys: MetaSysProps
   fields: {

--- a/lib/entities/space.ts
+++ b/lib/entities/space.ts
@@ -12,7 +12,7 @@ type SdkHttpClient = AxiosInstance & {
 }
 
 export type SpaceProps = {
-  sys: BasicMetaSysProps
+  sys: BasicMetaSysProps & { organisation: { sys: { id: string } } }
   name: string
 }
 

--- a/lib/entities/space.ts
+++ b/lib/entities/space.ts
@@ -12,7 +12,7 @@ type SdkHttpClient = AxiosInstance & {
 }
 
 export type SpaceProps = {
-  sys: BasicMetaSysProps & { organisation: { sys: { id: string } } }
+  sys: BasicMetaSysProps & { organization: { sys: { id: string } } }
   name: string
 }
 

--- a/lib/plain/endpoints/asset.ts
+++ b/lib/plain/endpoints/asset.ts
@@ -1,0 +1,131 @@
+import { AxiosInstance } from 'axios'
+import * as raw from './raw'
+import { CreateAssetProps, AssetProps } from '../../entities/asset'
+import { normalizeSelect } from './utils'
+import cloneDeep from 'lodash/cloneDeep'
+import { GetEnvironmentParams } from './environment'
+import { QueryParams, CollectionProp } from './common-types'
+
+export type GetManyEntriesParams = GetEnvironmentParams & QueryParams
+
+export const get = (
+  http: AxiosInstance,
+  params: GetEnvironmentParams & { assetId: string } & QueryParams
+) => {
+  return raw.get<AssetProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/assets/${params.assetId}`,
+    {
+      params: normalizeSelect(params.query),
+    }
+  )
+}
+
+export const getMany = (http: AxiosInstance, params: GetManyEntriesParams) => {
+  return raw.get<CollectionProp<AssetProps>>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/entries`,
+    {
+      params: normalizeSelect(params.query),
+    }
+  )
+}
+
+export const update = (
+  http: AxiosInstance,
+  params: GetEnvironmentParams & { assetId: string },
+  rawData: AssetProps,
+  headers?: Record<string, unknown>
+) => {
+  const data = cloneDeep(rawData)
+  delete data.sys
+  return raw.put<AssetProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/assets/${params.assetId}`,
+    data,
+    {
+      headers: {
+        'X-Contentful-Version': rawData.sys.version ?? 0,
+        ...headers,
+      },
+    }
+  )
+}
+
+export const del = (http: AxiosInstance, params: GetEnvironmentParams & { assetId: string }) => {
+  return raw.del(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/assets/${params.assetId}`
+  )
+}
+
+export const publish = (
+  http: AxiosInstance,
+  params: GetEnvironmentParams & { assetId: string },
+  rawData: AssetProps
+) => {
+  return raw.put<AssetProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/assets/${params.assetId}/published`,
+    null,
+    {
+      headers: {
+        'X-Contentful-Version': rawData.sys.version ?? 0,
+      },
+    }
+  )
+}
+
+export const unpublish = (
+  http: AxiosInstance,
+  params: GetEnvironmentParams & { assetId: string }
+) => {
+  return raw.del<AssetProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/assets/${params.assetId}/published`
+  )
+}
+
+export const archive = (
+  http: AxiosInstance,
+  params: GetEnvironmentParams & { assetId: string }
+) => {
+  return raw.put<AssetProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/assets/${params.assetId}/archived`
+  )
+}
+
+export const unarchive = (
+  http: AxiosInstance,
+  params: GetEnvironmentParams & { assetId: string }
+) => {
+  return raw.del<AssetProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/assets/${params.assetId}/archived`
+  )
+}
+
+export const create = (
+  http: AxiosInstance,
+  params: GetEnvironmentParams,
+  rawData: CreateAssetProps
+) => {
+  const data = cloneDeep(rawData)
+
+  return raw.post<AssetProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/assets`,
+    data
+  )
+}
+
+export const createWithId = (
+  http: AxiosInstance,
+  params: GetEnvironmentParams & { assetId: string },
+  rawData: CreateAssetProps
+) => {
+  const data = cloneDeep(rawData)
+
+  return raw.put<AssetProps>(http, `assets/${params.assetId}`, data)
+}

--- a/lib/plain/endpoints/asset.ts
+++ b/lib/plain/endpoints/asset.ts
@@ -6,7 +6,7 @@ import cloneDeep from 'lodash/cloneDeep'
 import { GetEnvironmentParams } from './environment'
 import { QueryParams, CollectionProp } from './common-types'
 
-export type GetManyEntriesParams = GetEnvironmentParams & QueryParams
+export type GetManyAssetsParams = GetEnvironmentParams & QueryParams
 
 export const get = (
   http: AxiosInstance,
@@ -21,10 +21,10 @@ export const get = (
   )
 }
 
-export const getMany = (http: AxiosInstance, params: GetManyEntriesParams) => {
+export const getMany = (http: AxiosInstance, params: GetManyAssetsParams) => {
   return raw.get<CollectionProp<AssetProps>>(
     http,
-    `/spaces/${params.spaceId}/environments/${params.environmentId}/entries`,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/assets`,
     {
       params: normalizeSelect(params.query),
     }

--- a/lib/plain/endpoints/entry.ts
+++ b/lib/plain/endpoints/entry.ts
@@ -37,7 +37,8 @@ export const getMany = <T extends KeyValueMap = KeyValueMap>(
 export const update = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
   params: GetEnvironmentParams & { entryId: string },
-  rawData: EntryProps<T>
+  rawData: EntryProps<T>,
+  headers?: Record<string, unknown>
 ) => {
   const data = cloneDeep(rawData)
   delete data.sys
@@ -48,6 +49,7 @@ export const update = <T extends KeyValueMap = KeyValueMap>(
     {
       headers: {
         'X-Contentful-Version': rawData.sys.version ?? 0,
+        ...headers,
       },
     }
   )

--- a/lib/plain/endpoints/environment.ts
+++ b/lib/plain/endpoints/environment.ts
@@ -16,7 +16,8 @@ export const get = (http: AxiosInstance, params: GetEnvironmentParams) => {
 export const update = (
   http: AxiosInstance,
   params: GetEnvironmentParams,
-  rawData: EnvironmentProps
+  rawData: EnvironmentProps,
+  headers?: Record<string, unknown>
 ) => {
   const data = cloneDeep(rawData)
   delete data.sys
@@ -28,6 +29,7 @@ export const update = (
     {
       headers: {
         'X-Contentful-Version': rawData.sys.version ?? 0,
+        ...headers,
       },
     }
   )

--- a/lib/plain/endpoints/index.ts
+++ b/lib/plain/endpoints/index.ts
@@ -1,5 +1,6 @@
 export * as contentType from './content-type'
 export * as entry from './entry'
+export * as asset from './asset'
 export * as environment from './environment'
 export * as locale from './locale'
 export * as raw from './raw'

--- a/lib/plain/endpoints/space.ts
+++ b/lib/plain/endpoints/space.ts
@@ -8,13 +8,19 @@ export type GetSpaceParams = { spaceId: string }
 export const get = (http: AxiosInstance, params: GetSpaceParams) =>
   raw.get<SpaceProps>(http, `/spaces/${params.spaceId}`)
 
-export const update = (http: AxiosInstance, params: GetSpaceParams, rawData: SpaceProps) => {
+export const update = (
+  http: AxiosInstance,
+  params: GetSpaceParams,
+  rawData: SpaceProps,
+  headers?: Record<string, unknown>
+) => {
   const data = cloneDeep(rawData)
   delete data.sys
 
   return raw.put<SpaceProps>(http, `/spaces/${params.spaceId}`, data, {
     headers: {
       'X-Contentful-Version': rawData.sys.version ?? 0,
+      ...headers,
     },
   })
 }

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -36,6 +36,18 @@ export const createPlainClient = (params: ClientParams, defaults?: DefaultParams
       create: wrap(wrapParams, endpoints.entry.create),
       createWithId: wrap(wrapParams, endpoints.entry.createWithId),
     },
+    asset: {
+      getMany: wrap(wrapParams, endpoints.asset.getMany),
+      get: wrap(wrapParams, endpoints.asset.get),
+      update: wrap(wrapParams, endpoints.asset.update),
+      delete: wrap(wrapParams, endpoints.asset.del),
+      publish: wrap(wrapParams, endpoints.asset.publish),
+      unpublish: wrap(wrapParams, endpoints.asset.unpublish),
+      archive: wrap(wrapParams, endpoints.asset.archive),
+      unarchive: wrap(wrapParams, endpoints.asset.unarchive),
+      create: wrap(wrapParams, endpoints.asset.create),
+      createWithId: wrap(wrapParams, endpoints.asset.createWithId),
+    },
     locale: {
       getMany: wrap(wrapParams, endpoints.locale.getMany),
     },


### PR DESCRIPTION
Adds the `asset` endpoint (similar to `entry`) to the plain CMA client. Adds a way to specify headers for `update` calls.