### PR TITLE
 feat: extract all locale methods

### DIFF
--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -731,7 +731,7 @@ export default function createEnvironmentApi({
     createUpload: createUpload,
     /**
      * Gets a Locale
-     * @param id - Locale ID
+     * @param localeId - Locale ID
      * @return Promise for an Locale
      * @example ```javascript
      * const contentful = require('contentful-management')
@@ -747,10 +747,15 @@ export default function createEnvironmentApi({
      * .catch(console.error)
      * ```
      */
-    getLocale(id: string) {
-      return http
-        .get('locales/' + id)
-        .then((response) => wrapLocale(http, response.data), errorHandler)
+    getLocale(localeId: string) {
+      const raw = this.toPlainObject() as EnvironmentProps
+      return endpoints.locale
+        .get(http, {
+          spaceId: raw.sys.space.sys.id,
+          environmentId: raw.sys.id,
+          localeId,
+        })
+        .then((data) => wrapLocale(http, data))
     },
 
     /**
@@ -804,9 +809,17 @@ export default function createEnvironmentApi({
      * ```
      */
     createLocale(data: CreateLocaleProps) {
-      return http
-        .post('locales', data)
-        .then((response) => wrapLocale(http, response.data), errorHandler)
+      const raw = this.toPlainObject() as EnvironmentProps
+      return endpoints.locale
+        .create(
+          http,
+          {
+            spaceId: raw.sys.space.sys.id,
+            environmentId: raw.sys.id,
+          },
+          data
+        )
+        .then((data) => wrapLocale(http, data))
     },
     /**
      * Gets an UI Extension

--- a/lib/entities/locale.ts
+++ b/lib/entities/locale.ts
@@ -4,11 +4,11 @@ import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import { Except, SetOptional } from 'type-fest'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
-import { createUpdateEntity, createDeleteEntity } from '../instance-actions'
-import { MetaSysProps, DefaultElements } from '../common-types'
+import { BasicMetaSysProps, MetaLinkProps, DefaultElements } from '../common-types'
+import * as endpoints from '../plain/endpoints'
 
 export type LocaleProps = {
-  sys: MetaSysProps
+  sys: BasicMetaSysProps & { space: { sys: MetaLinkProps }; environment: { sys: MetaLinkProps } }
   /**
    * Locale name
    */
@@ -87,21 +87,26 @@ export interface Locale extends LocaleProps, DefaultElements<LocaleProps> {
 }
 
 function createLocaleApi(http: AxiosInstance) {
+  const getParams = (locale: LocaleProps) => ({
+    spaceId: locale.sys.space.sys.id,
+    environmentId: locale.sys.environment.sys.id,
+    localeId: locale.sys.id,
+  })
+
   return {
     update: function () {
-      const self = this as Locale
-      delete self.default // we should not send this back
-      return createUpdateEntity({
-        http: http,
-        entityPath: 'locales',
-        wrapperMethod: wrapLocale,
-      }).call(self)
+      const raw = this.toPlainObject() as LocaleProps
+      return endpoints.locale
+        .update(http, getParams(raw), raw)
+        .then((data) => wrapLocale(http, data))
     },
 
-    delete: createDeleteEntity({
-      http: http,
-      entityPath: 'locales',
-    }),
+    delete: function () {
+      const raw = this.toPlainObject() as LocaleProps
+      return endpoints.locale.del(http, getParams(raw)).then(() => {
+        // noop
+      })
+    },
   }
 }
 

--- a/lib/plain/endpoints/locale.ts
+++ b/lib/plain/endpoints/locale.ts
@@ -1,17 +1,70 @@
 import { AxiosInstance } from 'axios'
+import cloneDeep from 'lodash/cloneDeep'
 import { CollectionProp } from '../../common-types'
-import { LocaleProps } from '../../entities/locale'
+import { LocaleProps, CreateLocaleProps } from '../../entities/locale'
 import { normalizeSelect } from './utils'
-import { get } from './raw'
+import * as raw from './raw'
 import { GetEnvironmentParams } from './environment'
 import { QueryParams } from './common-types'
 
+export const get = (http: AxiosInstance, params: GetEnvironmentParams & { localeId: string }) => {
+  return raw.get<LocaleProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/locales/${params.localeId}`
+  )
+}
+
 export const getMany = (http: AxiosInstance, params: GetEnvironmentParams & QueryParams) => {
-  return get<CollectionProp<LocaleProps>>(
+  return raw.get<CollectionProp<LocaleProps>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/locales`,
     {
       params: normalizeSelect(params.query),
     }
+  )
+}
+
+export const create = (
+  http: AxiosInstance,
+  params: GetEnvironmentParams,
+  data: CreateLocaleProps,
+  headers?: Record<string, unknown>
+) => {
+  return raw.post<LocaleProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/locales`,
+    data,
+    {
+      headers,
+    }
+  )
+}
+
+export const update = (
+  http: AxiosInstance,
+  params: GetEnvironmentParams & { localeId: string },
+  rawData: LocaleProps,
+  headers?: Record<string, unknown>
+) => {
+  const data = cloneDeep(rawData)
+  delete data.sys
+  delete data.default // we should not send this back
+  return raw.put<LocaleProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/locales/${params.localeId}`,
+    data,
+    {
+      headers: {
+        ...headers,
+        'X-Contentful-Version': rawData.sys.version ?? 0,
+      },
+    }
+  )
+}
+
+export const del = (http: AxiosInstance, params: GetEnvironmentParams & { localeId: string }) => {
+  return raw.del(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/locales/${params.localeId}`
   )
 }

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -61,7 +61,11 @@ export const createPlainClient = (params: ClientParams, defaults?: DefaultParams
       createWithId: wrap(wrapParams, endpoints.asset.createWithId),
     },
     locale: {
+      get: wrap(wrapParams, endpoints.locale.get),
       getMany: wrap(wrapParams, endpoints.locale.getMany),
+      delete: wrap(wrapParams, endpoints.locale.del),
+      update: wrap(wrapParams, endpoints.locale.update),
+      create: wrap(wrapParams, endpoints.locale.create),
     },
     raw: {
       getDefaultParams: () => defaults,

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -175,6 +175,9 @@ const uploadMock = {
 
 const localeMock = {
   sys: Object.assign(cloneDeep(sysMock), {
+    environment: {
+      sys: { id: 'environment-id' },
+    },
     type: 'Locale',
   }),
   name: 'English',


### PR DESCRIPTION
Extracts all available locale endpoints to the plain client and refactors the main client to use these endpoint methods.