### PR TITLE
feat: allow getting accessToken async

### DIFF
--- a/lib/create-cma-http-client.ts
+++ b/lib/create-cma-http-client.ts
@@ -12,7 +12,7 @@ export type ClientParams = CreateHttpClientParams & {
   /**
    * Contentful CMA Access Token
    */
-  accessToken: string
+  accessToken: CreateHttpClientParams['accessToken']
   /**
    * API host
    * @default api.contentful.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -5381,9 +5381,9 @@
       "dev": true
     },
     "contentful-sdk-core": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.6.0.tgz",
-      "integrity": "sha512-/+Pi1ZK+hkYL704TONSHuVU0WGM0egkg/gE709HNOCdk0/M+PItFm9a+/sR5KsLhWdp8koRa7Mv6ZvYQgJMSWw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.7.0.tgz",
+      "integrity": "sha512-+b8UXVE249Z6WzMLXvsu3CIvN/s5xXRZ9o+zY7zDdPkIYBMW15xcs9N2ATI6ncmc+s1uj4XZij/2skflletHiw==",
       "requires": {
         "fast-copy": "^2.1.0",
         "qs": "^6.9.4"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "tonic-example.js"
   ],
   "dependencies": {
-    "contentful-sdk-core": "^6.6.0",
+    "contentful-sdk-core": "^6.7.0",
     "axios": "^0.21.0",
     "lodash.isplainobject": "^4.0.6",
     "fast-copy": "^2.1.0",


### PR DESCRIPTION
## Summary

Bumps `contentful-sdk-core` to leverage the ability to get access token asynchronously and pass `onError` & `onBeforeRequest` interceptors.

See: https://github.com/contentful/contentful-sdk-core/releases/tag/v6.7.0 

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
