### PR TITLE
fix(AppInstallation): use app definition id for deleting an app installation

### DIFF
--- a/lib/entities/app-installation.ts
+++ b/lib/entities/app-installation.ts
@@ -75,10 +75,12 @@ function createAppInstallationApi(http: AxiosInstance) {
         .then((response) => wrapAppInstallation(http, response.data), errorHandler)
     },
 
-    delete: createDeleteEntity({
-      http: http,
-      entityPath: 'app_installations',
-    }),
+    delete: function () {
+      const raw = this.toPlainObject() as AppInstallation
+      return http.delete(`app_installations/${raw.sys.appDefinition.sys.id}`).then(() => {
+        // do nothing
+      }, errorHandler)
+    },
   }
 }
 


### PR DESCRIPTION
## Purpose

fixes issue https://github.com/contentful/contentful-management.js/issues/440. We can not use the `createDeleteEntity` helper since an `AppInstallation` does not have its own id and uses the id of an `AppDefinition`.