### PR TITLE
fix: allow required headers to be overwritten by custom ones

### DIFF
--- a/lib/create-cma-http-client.ts
+++ b/lib/create-cma-http-client.ts
@@ -69,8 +69,8 @@ export function createCMAHttpClient(params: ClientParams, plainClient = false) {
   }
 
   params.headers = {
-    ...params.headers,
     ...requiredHeaders,
+    ...params.headers,
   }
 
   return createHttpClient(axios, params)


### PR DESCRIPTION
## Summary

To be able to override user agent when necessary (for example in the main Contentful web application)

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
