### PR TITLE
fix: optional asset description

### DIFF
--- a/lib/entities/asset.ts
+++ b/lib/entities/asset.ts
@@ -28,7 +28,7 @@ export type AssetProps = {
     /** Title for this asset */
     title: { [key: string]: string }
     /** Description for this asset */
-    description: { [key: string]: string }
+    description?: { [key: string]: string }
     /** File object for this asset */
     file: {
       [key: string]: {


### PR DESCRIPTION
Creating assets is possible without providing a description.

E.g. the asset call here also doesn't have one https://www.contentful.com/developers/docs/references/content-management-api/#/reference/assets/asset