### PR TITLE
feat(getTags): send query params object

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -43,12 +43,15 @@ export interface Collection<T, TPlain>
     DefaultElements<CollectionProp<TPlain>> {}
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export interface QueryOptions {
+export interface QueryOptions extends BasicQueryOptions {
+  content_type?: string
+  include?: number
+}
+
+export interface BasicQueryOptions {
   skip?: number
   limit?: number
   order?: string
-  content_type?: string
-  include?: number
 
   [key: string]: any
 }

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -1023,9 +1023,9 @@ export default function createEnvironmentApi({
         })
         .then((response) => wrapTag(http, response.data), errorHandler)
     },
-    getTags(skip?: number, limit?: number) {
+    getTags(query: QueryOptions = {}) {
       return http
-        .get('tags', { params: { skip, limit } })
+        .get('tags', createRequestConfig({ query }))
         .then((response) => wrapTagCollection(http, response.data), errorHandler)
     },
     getTag(id: string) {

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -2,7 +2,7 @@ import { AxiosInstance } from 'axios'
 import { createRequestConfig } from 'contentful-sdk-core'
 import cloneDeep from 'lodash/cloneDeep'
 import { Stream } from 'stream'
-import { QueryOptions } from './common-types'
+import { BasicQueryOptions, QueryOptions } from './common-types'
 import entities from './entities'
 import { AppInstallationProps } from './entities/app-installation'
 import { AssetFileProp, AssetProps } from './entities/asset'
@@ -1023,7 +1023,7 @@ export default function createEnvironmentApi({
         })
         .then((response) => wrapTag(http, response.data), errorHandler)
     },
-    getTags(query: QueryOptions = {}) {
+    getTags(query: BasicQueryOptions = {}) {
       return http
         .get('tags', createRequestConfig({ query }))
         .then((response) => wrapTagCollection(http, response.data), errorHandler)

--- a/test/integration/tag-integration.js
+++ b/test/integration/tag-integration.js
@@ -30,7 +30,7 @@ async function createReadTagTest(t, space) {
 }
 
 async function createReadTagsTest(t, space) {
-  t.plan(1)
+  t.plan(2)
   const tagId = randomTagId()
   const tagName = 'Tag ' + tagId
   const environment = await space.getEnvironment('master')
@@ -41,6 +41,8 @@ async function createReadTagsTest(t, space) {
 
   const result = await environment.getTags()
   t.equals(result.total >= 10, true, 'should return a minimum of created tags')
+  const filteredResult = await environment.getTags({ limit: 2 })
+  t.equals(filteredResult.items.length, 2, 'limit param should work')
 }
 
 async function writeEntityTagsTest(t, entity, environment) {


### PR DESCRIPTION
We should send a query params object in getTags (for consistency with our other get-collection endpoints in the SDK).