### PR TITLE
fix: add missing MetaSysProps types for archived and deleted states

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -27,6 +27,11 @@ export interface MetaSysProps extends BasicMetaSysProps {
   status?: { sys: MetaLinkProps }
   publishedVersion?: number
   archivedVersion?: number
+  archivedBy?: { sys: MetaLinkProps }
+  archivedAt?: string
+  deletedVersion?: number
+  deletedBy?: { sys: MetaLinkProps }
+  deletedAt?: string
 }
 
 export interface MetaLinkProps {

--- a/lib/entities/entry.ts
+++ b/lib/entities/entry.ts
@@ -18,15 +18,15 @@ import {
 import errorHandler from '../error-handler'
 import { wrapSnapshot, wrapSnapshotCollection, SnapshotProps, Snapshot } from './snapshot'
 import {
-  BasicMetaSysProps,
   MetaLinkProps,
   DefaultElements,
   Collection,
   KeyValueMap,
+  MetaSysProps,
 } from '../common-types'
 
 export type EntryProps<T = KeyValueMap> = {
-  sys: BasicMetaSysProps & {
+  sys: MetaSysProps & {
     space: { sys: MetaLinkProps }
     contentType: { sys: MetaLinkProps }
     environment: { sys: MetaLinkProps }


### PR DESCRIPTION
Adds missing deleted and archived props to `MetaSysProps`. Make `Entry` use `MetaSysProps` instead of `BasicMetaSysProps`.