### PR TITLE
refactor: remove all url wrappers

### DIFF
--- a/lib/entities/environment.ts
+++ b/lib/entities/environment.ts
@@ -50,15 +50,11 @@ export function wrapEnvironment(http: AxiosInstance, data: EnvironmentProps): En
   const sdkHttp = http as SdkHttpClient
   const environment = toPlainObject(cloneDeep(data))
   const { hostUpload, defaultHostnameUpload } = sdkHttp.httpClientParams
-  const environmentScopedHttpClient = sdkHttp.cloneWithNewParams({
-    baseURL: http.defaults.baseURL + 'environments/' + environment.sys.id,
-  })
   const environmentScopedUploadClient = sdkHttp.cloneWithNewParams({
-    space: environment.sys.space.sys.id,
     host: hostUpload || defaultHostnameUpload,
   })
   const environmentApi = createEnvironmentApi({
-    http: environmentScopedHttpClient,
+    http,
     httpUpload: environmentScopedUploadClient,
   })
   const enhancedEnvironment = enhanceWithMethods(environment, environmentApi)

--- a/lib/entities/organization.ts
+++ b/lib/entities/organization.ts
@@ -33,13 +33,8 @@ export type OrganizationProp = {
  */
 export function wrapOrganization(http: AxiosInstance, data: OrganizationProp): Organization {
   const org = toPlainObject(cloneDeep(data))
-  const baseURL =
-    (http.defaults.baseURL || '').replace('/spaces/', '/organizations/') + org.sys.id + '/'
-
-  // @ts-expect-error
-  const orgScopedHttpClient = http.cloneWithNewParams({ baseURL })
   const orgApi = createOrganizationApi({
-    http: orgScopedHttpClient,
+    http: http,
   })
   const enhancedOrganization = enhanceWithMethods(org, orgApi)
   return freezeSys(enhancedOrganization)

--- a/lib/entities/space.ts
+++ b/lib/entities/space.ts
@@ -29,14 +29,9 @@ export type Space = SpaceProps & DefaultElements<SpaceProps> & ContentfulSpaceAP
  * @return {Space}
  */
 export function wrapSpace(http: AxiosInstance, data: SpaceProps): Space {
-  const sdkHttp = (http as unknown) as SdkHttpClient
-
   const space = toPlainObject(cloneDeep(data))
-  const spaceScopedHttpClient = sdkHttp.cloneWithNewParams({
-    space: space.sys.id,
-  })
   const spaceApi = createSpaceApi({
-    http: spaceScopedHttpClient,
+    http,
   })
   const enhancedSpace = enhanceWithMethods(space, spaceApi)
   return freezeSys(enhancedSpace)

--- a/test/unit/entities/environment-test.js
+++ b/test/unit/entities/environment-test.js
@@ -27,16 +27,6 @@ test('Environment is wrapped', (t) => {
   setup()
   const wrappedEnvironment = wrapEnvironment(httpMock, environmentMock)
   t.looseEqual(wrappedEnvironment.toPlainObject(), environmentMock)
-  t.equal(
-    httpMock.cloneWithNewParams.args[0][0].baseURL,
-    'http://foo.bar/environments/id',
-    'adjust the baseURL to match environments'
-  )
-  t.equal(
-    httpMock.cloneWithNewParams.args[1][0].space,
-    'id',
-    'adjust the baseURL to match environments'
-  )
   teardown()
   t.end()
 })

--- a/test/unit/entities/organization-test.js
+++ b/test/unit/entities/organization-test.js
@@ -27,11 +27,6 @@ test('Organization is wrapped', (t) => {
   setup()
   const wrappedOrg = wrapOrganization(httpMock, organizationMock)
   t.looseEqual(wrappedOrg.toPlainObject(), organizationMock)
-  t.equal(
-    httpMock.cloneWithNewParams.args[0][0].baseURL,
-    'http://foo.bar/organizations/id/',
-    'adjust the baseURL to match organizations'
-  )
   teardown()
   t.end()
 })


### PR DESCRIPTION
We don't need to reinitialize http clients anymore since all endpoints use full endpoint paths instead of relative paths.