### PR TITLE
build: only run release step when we actually release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,3 +58,10 @@ workflows:
           requires:
             - unit
             - integration
+          filters:
+            branches:
+              only:
+                - master
+                - next
+                - next-major
+                - experimental


### PR DESCRIPTION
Will reduce build time in PRs/branches.