### PR TITLE
feat: custom environment aliases

### DIFF
--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -22,6 +22,7 @@ import { QueryOptions } from './common-types'
 import { UIExtensionProps } from './entities/ui-extension'
 import { CreateApiKeyProps } from './entities/api-key'
 import { ScheduledActionQueryOptions, ScheduledActionProps } from './entities/scheduled-action'
+import { EnvironmentAliasProps } from './entities/environment-alias'
 
 function raiseDeprecationWarning(method: string) {
   console.warn(
@@ -1708,6 +1709,33 @@ export default function createSpaceApi({
       return http
         .get(`content_types/${contentTypeId}/snapshots`, createRequestConfig({ query: query }))
         .then((response) => wrapSnapshotCollection(http, response.data), errorHandler)
+    },
+    /**
+     * Creates an EnvironmentAlias with a custom ID
+     * @param id - EnvironmentAlias ID
+     * @param data - Object representation of the EnvironmentAlias to be created
+     * @return Promise for the newly created EnvironmentAlias
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getSpace('<space_id>')
+     * .then((space) => space.createEnvironmentAliasWithId('<environment-alias-id>', {
+     *   environment: {
+     *     sys: { type: 'Link', linkType: 'Environment', id: 'targetEnvironment' }
+     *   }
+     * }))
+     * .then((environmentAlias) => console.log(environmentAlias))
+     * .catch(console.error)
+     * ```
+     */
+    createEnvironmentAliasWithId(id: string, data: Omit<EnvironmentAliasProps, 'sys'>) {
+      return http
+        .put('environment_aliases/' + id, data)
+        .then((response) => wrapEnvironmentAlias(http, response.data), errorHandler)
     },
     /**
      * Gets an Environment Alias

--- a/lib/entities/environment-alias.ts
+++ b/lib/entities/environment-alias.ts
@@ -1,7 +1,7 @@
 import cloneDeep from 'lodash/cloneDeep'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
-import { createUpdateEntity } from '../instance-actions'
+import { createUpdateEntity, createDeleteEntity } from '../instance-actions'
 import { wrapCollection } from '../common-utils'
 import { DefaultElements, MetaLinkProps, MetaSysProps } from '../common-types'
 import { AxiosInstance } from 'axios'
@@ -40,6 +40,29 @@ export interface EnvironmentAlias
    * ```
    */
   update(): Promise<EnvironmentAlias>
+
+  /**
+   * Deletes this object on the server.
+   * @memberof EnvironmentAlias
+   * @func delete
+   * @return {Promise<void>} Promise for the deletion. It contains no data, but the Promise error case should be handled.
+   * ```javascript
+   * const contentful = require('contentful-management')
+   *
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
+   *
+   * client.getSpace('<space_id>')
+   * .then((space) => space.getEnvironmentAlias('<environment_alias_id>'))
+   * .then((alias) => {
+   *   return alias.delete()
+   * })
+   * .then(() => console.log(`Alias deleted.`))
+   * .catch(console.error)
+   * ```
+   */
+  delete(): Promise<void>
 }
 
 function createEnvironmentAliasApi(http: AxiosInstance) {
@@ -48,6 +71,10 @@ function createEnvironmentAliasApi(http: AxiosInstance) {
       http: http,
       entityPath: 'environment_aliases',
       wrapperMethod: wrapEnvironmentAlias,
+    }),
+    delete: createDeleteEntity({
+      http: http,
+      entityPath: 'environment_aliases',
     }),
   }
 }

--- a/test/integration/environment-alias-integration.js
+++ b/test/integration/environment-alias-integration.js
@@ -1,4 +1,4 @@
-export function environmentAliasReadOnlyTests(t, space) {
+export function environmentAliasTests(t, space) {
   t.test('Gets aliases', (t) => {
     t.plan(2)
     return space.getEnvironmentAliases().then((response) => {
@@ -7,7 +7,7 @@ export function environmentAliasReadOnlyTests(t, space) {
     })
   })
 
-  t.test('Updates alias', (t) => {
+  t.test('Updates master alias', (t) => {
     t.plan(4)
     return space
       .getEnvironmentAlias('master')
@@ -20,6 +20,41 @@ export function environmentAliasReadOnlyTests(t, space) {
       .then((updatedAlias) => {
         t.equals(updatedAlias.sys.id, 'master')
         t.equals(updatedAlias.environment.sys.id, 'feature-13')
+      })
+  })
+
+  t.test('Creates custom alias', (t) => {
+    t.plan(2)
+    return space
+      .createEnvironmentAliasWithId('new-alias', {
+        environment: {
+          sys: {
+            type: 'Link',
+            linkType: 'Environment',
+            id: 'previously-master',
+          },
+        },
+      })
+      .then((alias) => {
+        t.equals(alias.sys.id, 'new-alias')
+        t.equals(alias.environment.sys.id, 'previously-master')
+      })
+  })
+
+  t.test('Deletes custom alias', (t) => {
+    t.plan(3)
+    return space
+      .getEnvironmentAlias('new-alias')
+      .then((alias) => {
+        t.equals(alias.sys.id, 'new-alias')
+        t.equals(alias.environment.sys.id, 'previously-master')
+        return alias.delete()
+      })
+      .then(() => {
+        return space.getEnvironmentAlias('new-alias')
+      })
+      .catch((err) => {
+        t.equals(err.name, 'NotFound')
       })
   })
 }

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -23,7 +23,7 @@ import uiExtensionTests from './ui-extension-integration'
 import generateRandomId from './generate-random-id'
 import { createClient } from '../../'
 import { environmentTests } from './environment-integration'
-import { environmentAliasReadOnlyTests } from './environment-alias-integration'
+import { environmentAliasTests } from './environment-alias-integration'
 import { tagTests } from './tag-integration'
 
 const params = {
@@ -202,7 +202,7 @@ test('Gets v2 space for read only tests', (t) => {
   })
 })
 
-test('Gets v2 space for read only tests', (t) => {
+test('Gets v2 space for alias tests', (t) => {
   return v2Client.getSpace('w6xueg32zr68').then((space) => {
     test.onFinish(() => {
       // clean up and re-point alias to starting env
@@ -210,8 +210,17 @@ test('Gets v2 space for read only tests', (t) => {
         alias.environment.sys.id = 'previously-master'
         return alias.update()
       })
+
+      // In case something went wrong with deleting the new alias
+      // try to fetch and delete it again to clean up
+      space
+        .getEnvironmentAlias('new-alias')
+        .then((alias) => {
+          return alias.delete()
+        })
+        .catch(() => undefined)
     })
-    environmentAliasReadOnlyTests(t, space) // v2 space with alias feature enabled and opted-in
+    environmentAliasTests(t, space) // v2 space with alias feature enabled and opted-in
   })
 })
 


### PR DESCRIPTION
Adds methods for managing custom environment aliases.
This method is currently only available to a limited amount of customers.
Restrictions and constraints are only enforced on the API side and no additional logic is added to the SDK.
