### PR TITLE
fix: unify asset and entry types, remove non-existing 'locale' from asset.sys

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -37,6 +37,16 @@ export interface MetaSysProps extends BasicMetaSysProps {
   deletedAt?: string
 }
 
+export interface EntityMetaSysProps extends MetaSysProps {
+  space: SysLink
+  contentType: SysLink
+  environment: SysLink
+  publishedBy?: SysLink
+  publishedAt?: string
+  firstPublishedAt?: string
+  publishedCounter?: number
+}
+
 export interface MetaLinkProps {
   type: string
   linkType: string

--- a/lib/entities/asset.ts
+++ b/lib/entities/asset.ts
@@ -4,7 +4,7 @@ import { Stream } from 'stream'
 import { AxiosInstance } from 'axios'
 import enhanceWithMethods from '../enhance-with-methods'
 import errorHandler from '../error-handler'
-import { MetaSysProps, DefaultElements } from '../common-types'
+import { MetaSysProps, DefaultElements, EntityMetaSysProps } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import {
   createUpdateEntity,
@@ -20,10 +20,7 @@ import {
 } from '../instance-actions'
 
 export type AssetProps = {
-  sys: {
-    /** If present, indicates the locale which this asset uses */
-    locale: string
-  } & MetaSysProps
+  sys: EntityMetaSysProps
   fields: {
     /** Title for this asset */
     title: { [key: string]: string }

--- a/lib/entities/entry.ts
+++ b/lib/entities/entry.ts
@@ -17,25 +17,10 @@ import {
 } from '../instance-actions'
 import errorHandler from '../error-handler'
 import { wrapSnapshot, wrapSnapshotCollection, SnapshotProps, Snapshot } from './snapshot'
-import {
-  MetaLinkProps,
-  DefaultElements,
-  Collection,
-  KeyValueMap,
-  MetaSysProps,
-} from '../common-types'
+import { DefaultElements, Collection, KeyValueMap, EntityMetaSysProps } from '../common-types'
 
 export type EntryProps<T = KeyValueMap> = {
-  sys: MetaSysProps & {
-    space: { sys: MetaLinkProps }
-    contentType: { sys: MetaLinkProps }
-    environment: { sys: MetaLinkProps }
-    publishedBy?: { sys: MetaLinkProps }
-    publishedVersion?: number
-    publishedAt?: string
-    firstPublishedAt?: string
-    publishedCounter?: number
-  }
+  sys: EntityMetaSysProps
   fields: T
 }
 


### PR DESCRIPTION
Asset returned from CMA doesn't have `sys.locale`, so I removed it. This makes Entry and Asset `sys` compatible, so `EntityMetaSysProps` is extracted as a common type and use for both of them.