### PR TITLE
feat: be able to directly delete an entry by its Id

### DIFF
--- a/lib/create-cma-http-client.ts
+++ b/lib/create-cma-http-client.ts
@@ -12,7 +12,7 @@ export type ClientParams = CreateHttpClientParams & {
   /**
    * Contentful CMA Access Token
    */
-  accessToken: string
+  accessToken: CreateHttpClientParams['accessToken']
   /**
    * API host
    * @default api.contentful.com

--- a/lib/create-cma-http-client.ts
+++ b/lib/create-cma-http-client.ts
@@ -69,8 +69,8 @@ export function createCMAHttpClient(params: ClientParams, plainClient = false) {
   }
 
   params.headers = {
-    ...params.headers,
     ...requiredHeaders,
+    ...params.headers,
   }
 
   return createHttpClient(axios, params)

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -390,6 +390,36 @@ export default function createEnvironmentApi({ http }: { http: AxiosInstance }) 
     },
 
     /**
+     * Deletes an Entry of this environement
+     * @param id - Entry ID
+     * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getSpace('<space_id>')
+     * .then((space) => space.getEnvironment('<environment-id>'))
+     * .then((environment) => environment.deleteEntry("4bmLXiuviAZH3jkj5DLRWE"))
+     * .then(() => console.log('Entry deleted.'))
+     * .catch(console.error)
+     * ```
+     */
+    deleteEntry(id: string) {
+      const raw = this.toPlainObject() as EnvironmentProps
+      return endpoints.entry
+        .del(http, {
+          spaceId: raw.sys.space.sys.id,
+          environmentId: raw.sys.id,
+          entryId: id,
+        }).then(() => {
+          // noop
+        })
+    },
+
+    /**
      * Gets a collection of Entries
      * Warning: if you are using the select operator, when saving, any field that was not selected will be removed
      * from your entry in the backend

--- a/package-lock.json
+++ b/package-lock.json
@@ -5381,9 +5381,9 @@
       "dev": true
     },
     "contentful-sdk-core": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.6.0.tgz",
-      "integrity": "sha512-/+Pi1ZK+hkYL704TONSHuVU0WGM0egkg/gE709HNOCdk0/M+PItFm9a+/sR5KsLhWdp8koRa7Mv6ZvYQgJMSWw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.7.0.tgz",
+      "integrity": "sha512-+b8UXVE249Z6WzMLXvsu3CIvN/s5xXRZ9o+zY7zDdPkIYBMW15xcs9N2ATI6ncmc+s1uj4XZij/2skflletHiw==",
       "requires": {
         "fast-copy": "^2.1.0",
         "qs": "^6.9.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8224,9 +8224,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.2.tgz",
-      "integrity": "sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+      "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
       "dev": true
     },
     "hmac-drbg": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "tonic-example.js"
   ],
   "dependencies": {
-    "contentful-sdk-core": "^6.6.0",
+    "contentful-sdk-core": "^6.7.0",
     "axios": "^0.21.0",
     "lodash.isplainobject": "^4.0.6",
     "fast-copy": "^2.1.0",


### PR DESCRIPTION
## Summary

Be able to directly delete an entry by its Id
Avoid using the plain client for that purpose. 

## Motivation and Context

I need to delete an entry which I already now its sys.id
With this new method, I can delete the entry without calling  getEntry(id)  and then entry.delete() which produce 2 API calls

