### PR TITLE
feat: move all environment methods to plain client

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -2,10 +2,13 @@ export interface DefaultElements<TPlainObject extends object = object> {
   toPlainObject(): TPlainObject
 }
 
-export interface QueryOptions {
+export interface PaginationQueryOptions {
   skip?: number
   limit?: number
   order?: string
+}
+
+export interface QueryOptions extends PaginationQueryOptions {
   content_type?: string
   include?: number
   select?: string

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -12,6 +12,7 @@ import type { UIExtensionProps } from './entities/ui-extension'
 import type { AppInstallationProps } from './entities/app-installation'
 import { Stream } from 'stream'
 import { AxiosInstance } from 'axios'
+import { EnvironmentProps } from './entities/environment'
 
 export type ContentfulEnvironmentAPI = ReturnType<typeof createEnvironmentApi>
 
@@ -72,9 +73,12 @@ export default function createEnvironmentApi({
      * ```
      */
     delete: function deleteEnvironment() {
-      return http.delete('').then(() => {
-        // noop
-      }, errorHandler)
+      const raw = this.toPlainObject() as EnvironmentProps
+      return endpoints.environment
+        .del(http, { spaceId: raw.sys.space.sys.id, environmentId: raw.sys.id })
+        .then(() => {
+          // noop
+        })
     },
     /**
      * Updates the environment
@@ -97,7 +101,7 @@ export default function createEnvironmentApi({
      * ```
      */
     update: function updateEnvironment() {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as EnvironmentProps
       return endpoints.environment
         .update(http, { spaceId: raw.sys.space.sys.id, environmentId: raw.sys.id }, raw)
         .then((data) => {
@@ -215,7 +219,7 @@ export default function createEnvironmentApi({
      * ```
      */
     getContentTypes(query: QueryOptions = {}) {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as EnvironmentProps
       return endpoints.contentType
         .getMany(http, {
           spaceId: raw.sys.space.sys.id,
@@ -340,7 +344,7 @@ export default function createEnvironmentApi({
      * ```
      */
     getEntry(id: string, query: QueryOptions = {}) {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as EnvironmentProps
       return endpoints.entry
         .get(http, {
           spaceId: raw.sys.space.sys.id,
@@ -372,7 +376,7 @@ export default function createEnvironmentApi({
      * ```
      */
     getEntries(query: QueryOptions = {}) {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as EnvironmentProps
       return endpoints.entry
         .getMany(http, {
           spaceId: raw.sys.space.sys.id,
@@ -408,7 +412,7 @@ export default function createEnvironmentApi({
      * ```
      */
     createEntry(contentTypeId: string, data: Omit<EntryProps, 'sys'>) {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as EnvironmentProps
       return endpoints.entry
         .create(
           http,
@@ -450,7 +454,7 @@ export default function createEnvironmentApi({
      * ```
      */
     createEntryWithId(contentTypeId: string, id: string, data: Omit<EntryProps, 'sys'>) {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as EnvironmentProps
       return endpoints.entry
         .createWithId(
           http,
@@ -487,7 +491,7 @@ export default function createEnvironmentApi({
      * ```
      */
     getAsset(id: string, query: QueryOptions = {}) {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as EnvironmentProps
       return endpoints.asset
         .get(http, {
           spaceId: raw.sys.space.sys.id,
@@ -519,7 +523,7 @@ export default function createEnvironmentApi({
      * ```
      */
     getAssets(query: QueryOptions = {}) {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as EnvironmentProps
       return endpoints.asset
         .getMany(http, {
           spaceId: raw.sys.space.sys.id,
@@ -560,7 +564,7 @@ export default function createEnvironmentApi({
      * ```
      */
     createAsset(data: CreateAssetProps) {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as EnvironmentProps
       return endpoints.asset
         .create(
           http,
@@ -603,7 +607,7 @@ export default function createEnvironmentApi({
      * ```
      */
     createAssetWithId(id: string, data: CreateAssetProps) {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as EnvironmentProps
       return endpoints.asset
         .createWithId(
           http,
@@ -767,7 +771,7 @@ export default function createEnvironmentApi({
      * ```
      */
     getLocales() {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as EnvironmentProps
       return endpoints.locale
         .getMany(http, {
           spaceId: raw.sys.space.sys.id,

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -195,14 +195,19 @@ export default function createSpaceApi({ http }: { http: AxiosInstance }) {
      * .catch(console.error)
      * ```
      */
-    createEnvironmentWithId(id: string, data: CreateEnvironmentProps, sourceEnvironmentId: string) {
+    createEnvironmentWithId(
+      id: string,
+      data: CreateEnvironmentProps,
+      sourceEnvironmentId?: string
+    ) {
       const raw = this.toPlainObject() as SpaceProps
       return endpoints.environment
         .createWithId(
           http,
           {
             spaceId: raw.sys.id,
-            environmentId: sourceEnvironmentId,
+            environmentId: id,
+            sourceEnvironmentId,
           },
           data
         )

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -195,7 +195,7 @@ export default function createSpaceApi({ http }: { http: AxiosInstance }) {
      * .catch(console.error)
      * ```
      */
-    createEnvironmentWithId(id: string, data: CreateApiKeyProps, sourceEnvironmentId: string) {
+    createEnvironmentWithId(id: string, data: CreateEnvironmentProps, sourceEnvironmentId: string) {
       const raw = this.toPlainObject() as SpaceProps
       return endpoints.environment
         .createWithId(

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -7,7 +7,7 @@ import { AxiosInstance } from 'axios'
 import { createRequestConfig } from 'contentful-sdk-core'
 import errorHandler from './error-handler'
 import entities from './entities'
-import { EnvironmentProps } from './entities/environment'
+import { CreateEnvironmentProps } from './entities/environment'
 import { TeamSpaceMembershipProps } from './entities/team-space-membership'
 import { SpaceMembershipProps } from './entities/space-membership'
 import { RoleProps } from './entities/role'
@@ -15,6 +15,7 @@ import { WebhookProps } from './entities/webhook'
 import { QueryOptions } from './common-types'
 import { CreateApiKeyProps } from './entities/api-key'
 import * as endpoints from './plain/endpoints'
+import { SpaceProps } from './entities/space'
 
 function spaceMembershipDeprecationWarning() {
   console.warn(
@@ -65,7 +66,7 @@ export default function createSpaceApi({ http }: { http: AxiosInstance }) {
      * ```
      */
     delete: function deleteSpace() {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as SpaceProps
       return endpoints.space.del(http, { spaceId: raw.sys.id })
     },
     /**
@@ -88,7 +89,7 @@ export default function createSpaceApi({ http }: { http: AxiosInstance }) {
      * ```
      */
     update: function updateSpace() {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as SpaceProps
       return endpoints.space
         .update(http, { spaceId: raw.sys.id }, raw)
         .then((data) => wrapSpace(http, data))
@@ -111,7 +112,7 @@ export default function createSpaceApi({ http }: { http: AxiosInstance }) {
      * ```
      */
     getEnvironment(environmentId: string) {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as SpaceProps
       return endpoints.environment
         .get(http, {
           spaceId: raw.sys.id,
@@ -137,9 +138,12 @@ export default function createSpaceApi({ http }: { http: AxiosInstance }) {
      * ```
      */
     getEnvironments() {
-      return http
-        .get('environments')
-        .then((response) => wrapEnvironmentCollection(http, response.data), errorHandler)
+      const raw = this.toPlainObject() as SpaceProps
+      return endpoints.environment
+        .getAll(http, {
+          spaceId: raw.sys.id,
+        })
+        .then((data) => wrapEnvironmentCollection(http, data))
     },
 
     /**
@@ -159,10 +163,17 @@ export default function createSpaceApi({ http }: { http: AxiosInstance }) {
      * .catch(console.error)
      * ```
      */
-    createEnvironment(data = {}) {
-      return http
-        .post('environments', data)
-        .then((response) => wrapEnvironment(http, response.data), errorHandler)
+    createEnvironment(data: CreateEnvironmentProps = {}) {
+      const raw = this.toPlainObject() as SpaceProps
+      return endpoints.environment
+        .create(
+          http,
+          {
+            spaceId: raw.sys.id,
+          },
+          data
+        )
+        .then((response) => wrapEnvironment(http, response))
     },
 
     /**
@@ -184,18 +195,18 @@ export default function createSpaceApi({ http }: { http: AxiosInstance }) {
      * .catch(console.error)
      * ```
      */
-    createEnvironmentWithId(
-      id: string,
-      data: Omit<EnvironmentProps, 'sys'>,
-      sourceEnvironmentId?: string
-    ) {
-      return http
-        .put('environments/' + id, data, {
-          headers: sourceEnvironmentId
-            ? { 'X-Contentful-Source-Environment': sourceEnvironmentId }
-            : {},
-        })
-        .then((response) => wrapEnvironment(http, response.data), errorHandler)
+    createEnvironmentWithId(id: string, data: CreateApiKeyProps, sourceEnvironmentId: string) {
+      const raw = this.toPlainObject() as SpaceProps
+      return endpoints.environment
+        .createWithId(
+          http,
+          {
+            spaceId: raw.sys.id,
+            environmentId: sourceEnvironmentId,
+          },
+          data
+        )
+        .then((response) => wrapEnvironment(http, response))
     },
 
     /**
@@ -480,7 +491,7 @@ export default function createSpaceApi({ http }: { http: AxiosInstance }) {
      * ```
      */
     getSpaceUsers(query: QueryOptions = {}) {
-      const raw = this.toPlainObject()
+      const raw = this.toPlainObject() as SpaceProps
       return endpoints.user
         .getManyForSpace(http, {
           spaceId: raw.sys.id,

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -12,7 +12,7 @@ import { TeamSpaceMembershipProps } from './entities/team-space-membership'
 import { SpaceMembershipProps } from './entities/space-membership'
 import { RoleProps } from './entities/role'
 import { WebhookProps } from './entities/webhook'
-import { QueryOptions } from './common-types'
+import { QueryOptions, PaginationQueryOptions } from './common-types'
 import { CreateApiKeyProps } from './entities/api-key'
 import * as endpoints from './plain/endpoints'
 import { SpaceProps } from './entities/space'
@@ -137,11 +137,12 @@ export default function createSpaceApi({ http }: { http: AxiosInstance }) {
      * .catch(console.error)
      * ```
      */
-    getEnvironments() {
+    getEnvironments(query: PaginationQueryOptions = {}) {
       const raw = this.toPlainObject() as SpaceProps
       return endpoints.environment
-        .getAll(http, {
+        .getMany(http, {
           spaceId: raw.sys.id,
+          query,
         })
         .then((data) => wrapEnvironmentCollection(http, data))
     },

--- a/lib/entities/environment.ts
+++ b/lib/entities/environment.ts
@@ -22,9 +22,7 @@ export type EnvironmentProps = {
   name: string
 }
 
-export type CreateEnvironmentProps = {
-  name?: string
-}
+export type CreateEnvironmentProps = Partial<Omit<EnvironmentProps, 'sys'>>
 
 export type Environment = ContentfulEnvironmentAPI &
   EnvironmentProps &

--- a/lib/entities/environment.ts
+++ b/lib/entities/environment.ts
@@ -22,6 +22,10 @@ export type EnvironmentProps = {
   name: string
 }
 
+export type CreateEnvironmentProps = {
+  name?: string
+}
+
 export type Environment = ContentfulEnvironmentAPI &
   EnvironmentProps &
   DefaultElements<EnvironmentProps>

--- a/lib/plain/endpoints/common-types.ts
+++ b/lib/plain/endpoints/common-types.ts
@@ -1,5 +1,6 @@
-import { QueryOptions } from '../../common-types'
+import { QueryOptions, PaginationQueryOptions } from '../../common-types'
 
 export type QueryParams = { query?: QueryOptions }
+export type PaginationQueryParams = { query?: PaginationQueryOptions }
 
 export type { CollectionProp, KeyValueMap } from '../../common-types'

--- a/lib/plain/endpoints/environment.ts
+++ b/lib/plain/endpoints/environment.ts
@@ -3,7 +3,7 @@ import * as raw from './raw'
 import { EnvironmentProps, CreateEnvironmentProps } from '../../entities/environment'
 import cloneDeep from 'lodash/cloneDeep'
 import { GetSpaceParams } from './space'
-import { CollectionProp } from './common-types'
+import { CollectionProp, PaginationQueryParams } from './common-types'
 
 export type GetEnvironmentParams = GetSpaceParams & { environmentId: string }
 
@@ -14,8 +14,10 @@ export const get = (http: AxiosInstance, params: GetEnvironmentParams) => {
   )
 }
 
-export const getAll = (http: AxiosInstance, params: GetSpaceParams) => {
-  return raw.get<CollectionProp<EnvironmentProps>>(http, `/spaces/${params.spaceId}/environments`)
+export const getMany = (http: AxiosInstance, params: GetSpaceParams & PaginationQueryParams) => {
+  return raw.get<CollectionProp<EnvironmentProps>>(http, `/spaces/${params.spaceId}/environments`, {
+    params: params.query,
+  })
 }
 
 export const update = (

--- a/lib/plain/endpoints/environment.ts
+++ b/lib/plain/endpoints/environment.ts
@@ -1,8 +1,9 @@
 import { AxiosInstance } from 'axios'
 import * as raw from './raw'
-import { EnvironmentProps } from '../../entities/environment'
+import { EnvironmentProps, CreateEnvironmentProps } from '../../entities/environment'
 import cloneDeep from 'lodash/cloneDeep'
 import { GetSpaceParams } from './space'
+import { CollectionProp } from './common-types'
 
 export type GetEnvironmentParams = GetSpaceParams & { environmentId: string }
 
@@ -11,6 +12,10 @@ export const get = (http: AxiosInstance, params: GetEnvironmentParams) => {
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}`
   )
+}
+
+export const getAll = (http: AxiosInstance, params: GetSpaceParams) => {
+  return raw.get<CollectionProp<EnvironmentProps>>(http, `/spaces/${params.spaceId}/environments`)
 }
 
 export const update = (
@@ -33,4 +38,33 @@ export const update = (
       },
     }
   )
+}
+
+export const del = (http: AxiosInstance, params: GetEnvironmentParams) => {
+  return raw.del(http, `/spaces/${params.spaceId}/environments/${params.environmentId}`)
+}
+
+export const create = (
+  http: AxiosInstance,
+  params: GetSpaceParams,
+  rawData: CreateEnvironmentProps,
+  headers?: Record<string, unknown>
+) => {
+  const data = cloneDeep(rawData)
+  return raw.post<EnvironmentProps>(http, `/spaces/${params.spaceId}/environments`, data, {
+    headers,
+  })
+}
+
+export const createWithId = (
+  http: AxiosInstance,
+  params: GetEnvironmentParams,
+  rawData: CreateEnvironmentProps,
+  headers?: Record<string, unknown>
+) => {
+  const { spaceId, environmentId } = params
+  return create(http, { spaceId }, rawData, {
+    ...(headers || {}),
+    'X-Contentful-Source-Environment': environmentId,
+  })
 }

--- a/lib/plain/endpoints/environment.ts
+++ b/lib/plain/endpoints/environment.ts
@@ -64,7 +64,7 @@ export const createWithId = (
 ) => {
   const { spaceId, environmentId } = params
   return create(http, { spaceId }, rawData, {
-    ...(headers || {}),
+    ...headers,
     'X-Contentful-Source-Environment': environmentId,
   })
 }

--- a/lib/plain/endpoints/environment.ts
+++ b/lib/plain/endpoints/environment.ts
@@ -33,8 +33,8 @@ export const update = (
     data,
     {
       headers: {
-        'X-Contentful-Version': rawData.sys.version ?? 0,
         ...headers,
+        'X-Contentful-Version': rawData.sys.version ?? 0,
       },
     }
   )
@@ -58,13 +58,24 @@ export const create = (
 
 export const createWithId = (
   http: AxiosInstance,
-  params: GetEnvironmentParams,
+  params: GetEnvironmentParams & { sourceEnvironmentId?: string },
   rawData: CreateEnvironmentProps,
   headers?: Record<string, unknown>
 ) => {
-  const { spaceId, environmentId } = params
-  return create(http, { spaceId }, rawData, {
-    ...headers,
-    'X-Contentful-Source-Environment': environmentId,
-  })
+  const data = cloneDeep(rawData)
+  return raw.put<EnvironmentProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}`,
+    data,
+    {
+      headers: {
+        ...headers,
+        ...(params.sourceEnvironmentId
+          ? {
+              'X-Contentful-Source-Environment': params.sourceEnvironmentId,
+            }
+          : {}),
+      },
+    }
+  )
 }

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -23,7 +23,11 @@ export const createPlainClient = (params: ClientParams, defaults?: DefaultParams
     },
     environment: {
       get: wrap(wrapParams, endpoints.environment.get),
+      getAll: wrap(wrapParams, endpoints.environment.getAll),
+      create: wrap(wrapParams, endpoints.environment.create),
+      createWithId: wrap(wrapParams, endpoints.environment.createWithId),
       update: wrap(wrapParams, endpoints.environment.update),
+      delete: wrap(wrapParams, endpoints.environment.del),
     },
     contentType: {
       getMany: wrap(wrapParams, endpoints.contentType.getMany),

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -23,7 +23,7 @@ export const createPlainClient = (params: ClientParams, defaults?: DefaultParams
     },
     environment: {
       get: wrap(wrapParams, endpoints.environment.get),
-      getAll: wrap(wrapParams, endpoints.environment.getAll),
+      getMany: wrap(wrapParams, endpoints.environment.getMany),
       create: wrap(wrapParams, endpoints.environment.create),
       createWithId: wrap(wrapParams, endpoints.environment.createWithId),
       update: wrap(wrapParams, endpoints.environment.update),


### PR DESCRIPTION
Exposes all environment-related endpoints to a plain CMA client and reuses endpoints in the original CMA client internals.