### PR TITLE
fix(test): on cleanup explicitly target environment instead of alias

### DIFF
--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -387,12 +387,13 @@ test('Logs request and response with custom loggers', (t) => {
 test('gets V2 space for tag tests', (t) => {
   v2Client.getSpace('w6xueg32zr68').then((space) => {
     tagTests(t, space)
-    test.onFinish(() => deleteAllTags(space, 'master'))
+    test.onFinish(() => deleteAllTags(space))
   })
 })
 
-async function deleteAllTags(space, environmentName) {
-  const environment = await space.getEnvironment(environmentName)
+async function deleteAllTags(space) {
+  const environmentAsAlias = await space.getEnvironment('master')
+  const environment = await space.getEnvironment(environmentAsAlias.sys.aliasedEnvironment.sys.id)
   const tags = await environment.getTags(0, 1000)
   for (let index = 0; index < tags.total; index++) {
     await tags.items[index]['delete']()


### PR DESCRIPTION
On cleanup explicitly target environment instead of alias.

To unblock https://github.com/contentful/contentful-management.js/pull/530
