### PR TITLE
fix: change entity metadata tags to links

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -39,7 +39,7 @@ export interface MetaLinkProps {
 }
 
 export interface MetadataProps {
-  tags: TagProps[]
+  tags: Link<'Tag'>
 }
 
 export interface CollectionProp<TObj> {


### PR DESCRIPTION
Fixes the Entity `tags` property type, it's a list of links.