### PR TITLE
feat: move content type methods

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -19,21 +19,21 @@ export interface BasicMetaSysProps {
   type: string
   id: string
   version: number
-  createdBy?: { sys: MetaLinkProps }
+  createdBy?: SysLink
   createdAt: string
-  updatedBy?: { sys: MetaLinkProps }
+  updatedBy?: SysLink
   updatedAt: string
 }
 
 export interface MetaSysProps extends BasicMetaSysProps {
-  space?: { sys: MetaLinkProps }
-  status?: { sys: MetaLinkProps }
+  space?: SysLink
+  status?: SysLink
   publishedVersion?: number
   archivedVersion?: number
-  archivedBy?: { sys: MetaLinkProps }
+  archivedBy?: SysLink
   archivedAt?: string
   deletedVersion?: number
-  deletedBy?: { sys: MetaLinkProps }
+  deletedBy?: SysLink
   deletedAt?: string
 }
 
@@ -41,6 +41,10 @@ export interface MetaLinkProps {
   type: string
   linkType: string
   id: string
+}
+
+export interface SysLink {
+  sys: MetaLinkProps
 }
 
 export interface CollectionProp<TObj> {

--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -9,6 +9,7 @@ import { createCMAHttpClient, ClientParams } from './create-cma-http-client'
 
 export { createPlainClient } from './plain/plain-client'
 export { asIterator } from './plain/as-iterator'
+export { isDraft, isPublished, isUpdated } from './plain/checks'
 
 /**
  * Create a client instance

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -178,7 +178,7 @@ export default function createEnvironmentApi({
 
     /**
      * Gets a Content Type
-     * @param id - Content Type ID
+     * @param contentTypeId - Content Type ID
      * @return Promise for a Content Type
      * @example ```javascript
      * const contentful = require('contentful-management')
@@ -194,10 +194,16 @@ export default function createEnvironmentApi({
      * .catch(console.error)
      * ```
      */
-    getContentType(id: string) {
-      return http
-        .get('content_types/' + id)
-        .then((response) => wrapContentType(http, response.data), errorHandler)
+    getContentType(contentTypeId: string) {
+      const raw = this.toPlainObject() as EnvironmentProps
+
+      return endpoints.contentType
+        .get(http, {
+          spaceId: raw.sys.space.sys.id,
+          environmentId: raw.sys.id,
+          contentTypeId,
+        })
+        .then((data) => wrapContentType(http, data))
     },
 
     /**
@@ -258,13 +264,22 @@ export default function createEnvironmentApi({
      * ```
      */
     createContentType(data: CreateContentTypeProps) {
-      return http
-        .post('content_types', data)
-        .then((response) => wrapContentType(http, response.data), errorHandler)
+      const raw = this.toPlainObject() as EnvironmentProps
+
+      return endpoints.contentType
+        .create(
+          http,
+          {
+            spaceId: raw.sys.space.sys.id,
+            environmentId: raw.sys.id,
+          },
+          data
+        )
+        .then((data) => wrapContentType(http, data))
     },
     /**
      * Creates a Content Type with a custom ID
-     * @param id - Content Type ID
+     * @param contentTypeId - Content Type ID
      * @param data - Object representation of the Content Type to be created
      * @return Promise for the newly created Content Type
      * @example ```javascript
@@ -292,10 +307,28 @@ export default function createEnvironmentApi({
      * .catch(console.error)
      * ```
      */
-    createContentTypeWithId(id: string, data: CreateContentTypeProps) {
-      return http
-        .put('content_types/' + id, data)
-        .then((response) => wrapContentType(http, response.data), errorHandler)
+    createContentTypeWithId(contentTypeId: string, data: CreateContentTypeProps) {
+      const raw = this.toPlainObject() as EnvironmentProps
+      console.log(
+        'createContentTypeWithId',
+        {
+          spaceId: raw.sys.space.sys.id,
+          environmentId: raw.sys.id,
+          contentTypeId,
+        },
+        contentTypeId
+      )
+      return endpoints.contentType
+        .createWithId(
+          http,
+          {
+            spaceId: raw.sys.space.sys.id,
+            environmentId: raw.sys.id,
+            contentTypeId,
+          },
+          data
+        )
+        .then((data) => wrapContentType(http, data))
     },
 
     /**

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -309,15 +309,7 @@ export default function createEnvironmentApi({
      */
     createContentTypeWithId(contentTypeId: string, data: CreateContentTypeProps) {
       const raw = this.toPlainObject() as EnvironmentProps
-      console.log(
-        'createContentTypeWithId',
-        {
-          spaceId: raw.sys.space.sys.id,
-          environmentId: raw.sys.id,
-          contentTypeId,
-        },
-        contentTypeId
-      )
+
       return endpoints.contentType
         .createWithId(
           http,

--- a/lib/plain/checks.ts
+++ b/lib/plain/checks.ts
@@ -1,0 +1,8 @@
+import { MetaSysProps } from '../common-types'
+
+export const isPublished = (data: { sys: MetaSysProps }) => !!data.sys.publishedVersion
+
+export const isUpdated = (data: { sys: MetaSysProps }) =>
+  !!(data.sys.publishedVersion && data.sys.version > data.sys.publishedVersion + 1)
+
+export const isDraft = (data: { sys: MetaSysProps }) => !data.sys.publishedVersion

--- a/lib/plain/endpoints/content-type.ts
+++ b/lib/plain/endpoints/content-type.ts
@@ -1,17 +1,120 @@
 import { AxiosInstance } from 'axios'
 import * as raw from './raw'
-import { ContentTypeProps } from '../../entities/content-type'
+import { ContentTypeProps, CreateContentTypeProps } from '../../entities/content-type'
 import { GetEnvironmentParams } from './environment'
 import { CollectionProp, QueryParams } from './common-types'
+import { normalizeSelect } from './utils'
+import cloneDeep from 'lodash/cloneDeep'
+
+export type GetContentTypeParams = GetEnvironmentParams & { contentTypeId: string }
+
+const getBaseUrl = (params: GetEnvironmentParams) =>
+  `/spaces/${params.spaceId}/environments/${params.environmentId}/content_types`
+
+const getContentTypeUrl = (params: GetContentTypeParams) =>
+  getBaseUrl(params) + `/${params.contentTypeId}`
+
+export const get = (http: AxiosInstance, params: GetContentTypeParams & QueryParams) => {
+  return raw.get<ContentTypeProps>(http, getContentTypeUrl(params), {
+    params: normalizeSelect(params.query),
+  })
+}
 
 export type GetManyContentTypesParams = GetEnvironmentParams & QueryParams
 
 export const getMany = (http: AxiosInstance, params: GetManyContentTypesParams) => {
-  return raw.get<CollectionProp<ContentTypeProps>>(
+  return raw.get<CollectionProp<ContentTypeProps>>(http, getBaseUrl(params), {
+    params: params.query,
+  })
+}
+
+export const create = (
+  http: AxiosInstance,
+  params: GetEnvironmentParams,
+  rawData: CreateContentTypeProps
+) => {
+  const data = cloneDeep(rawData)
+
+  return raw.post<ContentTypeProps>(http, getBaseUrl(params), data)
+}
+
+export const createWithId = (
+  http: AxiosInstance,
+  params: GetContentTypeParams,
+  rawData: CreateContentTypeProps
+) => {
+  const data = cloneDeep(rawData)
+
+  return raw.put<ContentTypeProps>(http, getContentTypeUrl(params), data)
+}
+
+export const update = (
+  http: AxiosInstance,
+  params: GetContentTypeParams,
+  rawData: ContentTypeProps,
+  headers?: Record<string, unknown>
+) => {
+  const data = cloneDeep(rawData)
+  delete data.sys
+  return raw.put<ContentTypeProps>(http, getContentTypeUrl(params), data, {
+    headers: {
+      'X-Contentful-Version': rawData.sys.version ?? 0,
+      ...headers,
+    },
+  })
+}
+
+export const del = (http: AxiosInstance, params: GetContentTypeParams) => {
+  return raw.del(http, getContentTypeUrl(params))
+}
+
+export const publish = (
+  http: AxiosInstance,
+  params: GetContentTypeParams,
+  rawData: ContentTypeProps
+) => {
+  return raw.put<ContentTypeProps>(http, getContentTypeUrl(params) + '/published', null, {
+    headers: {
+      'X-Contentful-Version': rawData.sys.version ?? 0,
+    },
+  })
+}
+
+export const unpublish = (http: AxiosInstance, params: GetContentTypeParams) => {
+  return raw.del<ContentTypeProps>(http, getContentTypeUrl(params) + '/published')
+}
+
+type OmitOrDelete = 'omitted' | 'deleted'
+const findAndUpdateField = (
+  contentType: ContentTypeProps,
+  fieldId: string,
+  omitOrDelete: OmitOrDelete
+) => {
+  const field = contentType.fields.find((field) => field.id === fieldId)
+  if (!field) {
+    throw new Error(
+      `Tried to omitAndDeleteField on a nonexistent field, ${fieldId}, on the content type ${contentType.name}.`
+    )
+  }
+
+  // @ts-expect-error
+  field[omitOrDelete] = true
+
+  return contentType
+}
+
+export const omitAndDeleteField = async (
+  http: AxiosInstance,
+  params: GetContentTypeParams,
+  contentType: ContentTypeProps,
+  fieldId: string
+) => {
+  const withOmitted = await update(
     http,
-    `/spaces/${params.spaceId}/environments/${params.environmentId}/content_types`,
-    {
-      params: params.query,
-    }
+    params,
+    findAndUpdateField(contentType, fieldId, 'omitted')
   )
+  const withDeleted = update(http, params, findAndUpdateField(withOmitted, fieldId, 'deleted'))
+
+  return withDeleted
 }

--- a/lib/plain/endpoints/editor-interface.ts
+++ b/lib/plain/endpoints/editor-interface.ts
@@ -2,16 +2,16 @@ import { AxiosInstance } from 'axios'
 import * as raw from './raw'
 import { EnvironmentProps } from '../../entities/environment'
 import cloneDeep from 'lodash/cloneDeep'
-import { GetEnvironmentParams } from './environment'
 import { EditorInterfaceProps } from '../../entities/editor-interface'
+import { GetContentTypeParams } from './content-type'
 
-export type GetEditorInterfaceParams = GetEnvironmentParams & { contentTypeId: string }
+export type GetEditorInterfaceParams = GetContentTypeParams
 
-const getUrl = (params: GetEditorInterfaceParams) =>
+const getBaseUrl = (params: GetEditorInterfaceParams) =>
   `/spaces/${params.spaceId}/environments/${params.environmentId}/content_types/${params.contentTypeId}/editor_interface`
 
 export const get = (http: AxiosInstance, params: GetEditorInterfaceParams) => {
-  return raw.get<EditorInterfaceProps>(http, getUrl(params))
+  return raw.get<EditorInterfaceProps>(http, getBaseUrl(params))
 }
 
 export const update = (
@@ -23,7 +23,7 @@ export const update = (
   const data = cloneDeep(rawData)
   delete data.sys
 
-  return raw.put<EnvironmentProps>(http, getUrl(params), data, {
+  return raw.put<EnvironmentProps>(http, getBaseUrl(params), data, {
     headers: {
       'X-Contentful-Version': rawData.sys.version ?? 0,
       ...headers,

--- a/lib/plain/endpoints/entry.ts
+++ b/lib/plain/endpoints/entry.ts
@@ -6,8 +6,6 @@ import cloneDeep from 'lodash/cloneDeep'
 import { GetEnvironmentParams } from './environment'
 import { QueryParams, CollectionProp, KeyValueMap } from './common-types'
 
-export type GetManyEntriesParams = GetEnvironmentParams & QueryParams
-
 export const get = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
   params: GetEnvironmentParams & { entryId: string } & QueryParams
@@ -20,6 +18,8 @@ export const get = <T extends KeyValueMap = KeyValueMap>(
     }
   )
 }
+
+export type GetManyEntriesParams = GetEnvironmentParams & QueryParams
 
 export const getMany = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -30,7 +30,13 @@ export const createPlainClient = (params: ClientParams, defaults?: DefaultParams
       delete: wrap(wrapParams, endpoints.environment.del),
     },
     contentType: {
+      get: wrap(wrapParams, endpoints.contentType.get),
       getMany: wrap(wrapParams, endpoints.contentType.getMany),
+      update: wrap(wrapParams, endpoints.contentType.update),
+      delete: wrap(wrapParams, endpoints.contentType.del),
+      publish: wrap(wrapParams, endpoints.contentType.publish),
+      unpublish: wrap(wrapParams, endpoints.contentType.unpublish),
+      omitAndDeleteField: wrap(wrapParams, endpoints.contentType.omitAndDeleteField),
     },
     user: {
       getManyForSpace: wrap(wrapParams, endpoints.user.getManyForSpace),

--- a/test/unit/create-environment-api-test.js
+++ b/test/unit/create-environment-api-test.js
@@ -154,7 +154,7 @@ test('API call createContentTypeWithId', (t) => {
     entityType: 'contentType',
     mockToReturn: contentTypeMock,
     methodToTest: 'createContentTypeWithId',
-    entityPath: 'content_types',
+    entityPath: '/spaces/id/environments/id/content_types',
   })
 })
 

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -74,6 +74,12 @@ const appDefinitionMock = {
 const contentTypeMock = {
   sys: Object.assign(cloneDeep(sysMock), {
     type: 'ContentType',
+    space: {
+      sys: { id: 'space-id' },
+    },
+    environment: {
+      sys: { id: 'environment-id' },
+    },
   }),
   name: 'name',
   description: 'desc',


### PR DESCRIPTION
Add all existing endpoints for content types to plain client and makes current client used these endpoints.