### PR TITLE
fix: improve generics in raw plain client endpoints

### DIFF
--- a/lib/plain/endpoints/raw.ts
+++ b/lib/plain/endpoints/raw.ts
@@ -57,5 +57,5 @@ export function http<T = any>(http: AxiosInstance, url: string, config?: AxiosRe
   return http(url, {
     baseURL: getBaseUrl(http),
     ...config,
-  }).then((response) => response.data, errorHandler)
+  }).then((response) => response.data as T, errorHandler)
 }

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -1,4 +1,4 @@
-import { createCMAHttpClient, ClientParams, defaultHostParameters } from '../create-cma-http-client'
+import { createCMAHttpClient, ClientParams } from '../create-cma-http-client'
 import * as endpoints from './endpoints'
 import { wrap, wrapHttp, DefaultParams } from './wrappers/wrap'
 
@@ -15,14 +15,16 @@ export const createPlainClient = (params: ClientParams, defaults?: DefaultParams
   return {
     raw: {
       getDefaultParams: () => defaults,
-      get: (...args: RestParamsType<typeof endpoints.raw.get>) => endpoints.raw.get(http, ...args),
-      post: (...args: RestParamsType<typeof endpoints.raw.post>) =>
-        endpoints.raw.post(http, ...args),
-      put: (...args: RestParamsType<typeof endpoints.raw.put>) => endpoints.raw.put(http, ...args),
-      delete: (...args: RestParamsType<typeof endpoints.raw.del>) =>
-        endpoints.raw.del(http, ...args),
-      http: (...args: RestParamsType<typeof endpoints.raw.http>) =>
-        endpoints.raw.http(http, ...args),
+      get: <T = unknown>(...args: RestParamsType<typeof endpoints.raw.get>) =>
+        endpoints.raw.get<T>(http, ...args),
+      post: <T = unknown>(...args: RestParamsType<typeof endpoints.raw.post>) =>
+        endpoints.raw.post<T>(http, ...args),
+      put: <T = unknown>(...args: RestParamsType<typeof endpoints.raw.put>) =>
+        endpoints.raw.put<T>(http, ...args),
+      delete: <T = unknown>(...args: RestParamsType<typeof endpoints.raw.del>) =>
+        endpoints.raw.del<T>(http, ...args),
+      http: <T = unknown>(...args: RestParamsType<typeof endpoints.raw.http>) =>
+        endpoints.raw.http<T>(http, ...args),
     },
     editorInterface: {
       get: wrap(wrapParams, endpoints.editorInterface.get),


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Makes it easier to type raw methods in plain client version.


## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation