### PR TITLE
fix: typings for roles in space memberships

### DIFF
--- a/lib/entities/space-member.ts
+++ b/lib/entities/space-member.ts
@@ -13,7 +13,7 @@ export type SpaceMemberProps = {
   /**
    * Array of Role Links
    */
-  roles: MetaLinkProps[]
+  roles: { sys: MetaLinkProps }[]
 }
 
 export interface SpaceMember extends SpaceMemberProps, DefaultElements<SpaceMemberProps> {}

--- a/lib/entities/space-membership.ts
+++ b/lib/entities/space-membership.ts
@@ -13,7 +13,7 @@ export type SpaceMembershipProps = {
    * User is an admin
    */
   admin: boolean
-  roles: MetaLinkProps[]
+  roles: { sys: MetaLinkProps }[]
 }
 
 export interface SpaceMembership

--- a/lib/entities/team-space-membership.ts
+++ b/lib/entities/team-space-membership.ts
@@ -26,7 +26,7 @@ export type TeamSpaceMembershipProps = {
   /**
    * Roles
    */
-  roles: MetaLinkProps[]
+  roles: { sys: MetaLinkProps }[]
 }
 
 export interface TeamSpaceMembership


### PR DESCRIPTION
Fixing the typings for the roles in createTeamSpaceMemberships to address this https://github.com/contentful/contentful-management.js/issues/388. 