### PR TITLE
fix: typo in scheduled actions, rename query -> getMany

### DIFF
--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -965,7 +965,7 @@ export default function createSpaceApi({ http }: { http: AxiosInstance }) {
     getScheduledActions(query: ScheduledActionQueryOptions) {
       const raw = this.toPlainObject() as SpaceProps
       return endpoints.scheduledAction
-        .query(http, { spaceId: raw.sys.id, query })
+        .getMany(http, { spaceId: raw.sys.id, query })
         .then((response) => wrapScheduledActionCollection(http, response))
     },
     /**

--- a/lib/plain/endpoints/scheduled-action.ts
+++ b/lib/plain/endpoints/scheduled-action.ts
@@ -5,7 +5,7 @@ import { ScheduledActionProps, ScheduledAction } from '../../entities/scheduled-
 import { QueryParams, GetSpaceParams } from './common-types'
 import { CollectionProp } from '../../common-types'
 
-export const query = (http: AxiosInstance, params: GetSpaceParams & QueryParams) => {
+export const getMany = (http: AxiosInstance, params: GetSpaceParams & QueryParams) => {
   return raw.get<CollectionProp<ScheduledAction>>(
     http,
     `/spaces/${params.spaceId}/scheduled_actions`,

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -99,8 +99,8 @@ export const createPlainClient = (params: ClientParams, defaults?: DefaultParams
       update: wrap(wrapParams, endpoints.role.update),
       delete: wrap(wrapParams, endpoints.role.del),
     },
-    scheduledActons: {
-      query: wrap(wrapParams, endpoints.scheduledAction.query),
+    scheduledActions: {
+      getMany: wrap(wrapParams, endpoints.scheduledAction.getMany),
       create: wrap(wrapParams, endpoints.scheduledAction.create),
       delete: wrap(wrapParams, endpoints.scheduledAction.del),
     },


### PR DESCRIPTION
Changes in the PR:

- Fixing typo `scheduledActons`  -> `scheduledActions`
- Rename method `query` -> `getMany` for better consistancy