### PR TITLE
fix(tests): content-tags

### DIFF
--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -375,8 +375,7 @@ test('Logs request and response with custom loggers', (t) => {
   })
 })
 
-test.only('gets V2 space for tag tests', (t) => {
-  console.debug('1')
+test('gets V2 space for tag tests', (t) => {
   v2Client.getSpace('w6xueg32zr68').then((space) => {
     tagTests(t, space)
     test.onFinish(() => deleteAllTags(space, 'master'))
@@ -384,9 +383,6 @@ test.only('gets V2 space for tag tests', (t) => {
 })
 
 async function deleteAllTags(space, environmentName) {
-  console.debug('6')
-
-  console.log('delete all test tags')
   const environment = await space.getEnvironment(environmentName)
   const tags = await environment.getTags(0, 1000)
   for (let index = 0; index < tags.total; index++) {

--- a/test/integration/tag-integration.js
+++ b/test/integration/tag-integration.js
@@ -1,7 +1,6 @@
 async function createRandomTag(environment) {
   const tagId = randomTagId()
   const tagName = 'Tag ' + tagId
-  console.log(`create random tag ${tagName}:${tagId}`)
   return environment.createTag(tagId, tagName)
 }
 
@@ -24,15 +23,16 @@ async function createUpdateTagTest(t, space) {
   const tagName = 'Tag ' + tagId
   const environment = await space.getEnvironment('master')
   const tag = await environment.createTag(tagId, tagName)
-  tag.name = 'new tag name'
+  const newTagId = 'createUpdateTagTest-' + randomTagId()
+  tag.name = newTagId
   const result = await tag.update()
-  t.equals(result.name, 'new tag name', 'tag name should be updated')
+  t.equals(result.name, newTagId, 'tag name should be updated')
   t.equals(result.sys.id, tagId, 'tag id should be equal')
 }
 async function createReadTagTest(t, space) {
   t.plan(2)
   const tagId = randomTagId()
-  const tagName = 'Tag ' + tagId
+  const tagName = 'createReadTagTest-' + tagId
   const environment = await space.getEnvironment('master')
   await environment.createTag(tagId, tagName)
   const result = await environment.getTag(tagId)
@@ -43,7 +43,7 @@ async function createReadTagTest(t, space) {
 async function createReadTagsTest(t, space) {
   t.plan(2)
   const tagId = randomTagId()
-  const tagName = 'Tag ' + tagId
+  const tagName = 'createReadTagsTest-' + tagId
   const environment = await space.getEnvironment('master')
 
   for (let index = 0; index < 10; index++) {
@@ -67,11 +67,9 @@ async function writeEntityTagsTest(t, entity, environment) {
     },
   }
   entity.metadata.tags.push(tagLink)
-  console.log(`entity update`)
   const updatedEntity = await entity.update()
   t.deepEqual(updatedEntity.metadata.tags[0], tagLink, 'tag created on entity')
   updatedEntity.metadata.tags = []
-  console.log(`entity update`)
   const noTagsEntity = await updatedEntity.update()
   t.deepEqual(noTagsEntity.metadata.tags, [], 'tag removed from entity')
 }


### PR DESCRIPTION
We accidentally only ran tests for tags. 
This PR removes the only, and ensures unique names for all tags created during tests to avoid name collision.