### PR TITLE
fix: correct file uploads

### DIFF
--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -19,13 +19,7 @@ export type ContentfulEnvironmentAPI = ReturnType<typeof createEnvironmentApi>
 /**
  * Creates API object with methods to access the Environment API
  */
-export default function createEnvironmentApi({
-  http,
-  httpUpload,
-}: {
-  http: AxiosInstance
-  httpUpload: AxiosInstance
-}) {
+export default function createEnvironmentApi({ http }: { http: AxiosInstance }) {
   const { wrapEnvironment } = entities.environment
   const { wrapContentType, wrapContentTypeCollection } = entities.contentType
   const { wrapEntry, wrapEntryCollection } = entities.entry
@@ -695,7 +689,7 @@ export default function createEnvironmentApi({
     createAssetFromFiles(data: Omit<AssetFileProp, 'sys'>) {
       const raw = this.toPlainObject() as EnvironmentProps
       return endpoints.asset
-        .createFromFiles(httpUpload)(
+        .createFromFiles(
           http,
           {
             spaceId: raw.sys.space.sys.id,
@@ -726,12 +720,11 @@ export default function createEnvironmentApi({
     getUpload(id: string) {
       const raw = this.toPlainObject() as EnvironmentProps
       return endpoints.upload
-        .get(httpUpload, {
+        .get(http, {
           spaceId: raw.sys.space.sys.id,
-          environmentId: raw.sys.id,
           uploadId: id,
         })
-        .then((data) => wrapUpload(httpUpload, data))
+        .then((data) => wrapUpload(http, data))
     },
 
     /**
@@ -756,14 +749,13 @@ export default function createEnvironmentApi({
       const raw = this.toPlainObject() as EnvironmentProps
       return endpoints.upload
         .create(
-          httpUpload,
+          http,
           {
             spaceId: raw.sys.space.sys.id,
-            environmentId: raw.sys.id,
           },
           data
         )
-        .then((data) => wrapUpload(httpUpload, data))
+        .then((data) => wrapUpload(http, data))
     },
     /**
      * Gets a Locale

--- a/lib/entities/environment.ts
+++ b/lib/entities/environment.ts
@@ -6,11 +6,6 @@ import { wrapCollection } from '../common-utils'
 import { DefaultElements, SysLink, BasicMetaSysProps } from '../common-types'
 import { AxiosInstance } from 'axios'
 
-type SdkHttpClient = AxiosInstance & {
-  httpClientParams: Record<string, any>
-  cloneWithNewParams: (newParams: Record<string, any>) => SdkHttpClient
-}
-
 type EnvironmentMetaSys = BasicMetaSysProps & {
   status: SysLink
   space: SysLink
@@ -47,15 +42,9 @@ export type Environment = ContentfulEnvironmentAPI &
  */
 export function wrapEnvironment(http: AxiosInstance, data: EnvironmentProps): Environment {
   // do not pollute generated typings
-  const sdkHttp = http as SdkHttpClient
   const environment = toPlainObject(cloneDeep(data))
-  const { hostUpload, defaultHostnameUpload } = sdkHttp.httpClientParams
-  const environmentScopedUploadClient = sdkHttp.cloneWithNewParams({
-    host: hostUpload || defaultHostnameUpload,
-  })
   const environmentApi = createEnvironmentApi({
     http,
-    httpUpload: environmentScopedUploadClient,
   })
   const enhancedEnvironment = enhanceWithMethods(environment, environmentApi)
   return freezeSys(enhancedEnvironment)

--- a/lib/entities/upload.ts
+++ b/lib/entities/upload.ts
@@ -9,7 +9,7 @@ export type UploadProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { space: SysLink; environment: SysLink }
+  sys: MetaSysProps & { space: SysLink }
 }
 
 export interface Upload extends UploadProps, DefaultElements<UploadProps> {
@@ -39,7 +39,6 @@ function createUploadApi(http: AxiosInstance) {
       const raw = this.toPlainObject() as UploadProps
       return endpoints.upload.del(http, {
         spaceId: raw.sys.space.sys.id,
-        environmentId: raw.sys.environment.sys.id,
         uploadId: raw.sys.id,
       })
     },

--- a/lib/error-handler.ts
+++ b/lib/error-handler.ts
@@ -1,4 +1,5 @@
 import isPlainObject from 'lodash/isPlainObject'
+import get from 'lodash/get'
 import { AxiosError } from 'axios'
 
 /**
@@ -71,7 +72,7 @@ export default function errorHandler(errorResponse: AxiosError): never {
   try {
     error.message = JSON.stringify(errorData, null, '  ')
   } catch {
-    // do nothing
+    error.message = get(errorData, ['message'], '')
   }
   throw error
 }

--- a/lib/error-handler.ts
+++ b/lib/error-handler.ts
@@ -67,6 +67,11 @@ export default function errorHandler(errorResponse: AxiosError): never {
   const error = new Error()
   error.name =
     errorName && errorName !== 'Unknown' ? errorName : `${response?.status} ${response?.statusText}`
-  error.message = JSON.stringify(errorData, null, '  ')
+
+  try {
+    error.message = JSON.stringify(errorData, null, '  ')
+  } catch {
+    // do nothing
+  }
   throw error
 }

--- a/lib/plain/endpoints/asset.ts
+++ b/lib/plain/endpoints/asset.ts
@@ -10,6 +10,7 @@ import {
 import { normalizeSelect } from './utils'
 import cloneDeep from 'lodash/cloneDeep'
 import { create as createUpload } from './upload'
+import { getUploadHttpClient } from '../../upload-http-client'
 
 import { QueryParams, CollectionProp, GetSpaceEnvironmentParams } from './common-types'
 
@@ -142,11 +143,13 @@ export const createWithId = (
   )
 }
 
-export const createFromFiles = (httpUpload: AxiosInstance) => (
+export const createFromFiles = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams,
   data: Omit<AssetFileProp, 'sys'>
 ) => {
+  const httpUpload = getUploadHttpClient(http)
+
   const { file } = data.fields
   return Promise.all(
     Object.keys(file).map((locale) => {

--- a/lib/plain/endpoints/upload.ts
+++ b/lib/plain/endpoints/upload.ts
@@ -1,45 +1,35 @@
 import { AxiosInstance } from 'axios'
 import * as raw from './raw'
 import { Stream } from 'stream'
-import { GetSpaceEnvironmentParams } from './common-types'
+import { GetSpaceParams } from './common-types'
+import { getUploadHttpClient } from '../../upload-http-client'
 
 export const create = (
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams,
+  params: GetSpaceParams,
   data: { file: string | ArrayBuffer | Stream }
 ) => {
+  const httpUpload = getUploadHttpClient(http)
+
   const { file } = data
   if (!file) {
     return Promise.reject(new Error('Unable to locate a file to upload.'))
   }
-  return raw.post(
-    http,
-    `/spaces/${params.spaceId}/environments/${params.environmentId}/uploads`,
-    file,
-    {
-      headers: {
-        'Content-Type': 'application/octet-stream',
-      },
-    }
-  )
+  return raw.post(httpUpload, `/spaces/${params.spaceId}/uploads`, file, {
+    headers: {
+      'Content-Type': 'application/octet-stream',
+    },
+  })
 }
 
-export const del = (
-  http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { uploadId: string }
-) => {
-  return raw.del(
-    http,
-    `/spaces/${params.spaceId}/environments/${params.environmentId}/uploads/${params.uploadId}`
-  )
+export const del = (http: AxiosInstance, params: GetSpaceParams & { uploadId: string }) => {
+  const httpUpload = getUploadHttpClient(http)
+
+  return raw.del(httpUpload, `/spaces/${params.spaceId}/uploads/${params.uploadId}`)
 }
 
-export const get = (
-  http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { uploadId: string }
-) => {
-  return raw.get(
-    http,
-    `/spaces/${params.spaceId}/environments/${params.environmentId}/uploads/${params.uploadId}`
-  )
+export const get = (http: AxiosInstance, params: GetSpaceParams & { uploadId: string }) => {
+  const httpUpload = getUploadHttpClient(http)
+
+  return raw.get(httpUpload, `/spaces/${params.spaceId}/uploads/${params.uploadId}`)
 }

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -10,11 +10,6 @@ type RestParamsType<F> = F extends (p1: any, ...rest: infer REST) => any ? REST 
 
 export const createPlainClient = (params: ClientParams, defaults?: DefaultParams) => {
   const http = createCMAHttpClient(params, true)
-  const httpUpload = createCMAHttpClient({
-    ...params,
-    host: params.hostUpload || defaultHostParameters.defaultHostnameUpload,
-  })
-
   const wrapParams = { http, defaults }
 
   return {
@@ -95,14 +90,14 @@ export const createPlainClient = (params: ClientParams, defaults?: DefaultParams
       unarchive: wrap(wrapParams, endpoints.asset.unarchive),
       create: wrap(wrapParams, endpoints.asset.create),
       createWithId: wrap(wrapParams, endpoints.asset.createWithId),
-      createFromFiles: wrap(wrapParams, endpoints.asset.createFromFiles(httpUpload)),
+      createFromFiles: wrap(wrapParams, endpoints.asset.createFromFiles),
       processForAllLocales: wrap(wrapParams, endpoints.asset.processForAllLocales),
       processForLocale: wrap(wrapParams, endpoints.asset.processForLocale),
     },
     upload: {
-      get: wrap({ http: httpUpload, defaults }, endpoints.upload.get),
-      create: wrap({ http: httpUpload, defaults }, endpoints.upload.create),
-      delete: wrap({ http: httpUpload, defaults }, endpoints.upload.del),
+      get: wrap(wrapParams, endpoints.upload.get),
+      create: wrap(wrapParams, endpoints.upload.create),
+      delete: wrap(wrapParams, endpoints.upload.del),
     },
     locale: {
       get: wrap(wrapParams, endpoints.locale.get),

--- a/lib/upload-http-client.ts
+++ b/lib/upload-http-client.ts
@@ -1,0 +1,15 @@
+import { AxiosInstance } from 'axios'
+
+type SdkHttpClient = AxiosInstance & {
+  httpClientParams: Record<string, any>
+  cloneWithNewParams: (newParams: Record<string, any>) => SdkHttpClient
+}
+
+export function getUploadHttpClient(http: AxiosInstance): AxiosInstance {
+  const sdkHttp = http as SdkHttpClient
+  const { hostUpload, defaultHostnameUpload } = sdkHttp.httpClientParams
+  const uploadHttp = sdkHttp.cloneWithNewParams({
+    host: hostUpload || defaultHostnameUpload,
+  })
+  return uploadHttp
+}

--- a/test/unit/mocks/http.js
+++ b/test/unit/mocks/http.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon'
 
 export default function setupHttpMock(promise = Promise.resolve({ data: {} })) {
-  return {
+  const mock = {
     get: sinon.stub().returns(promise),
     post: sinon.stub().returns(promise),
     put: sinon.stub().returns(promise),
@@ -9,5 +9,12 @@ export default function setupHttpMock(promise = Promise.resolve({ data: {} })) {
     defaults: {
       baseURL: 'https://api.contentful.com/spaces/',
     },
+    httpClientParams: {
+      hostUpload: 'upload.contentful.com',
+    },
   }
+
+  mock.cloneWithNewParams = () => mock
+
+  return mock
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/contentful/contentful-management.js/issues/584

## Motivation and Context

Apparently, we did a mistake while migrating to a new plain API and scoped uploads to environments while upload are bound only to a space. Integration tests don't cover this part so it was never caught.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
