### PR TITLE
fix: check for undefined config in error handler

### DIFF
--- a/lib/error-handler.ts
+++ b/lib/error-handler.ts
@@ -14,7 +14,7 @@ export default function errorHandler(errorResponse: AxiosError): never {
   let errorName
 
   // Obscure the Management token
-  if (config.headers && config.headers['Authorization']) {
+  if (config && config.headers && config.headers['Authorization']) {
     const token = `...${config.headers['Authorization'].substr(-5)}`
     config.headers['Authorization'] = `Bearer ${token}`
   }


### PR DESCRIPTION
## Summary

Account for a case when `config` is undefined.