### PR TITLE
fix: add missing settings to editorInteface type definition

### DIFF
--- a/lib/entities/editor-interface.ts
+++ b/lib/entities/editor-interface.ts
@@ -15,6 +15,7 @@ export interface Control {
    */
   widgetId: string
   widgetNamespace: string
+  settings?: Record<string, any>
 }
 
 export type EditorInterfaceProps = {


### PR DESCRIPTION
Closes https://github.com/contentful/contentful-management.js/issues/401 and https://github.com/contentful/contentful-management.js/issues/399
