### PR TITLE
Add support for query params for getRoles method

### DIFF
--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -995,9 +995,10 @@ export default function createSpaceApi({
      * .catch(console.error)
      * ```
      */
-    getRoles() {
+    getRoles(query: QueryOptions = {}) {
+      normalizeSelect(query)
       return http
-        .get('roles')
+        .get('roles', createRequestConfig({ query }))
         .then((response) => wrapRoleCollection(http, response.data), errorHandler)
     },
 

--- a/test/integration/role-integration.js
+++ b/test/integration/role-integration.js
@@ -20,11 +20,36 @@ const roleDefinition = {
 
 export default function roleTests(t, space) {
   t.test('Gets roles', (t) => {
-    t.plan(2)
+    t.plan(3)
     return space.getRoles().then((response) => {
       t.ok(response.sys, 'sys')
       t.ok(response.items, 'fields')
+      t.equal(response.items.length, 4)
     })
+  })
+
+  t.test('Gets roles with a limit parameter', (t) => {
+    t.plan(2)
+    return space
+      .getRoles({
+        limit: 2,
+      })
+      .then((response) => {
+        t.ok(response.items, 'items')
+        t.equal(response.items.length, 2)
+      })
+  })
+
+  t.test('Gets roles with skip parameter', (t) => {
+    t.plan(2)
+    return space
+      .getRoles({
+        skip: 2,
+      })
+      .then((response) => {
+        t.ok(response.items, 'items')
+        t.equal(response.skip, 2)
+      })
   })
 
   t.test('Create role with id', (t) => {


### PR DESCRIPTION
There is currently no support in the sdk that allows to provide query params to `getRoles`. This pr adds it.