### PR TITLE
feat: additional raw endpoint for easy access to all HTTP verbs

### DIFF
--- a/lib/plain/endpoints/raw.ts
+++ b/lib/plain/endpoints/raw.ts
@@ -52,3 +52,10 @@ export function del<T = any>(http: AxiosInstance, url: string, config?: AxiosReq
     })
     .then((response) => response.data, errorHandler)
 }
+
+export function http<T = any>(http: AxiosInstance, url: string, config?: AxiosRequestConfig) {
+  return http(url, {
+    baseURL: getBaseUrl(http),
+    ...config,
+  }).then((response) => response.data, errorHandler)
+}

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -26,6 +26,8 @@ export const createPlainClient = (params: ClientParams, defaults?: DefaultParams
       put: (...args: RestParamsType<typeof endpoints.raw.put>) => endpoints.raw.put(http, ...args),
       delete: (...args: RestParamsType<typeof endpoints.raw.del>) =>
         endpoints.raw.del(http, ...args),
+      http: (...args: RestParamsType<typeof endpoints.raw.http>) =>
+        endpoints.raw.http(http, ...args),
     },
     editorInterface: {
       get: wrap(wrapParams, endpoints.editorInterface.get),


### PR DESCRIPTION
`contentful-migration` exposes a way to access to all HTTP verbs easily to make the shift easier this is reflected in the plain endpoint.