### PR TITLE
feat: expose raw.bareRequest from plain client

### DIFF
--- a/lib/plain/endpoints/raw.ts
+++ b/lib/plain/endpoints/raw.ts
@@ -57,5 +57,12 @@ export function http<T = any>(http: AxiosInstance, url: string, config?: AxiosRe
   return http(url, {
     baseURL: getBaseUrl(http),
     ...config,
-  }).then((response) => response.data, errorHandler)
+  }).then((response) => response.data as T, errorHandler)
+}
+
+export function bareRequest<T = any>(http: AxiosInstance, config: AxiosRequestConfig) {
+  return http.request<T>({
+    baseURL: getBaseUrl(http),
+    ...config,
+  })
 }

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -1,11 +1,12 @@
-import { createCMAHttpClient, ClientParams, defaultHostParameters } from '../create-cma-http-client'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { createCMAHttpClient, ClientParams } from '../create-cma-http-client'
 import * as endpoints from './endpoints'
 import { wrap, wrapHttp, DefaultParams } from './wrappers/wrap'
 
 export type { DefaultParams } from './wrappers/wrap'
 export type PlainClientAPI = ReturnType<typeof createPlainClient>
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RestParamsType<F> = F extends (p1: any, ...rest: infer REST) => any ? REST : never
 
 export const createPlainClient = (params: ClientParams, defaults?: DefaultParams) => {
@@ -15,14 +16,18 @@ export const createPlainClient = (params: ClientParams, defaults?: DefaultParams
   return {
     raw: {
       getDefaultParams: () => defaults,
-      get: (...args: RestParamsType<typeof endpoints.raw.get>) => endpoints.raw.get(http, ...args),
-      post: (...args: RestParamsType<typeof endpoints.raw.post>) =>
-        endpoints.raw.post(http, ...args),
-      put: (...args: RestParamsType<typeof endpoints.raw.put>) => endpoints.raw.put(http, ...args),
-      delete: (...args: RestParamsType<typeof endpoints.raw.del>) =>
-        endpoints.raw.del(http, ...args),
-      http: (...args: RestParamsType<typeof endpoints.raw.http>) =>
-        endpoints.raw.http(http, ...args),
+      get: <T = any>(...args: RestParamsType<typeof endpoints.raw.get>) =>
+        endpoints.raw.get<T>(http, ...args),
+      post: <T = any>(...args: RestParamsType<typeof endpoints.raw.post>) =>
+        endpoints.raw.post<T>(http, ...args),
+      put: <T = any>(...args: RestParamsType<typeof endpoints.raw.put>) =>
+        endpoints.raw.put<T>(http, ...args),
+      delete: <T = any>(...args: RestParamsType<typeof endpoints.raw.del>) =>
+        endpoints.raw.del<T>(http, ...args),
+      http: <T = any>(...args: RestParamsType<typeof endpoints.raw.http>) =>
+        endpoints.raw.http<T>(http, ...args),
+      bareRequest: <T = any>(...args: RestParamsType<typeof endpoints.raw.bareRequest>) =>
+        endpoints.raw.bareRequest<T>(http, ...args),
     },
     editorInterface: {
       get: wrap(wrapParams, endpoints.editorInterface.get),


### PR DESCRIPTION
## Summary

* Propagates generics to all `client.raw` methods
* Exposes a new `raw. bareRequest` method that will be used in 401 interceptor

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
