### PR TITLE
feat(tags): management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,7 @@ jspm_packages/
 
 # dotenv environment variables file
 .env
-
+.envrc
 
 ### OSX ###
 *.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# contentful-management.js
+    # contentful-management.js
 
 > JavaScript SDK for [Contentful's](https://www.contentful.com) Content Management API.
 

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1,3 +1,5 @@
+import { TagProps } from './entities/tag'
+
 export interface DefaultElements<TPlainObject extends object = object> {
   toPlainObject(): TPlainObject
 }
@@ -22,6 +24,10 @@ export interface MetaLinkProps {
   id: string
 }
 
+export interface MetadataProps {
+  tags: TagProps[]
+}
+
 export interface CollectionProp<TObj> {
   sys: {
     type: 'Array'
@@ -43,5 +49,6 @@ export interface QueryOptions {
   order?: string
   content_type?: string
   include?: number
+
   [key: string]: any
 }

--- a/lib/common-utils.ts
+++ b/lib/common-utils.ts
@@ -15,3 +15,9 @@ export const wrapCollection = <R, T>(fn: (http: AxiosInstance, entity: T) => R) 
   // @ts-ignore
   return collectionData
 }
+
+export const VersionHeader = (version?: number) => ({
+  headers: {
+    'X-Contentful-Version': Number.isInteger(version) ? version : 0,
+  },
+})

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -1,17 +1,18 @@
-import cloneDeep from 'lodash/cloneDeep'
-import { createRequestConfig } from 'contentful-sdk-core'
-import errorHandler from './error-handler'
-import entities from './entities'
-
-import type { CreateContentTypeProps, ContentType } from './entities/content-type'
-import type { QueryOptions } from './common-types'
-import { EntryProp, Entry } from './entities/entry'
-import type { AssetFileProp, AssetProps } from './entities/asset'
-import type { CreateLocaleProps } from './entities/locale'
-import type { UIExtensionProps } from './entities/ui-extension'
-import type { AppInstallationProps } from './entities/app-installation'
-import { Stream } from 'stream'
 import { AxiosInstance } from 'axios'
+import { createRequestConfig } from 'contentful-sdk-core'
+import cloneDeep from 'lodash/cloneDeep'
+import { Stream } from 'stream'
+import { QueryOptions } from './common-types'
+import entities from './entities'
+import { AppInstallationProps } from './entities/app-installation'
+import { AssetFileProp, AssetProps } from './entities/asset'
+
+import { ContentType, CreateContentTypeProps } from './entities/content-type'
+import { Entry, EntryProp } from './entities/entry'
+import { CreateLocaleProps } from './entities/locale'
+import { wrapTag, wrapTagCollection } from './entities/tag'
+import { UIExtensionProps } from './entities/ui-extension'
+import errorHandler from './error-handler'
 
 export type ContentfulEnvironmentAPI = ReturnType<typeof createEnvironmentApi>
 
@@ -1009,6 +1010,25 @@ export default function createEnvironmentApi({
       return http
         .get(`content_types/${contentTypeId}/snapshots`, createRequestConfig({ query: query }))
         .then((response) => wrapSnapshotCollection<ContentType>(http, response.data), errorHandler)
+    },
+
+    createTag(id: string, name: string) {
+      return http
+        .put(`tags/${id}`, {
+          name,
+          sys: {
+            id,
+          },
+        })
+        .then((response) => wrapTag(http, response.data), errorHandler)
+    },
+    getTags(skip?: number, limit?: number) {
+      return http
+        .get('tags', { params: { skip, limit } })
+        .then((response) => wrapTagCollection(http, response.data), errorHandler)
+    },
+    getTag(id: string) {
+      return http.get('tags/' + id).then((response) => wrapTag(http, response.data), errorHandler)
     },
   }
 }

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -1017,6 +1017,7 @@ export default function createEnvironmentApi({
         .put(`tags/${id}`, {
           name,
           sys: {
+            type: 'Tag',
             id,
           },
         })

--- a/lib/entities/asset.ts
+++ b/lib/entities/asset.ts
@@ -4,7 +4,7 @@ import { Stream } from 'stream'
 import { AxiosInstance } from 'axios'
 import enhanceWithMethods from '../enhance-with-methods'
 import errorHandler from '../error-handler'
-import { MetaSysProps, DefaultElements } from '../common-types'
+import { MetaSysProps, DefaultElements, MetadataProps } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import {
   createUpdateEntity,
@@ -44,6 +44,7 @@ export type AssetProps = {
       }
     }
   }
+  metadata?: MetadataProps
 }
 
 export interface AssetFileProp {

--- a/lib/entities/entry.ts
+++ b/lib/entities/entry.ts
@@ -17,7 +17,13 @@ import {
 } from '../instance-actions'
 import errorHandler from '../error-handler'
 import { wrapSnapshot, wrapSnapshotCollection, SnapshotProps, Snapshot } from './snapshot'
-import { MetaSysProps, MetaLinkProps, DefaultElements, Collection } from '../common-types'
+import {
+  MetaSysProps,
+  MetaLinkProps,
+  DefaultElements,
+  Collection,
+  MetadataProps,
+} from '../common-types'
 
 export interface EntrySys extends MetaSysProps {
   contentType: { sys: MetaLinkProps }
@@ -32,6 +38,7 @@ export interface EntrySys extends MetaSysProps {
 export type EntryProp = {
   sys: EntrySys
   fields: Record<string, any>
+  metadata?: MetadataProps
 }
 
 type EntryApi = {

--- a/lib/entities/index.ts
+++ b/lib/entities/index.ts
@@ -26,6 +26,7 @@ import * as usage from './usage'
 import * as environmentAlias from './environment-alias'
 import * as team from './team'
 import * as teamMembership from './team-membership'
+import * as tag from './tag'
 
 export default {
   appDefinition,
@@ -56,4 +57,5 @@ export default {
   environmentAlias,
   team,
   teamMembership,
+  tag,
 }

--- a/lib/entities/tag.ts
+++ b/lib/entities/tag.ts
@@ -1,0 +1,93 @@
+import { AxiosInstance } from 'axios'
+import { freezeSys, toPlainObject } from 'contentful-sdk-core'
+import { cloneDeep } from 'lodash'
+import { DefaultElements, MetaSysProps } from '../common-types'
+import { VersionHeader, wrapCollection } from '../common-utils'
+import enhanceWithMethods from '../enhance-with-methods'
+import errorHandler from '../error-handler'
+
+export type TagSysProps = Pick<
+  MetaSysProps,
+  'id' | 'space' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
+> & {
+  type: 'Tag'
+  environment: {
+    sys: {
+      id: string
+      type: 'Link'
+      linkType: 'Environment'
+    }
+  }
+}
+
+export type TagProps = {
+  sys: TagSysProps
+  name: string
+}
+
+export type TagCollectionProps = {
+  sys: {
+    type: 'Array'
+  }
+  items: TagProps[]
+  total: number
+}
+
+export interface TagCollection {
+  items: Tag[]
+  total: number
+}
+
+type ThisContext = TagProps & DefaultElements<TagProps>
+
+type TagApi = {
+  update(): Promise<Tag>
+  delete(): Promise<void>
+}
+
+export interface Tag extends TagProps, DefaultElements<TagProps>, TagApi {}
+
+export function createDeleteTag(http: AxiosInstance): () => Promise<void> {
+  return function (): Promise<void> {
+    const self = this as ThisContext
+    return (
+      http
+        .delete('tags/' + self.sys.id, VersionHeader(self.sys.version))
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        .then(() => {}, errorHandler)
+    )
+  }
+}
+
+export function createUpdateTag(http: AxiosInstance): () => Promise<Tag> {
+  return function (): Promise<Tag> {
+    const self = this as ThisContext
+    return http
+      .put(
+        'tags',
+        {
+          name: self.name,
+          sys: {
+            id: self.sys.id,
+          },
+        },
+        VersionHeader(self.sys.version)
+      )
+      .then((response) => wrapTag(http, response.data), errorHandler)
+  }
+}
+
+export default function createTagApi(http: AxiosInstance): TagApi {
+  return {
+    update: createUpdateTag(http),
+    delete: createDeleteTag(http),
+  }
+}
+
+export function wrapTag(http: AxiosInstance, data: TagProps): Tag {
+  const tag = toPlainObject(cloneDeep(data))
+  const tagWithMethods = enhanceWithMethods(tag, createTagApi(http))
+  return freezeSys(tagWithMethods)
+}
+
+export const wrapTagCollection = wrapCollection(wrapTag)

--- a/test/integration/environment-integration.js
+++ b/test/integration/environment-integration.js
@@ -7,7 +7,7 @@ export function environmentTests(t, space, waitForEnvironmentToBeReady) {
     })
   })
 
-  t.test('creates an enviroment with an id', (t) => {
+  t.test('creates an environment with an id', (t) => {
     t.plan(2)
     return space.createEnvironmentWithId('myId', { name: 'myId' }).then((response) => {
       t.equals(response.name, 'myId', 'env was created with correct name')

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -375,17 +375,17 @@ test('Logs request and response with custom loggers', (t) => {
   })
 })
 
-test('gets V2 space for tag tests', async (t) => {
-  const space = await v2Client.getSpace('w6xueg32zr68')
-  try {
-    await tagTests(t, space)
-  } finally {
-    // await deleteAllTags(space, 'master')
-  }
+test.only('gets V2 space for tag tests', (t) => {
+  console.debug('1')
+  v2Client.getSpace('w6xueg32zr68').then((space) => {
+    tagTests(t, space)
+    test.onFinish(() => deleteAllTags(space, 'master'))
+  })
 })
 
-/*
 async function deleteAllTags(space, environmentName) {
+  console.debug('6')
+
   console.log('delete all test tags')
   const environment = await space.getEnvironment(environmentName)
   const tags = await environment.getTags(0, 1000)
@@ -393,4 +393,3 @@ async function deleteAllTags(space, environmentName) {
     await tags.items[index]['delete']()
   }
 }
- */

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -375,7 +375,7 @@ test('Logs request and response with custom loggers', (t) => {
   })
 })
 
-test('gets V2 space for entity tag tests', async (t) => {
+test('gets V2 space for tag tests', async (t) => {
   const space = await v2Client.getSpace('w6xueg32zr68')
   try {
     await tagTests(t, space)

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -387,7 +387,6 @@ test('gets V2 space for entity tag tests', async (t) => {
 async function deleteAllTags(space, environmentName) {
   const environment = await space.getEnvironment(environmentName)
   const tags = await environment.getTags(0, 1000)
-  console.debug(`delete ${tags.total} test tags`)
   for (let index = 0; index < tags.total; index++) {
     await tags.items[index]['delete']()
   }

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -387,6 +387,7 @@ test('gets V2 space for entity tag tests', async (t) => {
 async function deleteAllTags(space, environmentName) {
   const environment = await space.getEnvironment(environmentName)
   const tags = await environment.getTags(0, 1000)
+  console.debug(`delete ${tags.total} test tags`)
   for (let index = 0; index < tags.total; index++) {
     await tags.items[index]['delete']()
   }

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -380,14 +380,17 @@ test('gets V2 space for tag tests', async (t) => {
   try {
     await tagTests(t, space)
   } finally {
-    await deleteAllTags(space, 'master')
+    // await deleteAllTags(space, 'master')
   }
 })
 
+/*
 async function deleteAllTags(space, environmentName) {
+  console.log('delete all test tags')
   const environment = await space.getEnvironment(environmentName)
   const tags = await environment.getTags(0, 1000)
   for (let index = 0; index < tags.total; index++) {
     await tags.items[index]['delete']()
   }
 }
+ */

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -24,6 +24,7 @@ import generateRandomId from './generate-random-id'
 import { createClient } from '../../'
 import { environmentTests } from './environment-integration'
 import { environmentAliasReadOnlyTests } from './environment-alias-integration'
+import { tagTests } from './tag-integration'
 
 const params = {
   accessToken: process.env.CONTENTFUL_ACCESS_TOKEN,
@@ -373,3 +374,20 @@ test('Logs request and response with custom loggers', (t) => {
     )
   })
 })
+
+test('gets V2 space for entity tag tests', async (t) => {
+  const space = await v2Client.getSpace('w6xueg32zr68')
+  try {
+    await tagTests(t, space)
+  } finally {
+    await deleteAllTags(space, 'master')
+  }
+})
+
+async function deleteAllTags(space, environmentName) {
+  const environment = await space.getEnvironment(environmentName)
+  const tags = await environment.getTags(0, 1000)
+  for (let index = 0; index < tags.total; index++) {
+    await tags.items[index]['delete']()
+  }
+}

--- a/test/integration/tag-integration.js
+++ b/test/integration/tag-integration.js
@@ -1,0 +1,36 @@
+export async function tagTests(t, space) {
+  await t.test('create tag', async () => {
+    const tagId = randomTagId()
+    const tagName = 'Tag ' + tagId
+    const environment = await space.getEnvironment('master')
+    const newTag = await environment.createTag(tagId, tagName)
+    t.equals(newTag.name, tagName, 'tag name should be equal')
+  })
+
+  await t.test('read tag', async () => {
+    const tagId = randomTagId()
+    const tagName = 'Tag ' + tagId
+    const environment = await space.getEnvironment('master')
+    await environment.createTag(tagId, tagName)
+    const result = await environment.getTag(tagId)
+    t.equals(result.name, tagName, 'tag name should be equal')
+    t.equals(result.sys.id, tagId, 'tag id should be equal')
+  })
+
+  await t.test('read tags', async () => {
+    const tagId = randomTagId()
+    const tagName = 'Tag ' + tagId
+    const environment = await space.getEnvironment('master')
+
+    for (let index = 0; index < 10; index++) {
+      await environment.createTag(`${tagId}-${index}`, `${tagName} ${index}`)
+    }
+
+    const result = await environment.getTags()
+    t.equals(result.total >= 10, true, 'should return a minimum of created tags')
+  })
+}
+
+function randomTagId() {
+  return 'test-' + Date.now()
+}

--- a/test/integration/tag-integration.js
+++ b/test/integration/tag-integration.js
@@ -60,7 +60,7 @@ export async function tagTests(t, space) {
       let asset = await env.getAsset('1YK5kwroV6UEGS64mQs0Eo')
       await writeEntityTagsTest(t, asset, env)
     } finally {
-      entry.delete()
+      await entry.delete()
     }
   })
 }

--- a/test/integration/tag-integration.js
+++ b/test/integration/tag-integration.js
@@ -29,6 +29,47 @@ export async function tagTests(t, space) {
     const result = await environment.getTags()
     t.equals(result.total >= 10, true, 'should return a minimum of created tags')
   })
+
+  async function writeEntityTagsTest(t, entity, environment) {
+    t.equal(entity.metadata.tags.length, 0, 'entity starts with no tags')
+    const tag = await createRandomTag(environment)
+    const tagLink = {
+      sys: {
+        type: 'Link',
+        linkType: 'Tag',
+        id: tag.sys.id,
+      },
+    }
+    entity.metadata.tags.push(tagLink)
+    console.log(`entity update`)
+    const updatedEntity = await entity.update()
+    t.deepEqual(updatedEntity.metadata.tags[0], tagLink, 'tag created on entity')
+    updatedEntity.metadata.tags = []
+    console.log(`entity update`)
+    const noTagsEntity = await updatedEntity.update()
+    t.deepEqual(noTagsEntity.metadata.tags, [], 'tag removed from entity')
+  }
+
+  await t.test('Creates, edits, deletes tags on entity', async (t) => {
+    t.plan(6)
+    let entry
+    try {
+      const env = await space.getEnvironment('master')
+      entry = await env.createEntry('layout', { fields: {} })
+      await writeEntityTagsTest(t, entry, env)
+      let asset = await env.getAsset('1YK5kwroV6UEGS64mQs0Eo')
+      await writeEntityTagsTest(t, asset, env)
+    } finally {
+      entry.delete()
+    }
+  })
+}
+
+async function createRandomTag(environment) {
+  const tagId = randomTagId()
+  const tagName = 'Tag ' + tagId
+  console.log(`create random tag ${tagName}:${tagId}`)
+  return environment.createTag(tagId, tagName)
 }
 
 function randomTagId() {

--- a/test/integration/tag-integration.js
+++ b/test/integration/tag-integration.js
@@ -1,70 +1,3 @@
-export async function tagTests(t, space) {
-  await t.test('create tag', async () => {
-    const tagId = randomTagId()
-    const tagName = 'Tag ' + tagId
-    const environment = await space.getEnvironment('master')
-    const newTag = await environment.createTag(tagId, tagName)
-    t.equals(newTag.name, tagName, 'tag name should be equal')
-  })
-
-  await t.test('read tag', async () => {
-    const tagId = randomTagId()
-    const tagName = 'Tag ' + tagId
-    const environment = await space.getEnvironment('master')
-    await environment.createTag(tagId, tagName)
-    const result = await environment.getTag(tagId)
-    t.equals(result.name, tagName, 'tag name should be equal')
-    t.equals(result.sys.id, tagId, 'tag id should be equal')
-  })
-
-  await t.test('read tags', async () => {
-    const tagId = randomTagId()
-    const tagName = 'Tag ' + tagId
-    const environment = await space.getEnvironment('master')
-
-    for (let index = 0; index < 10; index++) {
-      await environment.createTag(`${tagId}-${index}`, `${tagName} ${index}`)
-    }
-
-    const result = await environment.getTags()
-    t.equals(result.total >= 10, true, 'should return a minimum of created tags')
-  })
-
-  async function writeEntityTagsTest(t, entity, environment) {
-    t.equal(entity.metadata.tags.length, 0, 'entity starts with no tags')
-    const tag = await createRandomTag(environment)
-    const tagLink = {
-      sys: {
-        type: 'Link',
-        linkType: 'Tag',
-        id: tag.sys.id,
-      },
-    }
-    entity.metadata.tags.push(tagLink)
-    console.log(`entity update`)
-    const updatedEntity = await entity.update()
-    t.deepEqual(updatedEntity.metadata.tags[0], tagLink, 'tag created on entity')
-    updatedEntity.metadata.tags = []
-    console.log(`entity update`)
-    const noTagsEntity = await updatedEntity.update()
-    t.deepEqual(noTagsEntity.metadata.tags, [], 'tag removed from entity')
-  }
-
-  await t.test('Creates, edits, deletes tags on entity', async (t) => {
-    t.plan(6)
-    let entry
-    try {
-      const env = await space.getEnvironment('master')
-      entry = await env.createEntry('layout', { fields: {} })
-      await writeEntityTagsTest(t, entry, env)
-      let asset = await env.getAsset('1YK5kwroV6UEGS64mQs0Eo')
-      await writeEntityTagsTest(t, asset, env)
-    } finally {
-      await entry.delete()
-    }
-  })
-}
-
 async function createRandomTag(environment) {
   const tagId = randomTagId()
   const tagName = 'Tag ' + tagId
@@ -74,4 +7,86 @@ async function createRandomTag(environment) {
 
 function randomTagId() {
   return 'test-' + Date.now()
+}
+
+async function createTagTest(t, space) {
+  t.plan(1)
+  const tagId = randomTagId()
+  const tagName = 'Tag ' + tagId
+  const environment = await space.getEnvironment('master')
+  const newTag = await environment.createTag(tagId, tagName)
+  t.equals(newTag.name, tagName, 'tag name should be equal')
+}
+
+async function createReadTagTest(t, space) {
+  t.plan(2)
+  const tagId = randomTagId()
+  const tagName = 'Tag ' + tagId
+  const environment = await space.getEnvironment('master')
+  await environment.createTag(tagId, tagName)
+  const result = await environment.getTag(tagId)
+  t.equals(result.name, tagName, 'tag name should be equal')
+  t.equals(result.sys.id, tagId, 'tag id should be equal')
+}
+
+async function createReadTagsTest(t, space) {
+  t.plan(1)
+  const tagId = randomTagId()
+  const tagName = 'Tag ' + tagId
+  const environment = await space.getEnvironment('master')
+
+  for (let index = 0; index < 10; index++) {
+    await environment.createTag(`${tagId}-${index}`, `${tagName} ${index}`)
+  }
+
+  const result = await environment.getTags()
+  t.equals(result.total >= 10, true, 'should return a minimum of created tags')
+}
+
+async function writeEntityTagsTest(t, entity, environment) {
+  t.equal(entity.metadata.tags.length, 0, 'entity starts with no tags')
+  const tag = await createRandomTag(environment)
+  const tagLink = {
+    sys: {
+      type: 'Link',
+      linkType: 'Tag',
+      id: tag.sys.id,
+    },
+  }
+  entity.metadata.tags.push(tagLink)
+  console.log(`entity update`)
+  const updatedEntity = await entity.update()
+  t.deepEqual(updatedEntity.metadata.tags[0], tagLink, 'tag created on entity')
+  updatedEntity.metadata.tags = []
+  console.log(`entity update`)
+  const noTagsEntity = await updatedEntity.update()
+  t.deepEqual(noTagsEntity.metadata.tags, [], 'tag removed from entity')
+}
+
+async function createManipulateEntitiesTest(t, space) {
+  t.plan(6)
+  let entry
+  const env = await space.getEnvironment('master')
+  entry = await env.createEntry('layout', { fields: {} })
+  await writeEntityTagsTest(t, entry, env)
+  let asset = await env.getAsset('1YK5kwroV6UEGS64mQs0Eo')
+  await writeEntityTagsTest(t, asset, env)
+}
+
+export function tagTests(suite, space) {
+  suite.test('create tag', (t) => {
+    return createTagTest(t, space)
+  })
+
+  suite.test('read tag', (t) => {
+    return createReadTagTest(t, space)
+  })
+
+  suite.test('read tags', async (t) => {
+    return createReadTagsTest(t, space)
+  })
+
+  suite.test('Creates, edits, deletes tags on entity', (t) => {
+    return createManipulateEntitiesTest(t, space)
+  })
 }

--- a/test/unit/create-environment-api-test.js
+++ b/test/unit/create-environment-api-test.js
@@ -5,36 +5,41 @@ import createEnvironmentApi, {
   __RewireAPI__ as createEnvironmentApiRewireApi,
 } from '../../lib/create-environment-api'
 import {
-  contentTypeMock,
-  editorInterfaceMock,
+  appInstallationMock,
   assetMock,
   assetWithFilesMock,
-  uploadMock,
+  cloneMock,
+  contentTypeMock,
+  editorInterfaceMock,
   entryMock,
   localeMock,
+  mockCollection,
   setupEntitiesMock,
-  cloneMock,
-  uiExtensionMock,
-  appInstallationMock,
   snapShotMock,
+  uiExtensionMock,
+  uploadMock,
 } from './mocks/entities'
 import setupHttpMock from './mocks/http'
 import {
-  makeGetEntityTest,
-  makeGetCollectionTest,
   makeCreateEntityTest,
   makeCreateEntityWithIdTest,
   makeEntityMethodFailingTest,
+  makeGetCollectionTest,
+  makeGetEntityTest,
   testGettingEntrySDKObject,
 } from './test-creators/static-entity-methods'
 import { wrapEntry } from '../../lib/entities/entry'
 import { wrapAsset } from '../../lib/entities/asset'
+import { wrapTagCollection } from '../../lib/entities/tag'
 
 function setup(promise) {
   const entitiesMock = setupEntitiesMock(createEnvironmentApiRewireApi)
   const httpMock = setupHttpMock(promise)
   const httpUploadMock = setupHttpMock(promise)
-  const api = createEnvironmentApi({ http: httpMock, httpUpload: httpUploadMock })
+  const api = createEnvironmentApi({
+    http: httpMock,
+    httpUpload: httpUploadMock,
+  })
   return {
     api,
     httpMock,
@@ -71,14 +76,21 @@ test('API call environment delete fails', (t) => {
 test('API call environment update', (t) => {
   t.plan(3)
   const responseData = {
-    sys: { id: 'id', type: 'Environment' },
+    sys: {
+      id: 'id',
+      type: 'Environment',
+    },
     name: 'updatedname',
   }
   let { api, httpMock, entitiesMock } = setup(Promise.resolve({ data: responseData }))
   entitiesMock.environment.wrapEnvironment.returns(responseData)
 
   // mocks data that would exist in a environment object already retrieved from the server
-  api.sys = { id: 'id', type: 'Environment', version: 2 }
+  api.sys = {
+    id: 'id',
+    type: 'Environment',
+    version: 2,
+  }
   api = toPlainObject(api)
 
   api.name = 'updatedname'
@@ -96,7 +108,11 @@ test('API call environment update fails', (t) => {
   let { api } = setup(Promise.reject(error))
 
   // mocks data that would exist in a environment object already retrieved from the server
-  api.sys = { id: 'id', type: 'Space', version: 2 }
+  api.sys = {
+    id: 'id',
+    type: 'Space',
+    version: 2,
+  }
   api = toPlainObject(api)
 
   return api.update().catch((r) => {
@@ -659,5 +675,33 @@ test('API call getAppInstallations', (t) => {
 test('API call getAppInstallations fails', (t) => {
   makeEntityMethodFailingTest(t, setup, teardown, {
     methodToTest: 'getAppInstallations',
+  })
+})
+
+test('API call getTag', (t) => {
+  t.plan(1)
+  const tag = cloneMock('tag')
+  const { api } = setup(Promise.resolve({ data: cloneMock('tag') }))
+  api.getTag(tag.id).then((r) => {
+    t.looseEqual(r, tag)
+  })
+})
+
+test('API call getTags', (t) => {
+  t.plan(1)
+  const tagCollection = mockCollection(cloneMock('tag'))
+  const { api, httpMock } = setup(Promise.resolve({ data: tagCollection }))
+  const wrappedCollection = wrapTagCollection(httpMock, tagCollection)
+  api.getTags(0, 1).then((r) => {
+    t.looseEqual(r, wrappedCollection)
+  })
+})
+
+test('API call createTag', (t) => {
+  t.plan(1)
+  const tag = cloneMock('tag')
+  const { api } = setup(Promise.resolve({ data: cloneMock('tag') }))
+  api.createTag('my-tag', 'My tag').then((r) => {
+    t.looseEqual(r, tag)
   })
 })

--- a/test/unit/entities/asset-test.js
+++ b/test/unit/entities/asset-test.js
@@ -50,6 +50,24 @@ test('Asset update fails', (t) => {
   })
 })
 
+test('Asset update with tags works', (t) => {
+  t.plan(3)
+  const { httpMock } = setup()
+  const entityMock = cloneMock('assetWithTags')
+  entityMock.sys.version = 2
+  const entity = wrapAsset(httpMock, entityMock)
+  entity.metadata.tags[0] = {
+    name: 'newname',
+    sys: entityMock.metadata.tags[0].sys,
+  }
+  return entity.update().then((response) => {
+    t.ok(response.toPlainObject, 'response is wrapped')
+    t.equals(httpMock.put.args[0][1].metadata.tags[0].name, 'newname', 'metadata is sent')
+    t.equals(httpMock.put.args[0][2].headers['X-Contentful-Version'], 2, 'version header is sent')
+    return { httpMock, entityMock, response }
+  })
+})
+
 test('Asset delete', (t) => {
   return entityDeleteTest(t, setup, {
     wrapperMethod: wrapAsset,

--- a/test/unit/entities/entry-test.js
+++ b/test/unit/entities/entry-test.js
@@ -43,6 +43,24 @@ test('Entry update', (t) => {
   })
 })
 
+test('Entry update with tags works', (t) => {
+  t.plan(3)
+  const { httpMock } = setup()
+  const entityMock = cloneMock('entryWithTags')
+  entityMock.sys.version = 2
+  const entity = wrapEntry(httpMock, entityMock)
+  entity.metadata.tags[0] = {
+    name: 'newname',
+    sys: entityMock.metadata.tags[0].sys,
+  }
+  return entity.update().then((response) => {
+    t.ok(response.toPlainObject, 'response is wrapped')
+    t.equals(httpMock.put.args[0][1].metadata.tags[0].name, 'newname', 'metadata is sent')
+    t.equals(httpMock.put.args[0][2].headers['X-Contentful-Version'], 2, 'version header is sent')
+    return { httpMock, entityMock, response }
+  })
+})
+
 test('Entry update fails', (t) => {
   return failingVersionActionTest(t, setup, {
     wrapperMethod: wrapEntry,

--- a/test/unit/entities/tag-test.js
+++ b/test/unit/entities/tag-test.js
@@ -1,0 +1,42 @@
+import test from 'blue-tape'
+import { wrapTag } from '../../../lib/entities/tag'
+import setupHttpMock from '../mocks/http'
+import { cloneMock } from '../mocks/entities'
+import {
+  entityDeleteTest,
+  entityUpdateTest,
+  failingActionTest,
+} from '../test-creators/instance-entity-methods'
+
+function setup(promise) {
+  return {
+    httpMock: setupHttpMock(promise),
+    entityMock: cloneMock('tag'),
+  }
+}
+
+test('Tag update', (t) => {
+  return entityUpdateTest(t, setup, {
+    wrapperMethod: wrapTag,
+  })
+})
+
+test('Tag update fails', (t) => {
+  return failingActionTest(t, setup, {
+    wrapperMethod: wrapTag,
+    actionMethod: 'update',
+  })
+})
+
+test('Tag delete', (t) => {
+  return entityDeleteTest(t, setup, {
+    wrapperMethod: wrapTag,
+  })
+})
+
+test('Tag delete fails', (t) => {
+  return failingActionTest(t, setup, {
+    wrapperMethod: wrapTag,
+    actionMethod: 'delete',
+  })
+})

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -212,7 +212,11 @@ const teamSpaceMembershipMock = {
   sys: Object.assign(cloneDeep(membershipMock), {
     type: 'TeamSpaceMembership',
     space: {
-      sys: { id: 'space_id', type: 'Link', linkType: 'Space' },
+      sys: {
+        id: 'space_id',
+        type: 'Link',
+        linkType: 'Space',
+      },
     },
   }),
   roles: [{ sys: Object.assign(cloneDeep(linkMock), { linkType: 'Role' }) }],
@@ -309,6 +313,27 @@ const errorMock = {
   },
 }
 
+export const tagMock = {
+  name: 'My tag',
+  sys: {
+    id: 'my-tag',
+    space: {
+      sys: cloneDeep(linkMock),
+    },
+    version: 1,
+    createdAt: 'createdAt',
+    updatedAt: 'updatedAt',
+    type: 'Tag',
+    environment: {
+      sys: {
+        id: 'environment-id',
+        type: 'Link',
+        linkType: 'Environment',
+      },
+    },
+  },
+}
+
 const mocks = {
   link: linkMock,
   sys: sysMock,
@@ -338,6 +363,7 @@ const mocks = {
   personalAccessToken: personalAccessTokenMock,
   usage: usageMock,
   environmentAlias: environmentAliasMock,
+  tag: tagMock,
 }
 
 function cloneMock(name) {

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -106,6 +106,21 @@ const entryMock = {
     field1: 'str',
   },
 }
+
+const entryMockWithTags = {
+  ...entryMock,
+  metadata: {
+    tags: [
+      {
+        name: 'entrytag',
+        sys: {
+          type: 'Tag',
+          id: 'entrytag',
+        },
+      },
+    ],
+  },
+}
 const editorInterfaceMock = {
   sys: Object.assign(cloneDeep(sysMock), {
     type: 'EditorInterface',
@@ -126,6 +141,21 @@ const assetMock = {
   }),
   fields: {
     field1: 'str',
+  },
+}
+
+const assetMockWithTags = {
+  ...assetMock,
+  metadata: {
+    tags: [
+      {
+        name: 'tagname',
+        sys: {
+          type: 'Tag',
+          id: 'tagname',
+        },
+      },
+    ],
   },
 }
 
@@ -340,8 +370,10 @@ const mocks = {
   contentType: contentTypeMock,
   editorInterface: editorInterfaceMock,
   entry: entryMock,
+  entryWithTags: entryMockWithTags,
   snapshot: snapShotMock,
   asset: assetMock,
+  assetWithTags: assetMockWithTags,
   locale: localeMock,
   webhook: webhookMock,
   spaceMember: spaceMemberMock,

--- a/test/unit/test-creators/static-entity-methods.js
+++ b/test/unit/test-creators/static-entity-methods.js
@@ -1,9 +1,5 @@
 import { cloneMock } from '../mocks/entities'
-import cloneDeep from 'lodash/cloneDeep'
-
-function upperFirst(string) {
-  return string.charAt(0).toUpperCase() + string.slice(1)
-}
+import { cloneDeep, upperFirst } from 'lodash'
 
 export function makeGetEntityTest(
   t,


### PR DESCRIPTION
Add tag management to the SDK. Content tags are only available on the CMA, and used to organize content within the web app. Tags live under the `metadata` property, a new top-level property on entries and assets. 

This PR includes:

* CRUD operations on tags (via Environment API)
* updates to `entry` and `asset` typings to include the optional metadata property
* tests for entry and asset to confirm `metadata` is included in the payload and can be updated from those entities

Example:

```js
const env = await space.getEnvironment('main')
const entry = await env.getEntry('myEntry')

// create a tag
const myTag = await env.createTag('myTagId', 'myTagName')

// update entry with tag
entry.metadata.tags.push(myTag)
await entry.update()

// update tag name
myTag.name = 'my new tag name'
await myTag.update()

// delete tag
await myTag.delete()
```