### PR TITLE
chore: ensure teardown of all test spaces

### DIFF
--- a/mocharc.js
+++ b/mocharc.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   require: ['@babel/register'],
+  file: ['./test/mocha-global.js'],
   diff: true,
   recursive: true,
   extension: ['js', 'ts'],

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "test:browser": "BABEL_ENV=test karma start karma.conf.local.js --log-level info",
     "test:size": "bundlesize",
     "test:prepush": "npm run build && npm run test:unit && npm run test:size",
-    "test:cleanup": "BABEL_ENV=test babel-node --extensions .ts --extensions .js test/cleanupSpaces.js",
     "prettier": "prettier --write '**/*.{jsx,js,ts,tsx}'",
     "prettier:check": "prettier --check '**/*.{jsx,js,ts,tsx}'",
     "presemantic-release": "npm run build",

--- a/test/cleanup-spaces.js
+++ b/test/cleanup-spaces.js
@@ -3,13 +3,13 @@ const client = require('./helpers').client
 function filterDeletableSpaces(spaces, threshold) {
   return spaces.filter((space) => {
     return (
-      space.name.startsWith('CMA JS SDK') &&
+      space.name.startsWith('CMA JS SDK [AUTO]') &&
       Date.parse(space.sys.updatedAt) + threshold < Date.now()
     )
   })
 }
 
-async function cleanupSpaces(threshold = 1000 * 60 * 60, dryRun = false) {
+export async function cleanupSpaces(threshold = 1000 * 60 * 60, dryRun = false) {
   const api = client()
   const spaces = await api
     .getSpaces()
@@ -31,5 +31,3 @@ async function cleanupSpaces(threshold = 1000 * 60 * 60, dryRun = false) {
     await Promise.allSettled(spaces.map((space) => deleteSpace(space.sys.id)))
   }
 }
-
-cleanupSpaces().catch(console.error)

--- a/test/integration/environment-integration.js
+++ b/test/integration/environment-integration.js
@@ -1,5 +1,5 @@
 import { after, before, describe, test } from 'mocha'
-import { client, createTestSpace, generateRandomId } from '../helpers'
+import { client, createTestSpace, generateRandomId, waitForEnvironmentToBeReady } from '../helpers'
 import { expect } from 'chai'
 
 describe('Environment Api', function () {
@@ -16,17 +16,29 @@ describe('Environment Api', function () {
   })
 
   test('creates an environment', async () => {
-    return space.createEnvironment({ name: 'test-env' }).then((response) => {
-      expect(response.sys.type).equals('Environment', 'env is created')
-      expect(response.name).equals('test-env', 'env is created with name')
-    })
+    return space
+      .createEnvironment({ name: 'test-env' })
+      .then(async (env) => {
+        await waitForEnvironmentToBeReady(space, env)
+        return env
+      })
+      .then((response) => {
+        expect(response.sys.type).equals('Environment', 'env is created')
+        expect(response.name).equals('test-env', 'env is created with name')
+      })
   })
 
   test('creates an environment with an id', async () => {
     const id = generateRandomId('env')
-    return space.createEnvironmentWithId(id, { name: 'myId' }).then((response) => {
-      expect(response.name).equals('myId', 'env was created with correct name')
-      expect(response.sys.id).equals(id, 'env was created with id')
-    })
+    return space
+      .createEnvironmentWithId(id, { name: 'myId' })
+      .then(async (env) => {
+        await waitForEnvironmentToBeReady(space, env)
+        return env
+      })
+      .then((response) => {
+        expect(response.name).equals('myId', 'env was created with correct name')
+        expect(response.sys.id).equals(id, 'env was created with id')
+      })
   })
 })

--- a/test/integration/environment-integration.js
+++ b/test/integration/environment-integration.js
@@ -1,5 +1,5 @@
 import { after, before, describe, test } from 'mocha'
-import { client, createTestSpace } from '../helpers'
+import { client, createTestSpace, generateRandomId } from '../helpers'
 import { expect } from 'chai'
 
 describe('Environment Api', function () {
@@ -23,9 +23,10 @@ describe('Environment Api', function () {
   })
 
   test('creates an environment with an id', async () => {
-    return space.createEnvironmentWithId('myId', { name: 'myId' }).then((response) => {
+    const id = generateRandomId('env')
+    return space.createEnvironmentWithId(id, { name: 'myId' }).then((response) => {
       expect(response.name).equals('myId', 'env was created with correct name')
-      expect(response.sys.id).equals('myId', 'env was created with id')
+      expect(response.sys.id).equals(id, 'env was created with id')
     })
   })
 })

--- a/test/mocha-global.js
+++ b/test/mocha-global.js
@@ -1,0 +1,6 @@
+import { after } from 'mocha'
+import { cleanupSpaces } from './cleanup-spaces'
+
+after(async () => {
+  await cleanupSpaces()
+})

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,0 @@
---require @babel/register
---recursive


### PR DESCRIPTION
Teardown all created test spaces that exists > 1h after each run.
This should help to kill zombis spaces left alive after a run got intercepted.
