### PR TITLE
feat: add query to `getUiExtensions`

### DIFF
--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -8,7 +8,7 @@ import type { QueryOptions } from './common-types'
 import { EntryProp, Entry } from './entities/entry'
 import type { AssetFileProp, AssetProps } from './entities/asset'
 import type { CreateLocaleProps } from './entities/locale'
-import type { UIExtensionProps } from './entities/ui-extension'
+import type { UIExtensionProps, GetUiExtensionsQuery } from './entities/ui-extension'
 import type { AppInstallationProps } from './entities/app-installation'
 import { Stream } from 'stream'
 import { AxiosInstance } from 'axios'
@@ -791,7 +791,7 @@ export default function createEnvironmentApi({
     },
     /**
      * Gets a collection of UI Extension
-     * @param query - Object with search parameters. Check the <a href="https://www.contentful.com/developers/docs/javascript/tutorials/using-js-cda-sdk/#retrieving-entries-with-search-parameters">JS SDK tutorial</a> and the <a href="https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters">REST API reference</a> for more details.
+     * @param query - Object with search parameters.
      * @return Promise for a collection of UI Extensions
      * @example ```javascript
      * const contentful = require('contentful-management')
@@ -807,7 +807,7 @@ export default function createEnvironmentApi({
      * .catch(console.error)
      * ```
      */
-    getUiExtensions(query: QueryOptions = {}) {
+    getUiExtensions(query: GetUiExtensionsQuery = {}) {
       return http
         .get('extensions', createRequestConfig({ query: query }))
         .then((response) => wrapUiExtensionCollection(http, response.data), errorHandler)

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -791,7 +791,7 @@ export default function createEnvironmentApi({
     },
     /**
      * Gets a collection of UI Extension
-     * @param query - Object with search parameters.
+     * @param GetUiExtensionsQuery - Object with query parameters.
      * @return Promise for a collection of UI Extensions
      * @example ```javascript
      * const contentful = require('contentful-management')

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -791,6 +791,7 @@ export default function createEnvironmentApi({
     },
     /**
      * Gets a collection of UI Extension
+     * @param query - Object with search parameters. Check the <a href="https://www.contentful.com/developers/docs/javascript/tutorials/using-js-cda-sdk/#retrieving-entries-with-search-parameters">JS SDK tutorial</a> and the <a href="https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters">REST API reference</a> for more details.
      * @return Promise for a collection of UI Extensions
      * @example ```javascript
      * const contentful = require('contentful-management')
@@ -806,9 +807,9 @@ export default function createEnvironmentApi({
      * .catch(console.error)
      * ```
      */
-    getUiExtensions() {
+    getUiExtensions(query: QueryOptions = {}) {
       return http
-        .get('extensions')
+        .get('extensions', createRequestConfig({ query: query }))
         .then((response) => wrapUiExtensionCollection(http, response.data), errorHandler)
     },
     /**

--- a/lib/entities/ui-extension.ts
+++ b/lib/entities/ui-extension.ts
@@ -5,14 +5,19 @@ import enhanceWithMethods from '../enhance-with-methods'
 import { createUpdateEntity, createDeleteEntity } from '../instance-actions'
 import { EntryFields } from './entry-fields'
 import { wrapCollection } from '../common-utils'
-import { DefaultElements, MetaSysProps, QueryOptions } from '../common-types'
+import { DefaultElements, MetaSysProps } from '../common-types'
 
-export interface GetUiExtensionsQuery extends QueryOptions {
+export interface GetUiExtensionsQuery {
   /**
    * Whether to exclude srcdoc from the response. This can significantly reduce
    * the response size.
    */
   skipSrcdoc?: boolean
+  /**
+   * A comma seperated list of extension IDs. Only extensions with IDs that are
+   * in the list will be fetched.
+   */
+  'sys.id[in]'?: string
 }
 
 export type UIExtensionProps = {

--- a/lib/entities/ui-extension.ts
+++ b/lib/entities/ui-extension.ts
@@ -5,7 +5,15 @@ import enhanceWithMethods from '../enhance-with-methods'
 import { createUpdateEntity, createDeleteEntity } from '../instance-actions'
 import { EntryFields } from './entry-fields'
 import { wrapCollection } from '../common-utils'
-import { DefaultElements, MetaSysProps } from '../common-types'
+import { DefaultElements, MetaSysProps, QueryOptions } from '../common-types'
+
+export interface GetUiExtensionsQuery extends QueryOptions {
+  /**
+   * Whether to exclude srcdoc from the response. This can significantly reduce
+   * the response size.
+   */
+  skipSrcdoc?: boolean
+}
 
 export type UIExtensionProps = {
   sys: MetaSysProps

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -285,7 +285,7 @@ test('Create space for tests which create, change and delete data', (t) => {
           webhookTests(t, space),
           roleTests(t, space),
           apiKeyTests(t, space),
-          uiExtensionTests(t, space),
+          uiExtensionTests(t, space, waitForEnvironmentToBeReady),
           environmentTests(t, space, waitForEnvironmentToBeReady),
         ])
       })

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -19,7 +19,7 @@ import roleTests from './role-integration'
 import spaceUserTests from './space-user-integration'
 import userTests from './user-integration'
 import apiKeyTests from './api-key-integration'
-import uiExtensionTests from './ui-extension-integration'
+import uiExtensionTests, { uiExtensionTestsForEnvironmentOnly } from './ui-extension-integration'
 import generateRandomId from './generate-random-id'
 import { createClient } from '../../'
 import { environmentTests } from './environment-integration'
@@ -285,7 +285,7 @@ test('Create space for tests which create, change and delete data', (t) => {
           webhookTests(t, space),
           roleTests(t, space),
           apiKeyTests(t, space),
-          uiExtensionTests(t, space, waitForEnvironmentToBeReady),
+          uiExtensionTests(t, space),
           environmentTests(t, space, waitForEnvironmentToBeReady),
         ])
       })
@@ -346,6 +346,7 @@ test('Create space with an environment for tests which create, change and delete
         entryWriteTests(t, environment)
         assetWriteTests(t, environment)
         uiExtensionTests(t, environment)
+        uiExtensionTestsForEnvironmentOnly(t, environment)
         // test.onFinish(() => environment.delete())
         test.onFinish(() => space.delete())
       })

--- a/test/integration/ui-extension-integration.js
+++ b/test/integration/ui-extension-integration.js
@@ -1,4 +1,4 @@
-export default function uiExtensionTests(t, space) {
+export default function uiExtensionTests(t, space, waitForEnvironmentToBeReady) {
   t.test('Create, update, get, get all and delete UI Extension', (t) => {
     return space
       .createUiExtension({
@@ -69,5 +69,38 @@ export default function uiExtensionTests(t, space) {
         t.equals(uiExtension.extension.name, 'Awesome extension!', 'name')
         t.equals(uiExtension.extension.src, 'https://awesome.extension', 'src')
       })
+  })
+
+  t.test('Filter UI extensions by ID', async (t) => {
+    const environment = await space.createEnvironmentWithId('newEnv', { name: 'newEnv' })
+
+    await waitForEnvironmentToBeReady(space, environment)
+
+    const idOne = 'idOne'
+    const idTwo = 'idTwo'
+
+    const extensionOne = await environment.createUiExtensionWithId(idOne, {
+      extension: {
+        name: 'Awesome extension!',
+        src: 'https://awesome.extension',
+        fieldTypes: [{ type: 'Symbol' }],
+      },
+    })
+
+    const extensionTwo = await environment.createUiExtensionWithId(idTwo, {
+      extension: {
+        name: 'Another awesome extension!',
+        src: 'https://anotherawesome.extension',
+        fieldTypes: [{ type: 'Text' }],
+      },
+    })
+
+    const extensions = await environment.getUiExtensions({ 'sys.id[in]': idTwo })
+
+    t.equals(extensions.items.length, 1)
+    t.equals(extensions.items.name, 'Another awesome extension!', 'name')
+
+    await extensionOne.delete()
+    await extensionTwo.delete()
   })
 }

--- a/test/integration/ui-extension-integration.js
+++ b/test/integration/ui-extension-integration.js
@@ -72,6 +72,14 @@ export default function uiExtensionTests(t, spaceOrEnvironment) {
   })
 }
 
+function deleteExtensions(extensions) {
+  return new Promise((resolve, reject) =>
+    setTimeout(() => {
+      Promise.all(extensions.map((e) => e.delete())).then(resolve, reject)
+    }, 2000)
+  )
+}
+
 export function uiExtensionTestsForEnvironmentOnly(t, environment) {
   t.test('GetUiExtensions can filter UI extensions by ID', async (t) => {
     const idOne = 'idOne'
@@ -98,14 +106,13 @@ export function uiExtensionTestsForEnvironmentOnly(t, environment) {
     t.equals(extensions.items.length, 1)
     t.equals(extensions.items[0].extension.name, 'Another awesome extension!', 'name')
 
-    await extensionOne.delete()
-    await extensionTwo.delete()
+    return deleteExtensions([extensionOne, extensionTwo])
   })
 
   t.test('GetUiExtensions can strip srcdoc with query parameter', async (t) => {
     const extension = await environment.createUiExtension({
       extension: {
-        name: 'Awesome extension!',
+        name: 'fun extension!',
         srcdoc: '<html>source doc source doc source doc</html>',
         fieldTypes: [{ type: 'Symbol' }],
       },
@@ -115,7 +122,7 @@ export function uiExtensionTestsForEnvironmentOnly(t, environment) {
 
     console.log(extensions)
     t.equals(extensions.items.length, 1)
-    t.equals(extensions.items[0].extension.name, 'Awesome extension!', 'name')
+    t.equals(extensions.items[0].extension.name, 'fun extension!', 'name')
     t.equals(extensions.items[0].extension.srcdoc, undefined, 'srcdoc')
 
     await extension.delete()

--- a/test/integration/ui-extension-integration.js
+++ b/test/integration/ui-extension-integration.js
@@ -114,7 +114,8 @@ export function uiExtensionTestsForEnvironmentOnly(t, environment) {
     const extensions = await environment.getUiExtensions({ skipSrcdoc: true })
 
     t.equals(extensions.items.length, 1)
-    t.equals(extensions.items[0].name, 'Another awesome extension!', 'name')
+    t.equals(extensions.items[0].extensions.name, 'Awesome extension!', 'name')
+    t.equals(extensions.items[0].extensions.srcdoc, undefined, 'srcdoc')
 
     await extension.delete()
   })

--- a/test/integration/ui-extension-integration.js
+++ b/test/integration/ui-extension-integration.js
@@ -113,9 +113,10 @@ export function uiExtensionTestsForEnvironmentOnly(t, environment) {
 
     const extensions = await environment.getUiExtensions({ skipSrcdoc: true })
 
+    console.log(extensions)
     t.equals(extensions.items.length, 1)
-    t.equals(extensions.items[0].extensions.name, 'Awesome extension!', 'name')
-    t.equals(extensions.items[0].extensions.srcdoc, undefined, 'srcdoc')
+    t.equals(extensions.items[0].extension.name, 'Awesome extension!', 'name')
+    t.equals(extensions.items[0].extension.srcdoc, undefined, 'srcdoc')
 
     await extension.delete()
   })


### PR DESCRIPTION
We want it possible to pass query parameters to the getExtensions method.
I've tested this with the properties we care about: `stripSrcdoc` and `sys.id[in]`. Both of these work.

I wonder if I should create a new more specific type that just lists these properties? Or whether the existing `QueryOptions` type is the appropriate one to use. 

I also wonder whether I should be adding a new integration test to cover these cases?
