### PR TITLE
refactor: replace lodash with fast-copy

### DIFF
--- a/lib/common-utils.ts
+++ b/lib/common-utils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-ignore */
 
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { toPlainObject } from 'contentful-sdk-core'
 import { CollectionProp, Collection } from './common-types'
@@ -9,7 +9,7 @@ import { CollectionProp, Collection } from './common-types'
 export const wrapCollection = <R, T, Rest extends any[]>(
   fn: (http: AxiosInstance, entity: T, ...rest: Rest) => R
 ) => (http: AxiosInstance, data: CollectionProp<T>, ...rest: Rest): Collection<R, T> => {
-  const collectionData = toPlainObject(cloneDeep(data))
+  const collectionData = toPlainObject(copy(data))
   // @ts-ignore
   collectionData.items = collectionData.items.map((entity) => fn(http, entity, ...rest))
   // @ts-ignore

--- a/lib/create-cma-http-client.ts
+++ b/lib/create-cma-http-client.ts
@@ -6,7 +6,7 @@
 import axios from 'axios'
 import { createHttpClient, getUserAgentHeader } from 'contentful-sdk-core'
 import type { CreateHttpClientParams } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 
 export type ClientParams = CreateHttpClientParams & {
   /**
@@ -61,7 +61,7 @@ export function createCMAHttpClient(params: ClientParams, plainClient = false) {
 
   params = {
     ...defaultHostParameters,
-    ...cloneDeep(params),
+    ...copy(params),
   }
 
   if (!params.accessToken) {

--- a/lib/entities/api-key.ts
+++ b/lib/entities/api-key.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -87,7 +87,7 @@ function createApiKeyApi(http: AxiosInstance) {
  * @param data - Raw api key data
  */
 export function wrapApiKey(http: AxiosInstance, data: ApiKeyProps): ApiKey {
-  const apiKey = toPlainObject(cloneDeep(data))
+  const apiKey = toPlainObject(copy(data))
   const apiKeyWithMethods = enhanceWithMethods(apiKey, createApiKeyApi(http))
   return freezeSys(apiKeyWithMethods)
 }

--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import { DefaultElements, BasicMetaSysProps, SysLink } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -132,7 +132,7 @@ function createAppDefinitionApi(http: AxiosInstance) {
  * @return Wrapped App Definition data
  */
 export function wrapAppDefinition(http: AxiosInstance, data: AppDefinitionProps): AppDefinition {
-  const appDefinition = toPlainObject(cloneDeep(data))
+  const appDefinition = toPlainObject(copy(data))
   const appDefinitionWithMethods = enhanceWithMethods(appDefinition, createAppDefinitionApi(http))
   return freezeSys(appDefinitionWithMethods)
 }

--- a/lib/entities/app-installation.ts
+++ b/lib/entities/app-installation.ts
@@ -1,6 +1,6 @@
 import { toPlainObject, freezeSys } from 'contentful-sdk-core'
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
 import * as endpoints from '../plain/endpoints'
@@ -100,7 +100,7 @@ export function wrapAppInstallation(
   http: AxiosInstance,
   data: AppInstallationProps
 ): AppInstallation {
-  const appInstallation = toPlainObject(cloneDeep(data))
+  const appInstallation = toPlainObject(copy(data))
   const appInstallationWithMethods = enhanceWithMethods(
     appInstallation,
     createAppInstallationApi(http)

--- a/lib/entities/asset.ts
+++ b/lib/entities/asset.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import { Stream } from 'stream'
 import type { AxiosInstance } from 'contentful-sdk-core'
@@ -354,7 +354,7 @@ function createAssetApi(http: AxiosInstance): AssetApi {
  * @return Wrapped asset data
  */
 export function wrapAsset(http: AxiosInstance, data: AssetProps): Asset {
-  const asset = toPlainObject(cloneDeep(data))
+  const asset = toPlainObject(copy(data))
   const assetWithMethods = enhanceWithMethods(asset, createAssetApi(http))
   return freezeSys(assetWithMethods)
 }

--- a/lib/entities/content-type.ts
+++ b/lib/entities/content-type.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
@@ -311,7 +311,7 @@ function createContentTypeApi(http: AxiosInstance): ContentTypeApi {
  * @return Wrapped content type data
  */
 export function wrapContentType(http: AxiosInstance, data: ContentTypeProps): ContentType {
-  const contentType = toPlainObject(cloneDeep(data))
+  const contentType = toPlainObject(copy(data))
   const contentTypeWithMethods = enhanceWithMethods(contentType, createContentTypeApi(http))
   return freezeSys(contentTypeWithMethods)
 }

--- a/lib/entities/editor-interface.ts
+++ b/lib/entities/editor-interface.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import type { AxiosInstance } from 'contentful-sdk-core'
@@ -175,7 +175,7 @@ export function wrapEditorInterface(
   http: AxiosInstance,
   data: EditorInterfaceProps
 ): EditorInterface {
-  const editorInterface = toPlainObject(cloneDeep(data))
+  const editorInterface = toPlainObject(copy(data))
   const editorInterfaceWithMethods = enhanceWithMethods(
     editorInterface,
     createEditorInterfaceApi(http)

--- a/lib/entities/entry.ts
+++ b/lib/entities/entry.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
@@ -298,7 +298,7 @@ function createEntryApi(http: AxiosInstance): EntryApi {
  * @return Wrapped entry data
  */
 export function wrapEntry(http: AxiosInstance, data: EntryProps): Entry {
-  const entry = toPlainObject(cloneDeep(data))
+  const entry = toPlainObject(copy(data))
   const entryWithMethods = enhanceWithMethods(entry, createEntryApi(http))
   return freezeSys(entryWithMethods)
 }

--- a/lib/entities/environment-alias.ts
+++ b/lib/entities/environment-alias.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
@@ -100,7 +100,7 @@ export function wrapEnvironmentAlias(
   http: AxiosInstance,
   data: EnvironmentAliasProps
 ): EnvironmentAlias {
-  const alias = toPlainObject(cloneDeep(data))
+  const alias = toPlainObject(copy(data))
   const enhancedAlias = enhanceWithMethods(alias, createEnvironmentAliasApi(http))
   return freezeSys(enhancedAlias)
 }

--- a/lib/entities/environment.ts
+++ b/lib/entities/environment.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import createEnvironmentApi, { ContentfulEnvironmentAPI } from '../create-environment-api'
@@ -42,7 +42,7 @@ export type Environment = ContentfulEnvironmentAPI &
  */
 export function wrapEnvironment(http: AxiosInstance, data: EnvironmentProps): Environment {
   // do not pollute generated typings
-  const environment = toPlainObject(cloneDeep(data))
+  const environment = toPlainObject(copy(data))
   const environmentApi = createEnvironmentApi({
     http,
   })

--- a/lib/entities/locale.ts
+++ b/lib/entities/locale.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import { Except, SetOptional } from 'type-fest'
@@ -129,7 +129,7 @@ export function wrapLocale(http: AxiosInstance, data: LocaleProps): Locale {
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore
   delete data.internal_code
-  const locale = toPlainObject(cloneDeep(data))
+  const locale = toPlainObject(copy(data))
   const localeWithMethods = enhanceWithMethods(locale, createLocaleApi(http))
   return freezeSys(localeWithMethods)
 }

--- a/lib/entities/organization-invitation.ts
+++ b/lib/entities/organization-invitation.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { MetaLinkProps, MetaSysProps, DefaultElements } from '../common-types'
@@ -32,6 +32,6 @@ export function wrapOrganizationInvitation(
   _http: AxiosInstance,
   data: OrganizationInvitationProps
 ): OrganizationInvitation {
-  const invitation = toPlainObject(cloneDeep(data))
+  const invitation = toPlainObject(copy(data))
   return freezeSys(invitation)
 }

--- a/lib/entities/organization-membership.ts
+++ b/lib/entities/organization-membership.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
@@ -98,7 +98,7 @@ export function wrapOrganizationMembership(
   data: OrganizationMembershipProps,
   organizationId: string
 ): OrganizationMembership {
-  const organizationMembership = toPlainObject(cloneDeep(data))
+  const organizationMembership = toPlainObject(copy(data))
   const organizationMembershipWithMethods = enhanceWithMethods(
     organizationMembership,
     createOrganizationMembershipApi(http, organizationId)

--- a/lib/entities/organization.ts
+++ b/lib/entities/organization.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import createOrganizationApi, { ContentfulOrganizationAPI } from '../create-organization-api'
@@ -32,7 +32,7 @@ export type OrganizationProp = {
  * @return {Organization}
  */
 export function wrapOrganization(http: AxiosInstance, data: OrganizationProp): Organization {
-  const org = toPlainObject(cloneDeep(data))
+  const org = toPlainObject(copy(data))
   const orgApi = createOrganizationApi({
     http: http,
   })

--- a/lib/entities/personal-access-token.ts
+++ b/lib/entities/personal-access-token.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
@@ -49,7 +49,7 @@ export function wrapPersonalAccessToken(
   http: AxiosInstance,
   data: PersonalAccessTokenProp
 ): PersonalAccessToken {
-  const personalAccessToken = toPlainObject(cloneDeep(data))
+  const personalAccessToken = toPlainObject(copy(data))
   const personalAccessTokenWithMethods = enhanceWithMethods(personalAccessToken, {
     revoke: function () {
       return endpoints.personalAccessToken

--- a/lib/entities/preview-api-key.ts
+++ b/lib/entities/preview-api-key.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -24,7 +24,7 @@ function createPreviewApiKeyApi() {
  * @return Wrapped preview api key data
  */
 export function wrapPreviewApiKey(_http: AxiosInstance, data: PreviewApiKeyProps): PreviewApiKey {
-  const previewApiKey = toPlainObject(cloneDeep(data))
+  const previewApiKey = toPlainObject(copy(data))
   const previewApiKeyWithMethods = enhanceWithMethods(previewApiKey, createPreviewApiKeyApi())
   return freezeSys(previewApiKeyWithMethods)
 }

--- a/lib/entities/role.ts
+++ b/lib/entities/role.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -113,7 +113,7 @@ function createRoleApi(http: AxiosInstance) {
  * @return Wrapped role data
  */
 export function wrapRole(http: AxiosInstance, data: RoleProps): Role {
-  const role = toPlainObject(cloneDeep(data))
+  const role = toPlainObject(copy(data))
   const roleWithMethods = enhanceWithMethods(role, createRoleApi(http))
   return freezeSys(roleWithMethods)
 }

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -1,6 +1,6 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
-import { cloneDeep } from 'lodash'
+import copy from 'fast-copy'
 import {
   DefaultElements,
   ISO8601Timestamp,
@@ -101,7 +101,7 @@ export function wrapScheduledAction(
   http: AxiosInstance,
   data: ScheduledActionProps
 ): ScheduledAction {
-  const scheduledAction = toPlainObject(cloneDeep(data))
+  const scheduledAction = toPlainObject(copy(data))
   const scheduledActionWithMethods = enhanceWithMethods(
     scheduledAction,
     createScheduledActionApi(http)

--- a/lib/entities/snapshot.ts
+++ b/lib/entities/snapshot.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
@@ -27,7 +27,7 @@ function createSnapshotApi() {
  * @return Wrapped snapshot data
  */
 export function wrapSnapshot<T>(_http: AxiosInstance, data: SnapshotProps<T>): Snapshot<T> {
-  const snapshot = toPlainObject(cloneDeep(data))
+  const snapshot = toPlainObject(copy(data))
   const snapshotWithMethods = enhanceWithMethods(snapshot, createSnapshotApi())
   return freezeSys(snapshotWithMethods)
 }

--- a/lib/entities/space-member.ts
+++ b/lib/entities/space-member.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import { wrapCollection } from '../common-utils'
 import { MetaSysProps, MetaLinkProps, DefaultElements } from '../common-types'
@@ -25,7 +25,7 @@ export interface SpaceMember extends SpaceMemberProps, DefaultElements<SpaceMemb
  * @return Wrapped space member data
  */
 export function wrapSpaceMember(http: AxiosInstance, data: SpaceMemberProps) {
-  const spaceMember = toPlainObject(cloneDeep(data))
+  const spaceMember = toPlainObject(copy(data))
   return freezeSys(spaceMember)
 }
 

--- a/lib/entities/space-membership.ts
+++ b/lib/entities/space-membership.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
@@ -90,7 +90,7 @@ export function wrapSpaceMembership(
   http: AxiosInstance,
   data: SpaceMembershipProps
 ): SpaceMembership {
-  const spaceMembership = toPlainObject(cloneDeep(data))
+  const spaceMembership = toPlainObject(copy(data))
   const spaceMembershipWithMethods = enhanceWithMethods(
     spaceMembership,
     createSpaceMembershipApi(http)

--- a/lib/entities/space.ts
+++ b/lib/entities/space.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
@@ -29,7 +29,7 @@ export type Space = SpaceProps & DefaultElements<SpaceProps> & ContentfulSpaceAP
  * @return {Space}
  */
 export function wrapSpace(http: AxiosInstance, data: SpaceProps): Space {
-  const space = toPlainObject(cloneDeep(data))
+  const space = toPlainObject(copy(data))
   const spaceApi = createSpaceApi({
     http,
   })

--- a/lib/entities/tag.ts
+++ b/lib/entities/tag.ts
@@ -1,6 +1,6 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
-import { cloneDeep } from 'lodash'
+import copy from 'fast-copy'
 import { DefaultElements, MetaSysProps, SysLink } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -67,7 +67,7 @@ export default function createTagApi(http: AxiosInstance): TagApi {
 }
 
 export function wrapTag(http: AxiosInstance, data: TagProps): Tag {
-  const tag = toPlainObject(cloneDeep(data))
+  const tag = toPlainObject(copy(data))
   const tagWithMethods = enhanceWithMethods(tag, createTagApi(http))
   return freezeSys(tagWithMethods)
 }

--- a/lib/entities/team-membership.ts
+++ b/lib/entities/team-membership.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
@@ -100,7 +100,7 @@ function createTeamMembershipApi(http: AxiosInstance) {
  * @return Wrapped team membership data
  */
 export function wrapTeamMembership(http: AxiosInstance, data: TeamMembershipProps): TeamMembership {
-  const teamMembership = toPlainObject(cloneDeep(data))
+  const teamMembership = toPlainObject(copy(data))
   const teamMembershipWithMethods = enhanceWithMethods(
     teamMembership,
     createTeamMembershipApi(http)

--- a/lib/entities/team-space-membership.ts
+++ b/lib/entities/team-space-membership.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
@@ -113,7 +113,7 @@ export function wrapTeamSpaceMembership(
   http: AxiosInstance,
   data: TeamSpaceMembershipProps
 ): TeamSpaceMembership {
-  const teamSpaceMembership = toPlainObject(cloneDeep(data))
+  const teamSpaceMembership = toPlainObject(copy(data))
   const teamSpaceMembershipWithMethods = enhanceWithMethods(
     teamSpaceMembership,
     createTeamSpaceMembershipApi(http)

--- a/lib/entities/team.ts
+++ b/lib/entities/team.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
@@ -97,7 +97,7 @@ function createTeamApi(http: AxiosInstance) {
  * @return Wrapped team data
  */
 export function wrapTeam(http: AxiosInstance, data: TeamProps): Team {
-  const team = toPlainObject(cloneDeep(data))
+  const team = toPlainObject(copy(data))
   const teamWithMethods = enhanceWithMethods(team, createTeamApi(http))
   return freezeSys(teamWithMethods)
 }

--- a/lib/entities/ui-extension.ts
+++ b/lib/entities/ui-extension.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -129,7 +129,7 @@ function createUiExtensionApi(http: AxiosInstance) {
  * @return Wrapped UI Extension data
  */
 export function wrapUiExtension(http: AxiosInstance, data: UIExtensionProps): UIExtension {
-  const uiExtension = toPlainObject(cloneDeep(data))
+  const uiExtension = toPlainObject(copy(data))
   const uiExtensionWithMethods = enhanceWithMethods(uiExtension, createUiExtensionApi(http))
   return freezeSys(uiExtensionWithMethods)
 }

--- a/lib/entities/upload.ts
+++ b/lib/entities/upload.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import type { AxiosInstance } from 'contentful-sdk-core'
@@ -52,7 +52,7 @@ function createUploadApi(http: AxiosInstance) {
  * @return {Upload} Wrapped upload data
  */
 export function wrapUpload(http: AxiosInstance, data: UploadProps) {
-  const upload = toPlainObject(cloneDeep(data))
+  const upload = toPlainObject(copy(data))
   const uploadWithMethods = enhanceWithMethods(upload, createUploadApi(http))
   return freezeSys(uploadWithMethods)
 }

--- a/lib/entities/usage.ts
+++ b/lib/entities/usage.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -61,7 +61,7 @@ export interface Usage extends UsageProps, DefaultElements<UsageProps> {}
  * @return Normalized usage
  */
 export function wrapUsage(http: AxiosInstance, data: UsageProps): Usage {
-  const usage = toPlainObject(cloneDeep(data))
+  const usage = toPlainObject(copy(data))
   const usageWithMethods = enhanceWithMethods(usage, {})
   return freezeSys(usageWithMethods)
 }

--- a/lib/entities/user.ts
+++ b/lib/entities/user.ts
@@ -1,6 +1,6 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
 import { DefaultElements, BasicMetaSysProps } from '../common-types'
@@ -59,7 +59,7 @@ export interface User extends UserProps, DefaultElements<UserProps> {}
  * @return Normalized user
  */
 export function wrapUser(http: AxiosInstance, data: UserProps): User {
-  const user = toPlainObject(cloneDeep(data))
+  const user = toPlainObject(copy(data))
   const userWithMethods = enhanceWithMethods(user, {})
   return freezeSys(userWithMethods)
 }

--- a/lib/entities/webhook.ts
+++ b/lib/entities/webhook.ts
@@ -1,6 +1,6 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { JsonValue, Except, SetOptional } from 'type-fest'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import * as endpoints from '../plain/endpoints'
@@ -324,7 +324,7 @@ function createWebhookApi(http: AxiosInstance) {
  * @return Wrapped webhook data
  */
 export function wrapWebhook(http: AxiosInstance, data: WebhookProps): WebHooks {
-  const webhook = toPlainObject(cloneDeep(data))
+  const webhook = toPlainObject(copy(data))
   const webhookWithMethods = enhanceWithMethods(webhook, createWebhookApi(http))
   return freezeSys(webhookWithMethods)
 }

--- a/lib/error-handler.ts
+++ b/lib/error-handler.ts
@@ -1,5 +1,4 @@
-import isPlainObject from 'lodash/isPlainObject'
-import get from 'lodash/get'
+import isPlainObject from 'lodash.isplainobject'
 import { AxiosError } from 'axios'
 
 /**
@@ -72,7 +71,7 @@ export default function errorHandler(errorResponse: AxiosError): never {
   try {
     error.message = JSON.stringify(errorData, null, '  ')
   } catch {
-    error.message = get(errorData, ['message'], '')
+    error.message = errorData?.message ?? ''
   }
   throw error
 }

--- a/lib/plain/as-iterator.ts
+++ b/lib/plain/as-iterator.ts
@@ -1,6 +1,5 @@
 import { QueryParams, CollectionProp } from './endpoints/common-types'
-import cloneDeep from 'lodash/cloneDeep'
-import merge from 'lodash/merge'
+import copy from 'fast-copy'
 
 type IterableFn<P = any, T = any> = (params: P) => Promise<CollectionProp<T>>
 type ParamsType<T extends IterableFn> = T extends (params: infer P) => any ? P : never
@@ -11,8 +10,8 @@ export const asIterator = <P extends QueryParams, T, F extends IterableFn<P, T>>
 ): AsyncIterable<T> => {
   return {
     [Symbol.asyncIterator]() {
-      const options = cloneDeep(params)
-      const get = () => fn(cloneDeep(options))
+      let options = copy(params)
+      const get = () => fn(copy(options))
       let currentResult = get()
 
       return {
@@ -29,7 +28,13 @@ export const asIterator = <P extends QueryParams, T, F extends IterableFn<P, T>>
           const endOfList = this.current === total
 
           if (endOfPage && !endOfList) {
-            merge(options, { query: { skip: skip + limit } })
+            options = {
+              ...options,
+              query: {
+                ...options.query,
+                skip: skip + limit,
+              },
+            }
             currentResult = get()
           }
 

--- a/lib/plain/endpoints/api-key.ts
+++ b/lib/plain/endpoints/api-key.ts
@@ -2,7 +2,7 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import * as raw from './raw'
 import { ApiKeyProps, CreateApiKeyProps } from '../../entities/api-key'
 import { CollectionProp, QueryParams, GetSpaceParams } from './common-types'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 
 export const get = (http: AxiosInstance, params: GetSpaceParams & { apiKeyId: string }) => {
   return raw.get<ApiKeyProps>(http, `/spaces/${params.spaceId}/api_keys/${params.apiKeyId}`)
@@ -40,7 +40,7 @@ export const update = (
   rawData: ApiKeyProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   if ('accessToken' in data) {
     delete data.accessToken
   }

--- a/lib/plain/endpoints/app-definition.ts
+++ b/lib/plain/endpoints/app-definition.ts
@@ -1,6 +1,6 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import * as raw from './raw'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { GetOrganizationParams, QueryParams } from './common-types'
 import { AppDefinitionProps, CreateAppDefinitionProps } from '../../entities/app-definition'
 import { normalizeSelect } from './utils'
@@ -31,7 +31,7 @@ export const create = (
   params: GetOrganizationParams,
   rawData: CreateAppDefinitionProps
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   return raw.post<AppDefinitionProps>(http, getBaseUrl(params), data)
 }
@@ -42,7 +42,7 @@ export const update = async (
   rawData: AppDefinitionProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   delete data.sys
 

--- a/lib/plain/endpoints/app-installation.ts
+++ b/lib/plain/endpoints/app-installation.ts
@@ -3,7 +3,7 @@ import * as raw from './raw'
 import { GetSpaceEnvironmentParams, CollectionProp, PaginationQueryParams } from './common-types'
 import { normalizeSelect } from './utils'
 import { AppInstallationProps, CreateAppInstallationProps } from '../../entities/app-installation'
-import { cloneDeep } from 'lodash'
+import copy from 'fast-copy'
 
 type GetAppInstallationParams = GetSpaceEnvironmentParams & { appDefinitionId: string }
 
@@ -37,7 +37,7 @@ export const upsert = (
   rawData: CreateAppInstallationProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   return raw.put<AppInstallationProps>(http, getAppInstallationUrl(params), data, {
     ...headers,

--- a/lib/plain/endpoints/asset.ts
+++ b/lib/plain/endpoints/asset.ts
@@ -8,7 +8,7 @@ import {
   AssetProcessingForLocale,
 } from '../../entities/asset'
 import { normalizeSelect } from './utils'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { create as createUpload } from './upload'
 import { getUploadHttpClient } from '../../upload-http-client'
 
@@ -43,7 +43,7 @@ export const update = (
   rawData: AssetProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
   return raw.put<AssetProps>(
     http,
@@ -120,7 +120,7 @@ export const create = (
   params: GetSpaceEnvironmentParams,
   rawData: CreateAssetProps
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   return raw.post<AssetProps>(
     http,
@@ -134,7 +134,7 @@ export const createWithId = (
   params: GetSpaceEnvironmentParams & { assetId: string },
   rawData: CreateAssetProps
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   return raw.put<AssetProps>(
     http,

--- a/lib/plain/endpoints/content-type.ts
+++ b/lib/plain/endpoints/content-type.ts
@@ -4,7 +4,7 @@ import { ContentTypeProps, CreateContentTypeProps } from '../../entities/content
 
 import { CollectionProp, QueryParams, GetSpaceEnvironmentParams } from './common-types'
 import { normalizeSelect } from './utils'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 
 type GetContentTypeParams = GetSpaceEnvironmentParams & { contentTypeId: string }
 
@@ -31,7 +31,7 @@ export const create = (
   params: GetSpaceEnvironmentParams,
   rawData: CreateContentTypeProps
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   return raw.post<ContentTypeProps>(http, getBaseUrl(params), data)
 }
@@ -41,7 +41,7 @@ export const createWithId = (
   params: GetContentTypeParams,
   rawData: CreateContentTypeProps
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   return raw.put<ContentTypeProps>(http, getContentTypeUrl(params), data)
 }
@@ -52,7 +52,7 @@ export const update = (
   rawData: ContentTypeProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
   return raw.put<ContentTypeProps>(http, getContentTypeUrl(params), data, {
     headers: {

--- a/lib/plain/endpoints/editor-interface.ts
+++ b/lib/plain/endpoints/editor-interface.ts
@@ -1,6 +1,6 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import * as raw from './raw'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { EditorInterfaceProps } from '../../entities/editor-interface'
 import { CollectionProp, GetSpaceEnvironmentParams, QueryParams } from './common-types'
 
@@ -26,7 +26,7 @@ export const update = (
   rawData: EditorInterfaceProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
 
   return raw.put<EditorInterfaceProps>(http, getBaseUrl(params), data, {

--- a/lib/plain/endpoints/entry.ts
+++ b/lib/plain/endpoints/entry.ts
@@ -2,7 +2,7 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import * as raw from './raw'
 import { CreateEntryProps, EntryProps } from '../../entities/entry'
 import { normalizeSelect } from './utils'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { QueryParams, CollectionProp, KeyValueMap, GetSpaceEnvironmentParams } from './common-types'
 
 export const get = <T extends KeyValueMap = KeyValueMap>(
@@ -37,7 +37,7 @@ export const update = <T extends KeyValueMap = KeyValueMap>(
   rawData: EntryProps<T>,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
   return raw.put<EntryProps<T>>(
     http,
@@ -114,7 +114,7 @@ export const create = <T extends KeyValueMap = KeyValueMap>(
   params: GetSpaceEnvironmentParams & { contentTypeId: string },
   rawData: CreateEntryProps<T>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   return raw.post<EntryProps<T>>(
     http,
@@ -133,7 +133,7 @@ export const createWithId = <T extends KeyValueMap = KeyValueMap>(
   params: GetSpaceEnvironmentParams & { entryId: string; contentTypeId: string },
   rawData: CreateEntryProps<T>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   return raw.put<EntryProps<T>>(
     http,

--- a/lib/plain/endpoints/environment-alias.ts
+++ b/lib/plain/endpoints/environment-alias.ts
@@ -1,6 +1,6 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import * as raw from './raw'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import {
   EnvironmentAliasProps,
   CreateEnvironmentAliasProps,
@@ -38,7 +38,7 @@ export const createWithId = (
   rawData: CreateEnvironmentAliasProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   return raw.put<EnvironmentAliasProps>(http, getEnvironmentAliasUrl(params), data, {
     headers: headers,
   })
@@ -50,7 +50,7 @@ export const update = (
   rawData: EnvironmentAliasProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
   return raw.put<EnvironmentAliasProps>(http, getEnvironmentAliasUrl(params), data, {
     headers: {

--- a/lib/plain/endpoints/environment.ts
+++ b/lib/plain/endpoints/environment.ts
@@ -1,7 +1,7 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import * as raw from './raw'
 import { EnvironmentProps, CreateEnvironmentProps } from '../../entities/environment'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import {
   CollectionProp,
   PaginationQueryParams,
@@ -28,7 +28,7 @@ export const update = (
   rawData: EnvironmentProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
 
   return raw.put<EnvironmentProps>(
@@ -54,7 +54,7 @@ export const create = (
   rawData: CreateEnvironmentProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   return raw.post<EnvironmentProps>(http, `/spaces/${params.spaceId}/environments`, data, {
     headers,
   })
@@ -66,7 +66,7 @@ export const createWithId = (
   rawData: CreateEnvironmentProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   return raw.put<EnvironmentProps>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}`,

--- a/lib/plain/endpoints/locale.ts
+++ b/lib/plain/endpoints/locale.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { CollectionProp } from '../../common-types'
 import { LocaleProps, CreateLocaleProps } from '../../entities/locale'
 import { normalizeSelect } from './utils'
@@ -48,7 +48,7 @@ export const update = (
   rawData: LocaleProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
   delete data.default // we should not send this back
   return raw.put<LocaleProps>(

--- a/lib/plain/endpoints/organization-membership.ts
+++ b/lib/plain/endpoints/organization-membership.ts
@@ -1,6 +1,6 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import * as raw from './raw'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { CollectionProp, GetOrganizationParams, QueryParams } from './common-types'
 import { OrganizationMembershipProps } from '../../entities/organization-membership'
 
@@ -26,7 +26,7 @@ export const update = (
   rawData: OrganizationMembershipProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
 
   const { role } = data

--- a/lib/plain/endpoints/role.ts
+++ b/lib/plain/endpoints/role.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import * as raw from './raw'
 import { normalizeSelect } from './utils'
 import { RoleProps, CreateRoleProps } from '../../entities/role'
@@ -43,7 +43,7 @@ export const update = (
   rawData: RoleProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
   return raw.put<RoleProps>(http, `/spaces/${params.spaceId}/roles/${params.roleId}`, data, {
     headers: {

--- a/lib/plain/endpoints/space-membership.ts
+++ b/lib/plain/endpoints/space-membership.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import * as raw from './raw'
 import { SpaceMembershipProps, CreateSpaceMembershipProps } from '../../entities/space-membership'
 import { CollectionProp, QueryParams, GetSpaceParams, GetOrganizationParams } from './common-types'
@@ -81,7 +81,7 @@ export const update = (
   rawData: SpaceMembershipProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
   return raw.put<SpaceMembershipProps>(http, getEntityUrl(params), data, {
     headers: {

--- a/lib/plain/endpoints/space.ts
+++ b/lib/plain/endpoints/space.ts
@@ -1,7 +1,7 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import * as raw from './raw'
 import { SpaceProps } from '../../entities/space'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { CollectionProp, QueryParams, GetSpaceParams } from './common-types'
 
 export const get = (http: AxiosInstance, params: GetSpaceParams) =>
@@ -31,7 +31,7 @@ export const update = (
   rawData: SpaceProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
 
   return raw.put<SpaceProps>(http, `/spaces/${params.spaceId}`, data, {

--- a/lib/plain/endpoints/tag.ts
+++ b/lib/plain/endpoints/tag.ts
@@ -1,7 +1,7 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import * as raw from './raw'
 import { CreateTagProps, TagProps } from '../../entities/tag'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import type { CollectionProp, QueryParams, GetSpaceEnvironmentParams } from './common-types'
 
 type GetTagParams = GetSpaceEnvironmentParams & { tagId: string }
@@ -24,7 +24,7 @@ export const createWithId = (
   params: GetTagParams,
   rawData: CreateTagProps
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   return raw.put<TagProps>(http, getTagUrl(params), data)
 }
@@ -35,7 +35,7 @@ export const update = (
   rawData: TagProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
 
   return raw.put<TagProps>(http, getTagUrl(params), data, {

--- a/lib/plain/endpoints/team-membership.ts
+++ b/lib/plain/endpoints/team-membership.ts
@@ -1,6 +1,6 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import * as raw from './raw'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import { CollectionProp, QueryParams, GetOrganizationParams, GetTeamParams } from './common-types'
 import { normalizeSelect } from './utils'
 import { CreateTeamMembershipProps, TeamMembershipProps } from '../../entities/team-membership'
@@ -49,7 +49,7 @@ export const update = (
   rawData: TeamMembershipProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
 
   return raw.put<TeamMembershipProps>(http, getEntityUrl(params), data, {

--- a/lib/plain/endpoints/team-space-membership.ts
+++ b/lib/plain/endpoints/team-space-membership.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import * as raw from './raw'
 import { GetSpaceParams, QueryParams, CollectionProp, GetOrganizationParams } from './common-types'
 import {
@@ -69,7 +69,7 @@ export const update = (
   rawData: TeamSpaceMembershipProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
 
   return raw.put<TeamSpaceMembershipProps>(http, getEntityUrl(params), data, {

--- a/lib/plain/endpoints/team.ts
+++ b/lib/plain/endpoints/team.ts
@@ -3,7 +3,7 @@ import * as raw from './raw'
 import { CollectionProp, QueryParams, GetOrganizationParams, GetTeamParams } from './common-types'
 import { CreateTeamProps, TeamProps } from '../../entities/team'
 import { normalizeSelect } from './utils'
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 
 const getBaseUrl = (params: GetOrganizationParams) =>
   `/organizations/${params.organizationId}/teams`
@@ -33,7 +33,7 @@ export const update = (
   rawData: TeamProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
   delete data.sys
 
   return raw.put<TeamProps>(http, getEntityUrl(params), data, {

--- a/lib/plain/endpoints/ui-extension.ts
+++ b/lib/plain/endpoints/ui-extension.ts
@@ -3,7 +3,7 @@ import * as raw from './raw'
 import { QueryParams, GetSpaceEnvironmentParams, CollectionProp } from './common-types'
 import { normalizeSelect } from './utils'
 import { UIExtensionProps, CreateUIExtensionProps } from '../../entities/ui-extension'
-import { cloneDeep } from 'lodash'
+import copy from 'fast-copy'
 
 type GetUiExtensionParams = GetSpaceEnvironmentParams & { extensionId: string }
 
@@ -40,7 +40,7 @@ export const createWithId = (
   rawData: CreateUIExtensionProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   return raw.put<UIExtensionProps>(http, getUIExtensionUrl(params), data, { headers })
 }
@@ -51,7 +51,7 @@ export const update = async (
   rawData: UIExtensionProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   delete data.sys
 

--- a/lib/plain/endpoints/webhook.ts
+++ b/lib/plain/endpoints/webhook.ts
@@ -9,7 +9,7 @@ import {
   WebhookCallDetailsProps,
   WebhookCallOverviewProps,
 } from '../../entities/webhook'
-import { cloneDeep } from 'lodash'
+import copy from 'fast-copy'
 
 type GetWebhookParams = GetSpaceParams & { webhookDefinitionId: string }
 
@@ -61,7 +61,7 @@ export const create = (
   rawData: CreateWebhooksProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   return raw.post<WebhookProps>(http, getBaseUrl(params), data, { headers })
 }
@@ -72,7 +72,7 @@ export const createWithId = (
   rawData: CreateWebhooksProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   return raw.put<WebhookProps>(http, getWebhookUrl(params), data, { headers })
 }
@@ -83,7 +83,7 @@ export const update = async (
   rawData: WebhookProps,
   headers?: Record<string, unknown>
 ) => {
-  const data = cloneDeep(rawData)
+  const data = copy(rawData)
 
   delete data.sys
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2554,6 +2554,15 @@
       "integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==",
       "dev": true
     },
+    "@types/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/minimist": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
@@ -10308,7 +10317,8 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "lodash-webpack-plugin": {
       "version": "0.11.5",
@@ -10358,8 +10368,7 @@
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
   "dependencies": {
     "contentful-sdk-core": "^6.6.0",
     "axios": "^0.21.0",
-    "lodash": "^4.17.20",
+    "lodash.isplainobject": "^4.0.6",
+    "fast-copy": "^2.1.0",
     "type-fest": "0.20.2"
   },
   "devDependencies": {
@@ -73,6 +74,7 @@
     "@babel/preset-typescript": "^7.12.7",
     "@semantic-release/changelog": "^5.0.1",
     "@types/lodash": "^4.14.165",
+    "@types/lodash.isplainobject": "^4.0.6",
     "@types/chai": "^4.2.12",
     "@typescript-eslint/eslint-plugin": "2.34.0",
     "@typescript-eslint/parser": "2.34.0",
@@ -108,6 +110,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^4.0.2",
     "lint-staged": "^10.5.1",
+    "lodash": "^4.17.20",
     "lodash-webpack-plugin": "^0.11.5",
     "nodemon": "^2.0.6",
     "mocha": "^8.1.1",


### PR DESCRIPTION
## Summary

* Replaces `lodash/cloneDeep` with `fast-copy`
* Replaces `lodash/isPlainObject` with `lodash.isplainobject` (300 bytes)
* Replaces all other lodash methods with native ES6