### PR TITLE
feat(getCurrentUser): allow for query params to be passed

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -6,8 +6,10 @@ import { Collection, QueryOptions } from './common-types'
 import { OrganizationProp, Organization } from './entities/organization'
 import { SpaceProps, Space } from './entities/space'
 import { CreatePersonalAccessTokenProps } from './entities/personal-access-token'
-import { UsageQuery } from './entities/usage'
 import * as endpoints from './plain/endpoints'
+import { QueryParams } from './plain/endpoints/common-types'
+import { UsageQuery } from './entities/usage'
+import { UserProps } from './entities/user'
 
 export type ClientAPI = ReturnType<typeof createClientApi>
 
@@ -150,8 +152,8 @@ export default function createClientApi({ http }: { http: AxiosInstance }) {
      * .catch(console.error)
      * ```
      */
-    getCurrentUser: function getCurrentUser() {
-      return endpoints.user.getCurrent(http).then((data) => wrapUser(http, data))
+    getCurrentUser: function getCurrentUser<T = UserProps>(params?: QueryParams) {
+      return endpoints.user.getCurrent<T>(http, params).then((data) => wrapUser(http, data))
     },
     /**
      * Creates a personal access token

--- a/lib/entities/user.ts
+++ b/lib/entities/user.ts
@@ -58,7 +58,7 @@ export interface User extends UserProps, DefaultElements<UserProps> {}
  * @param data - Raw data
  * @return Normalized user
  */
-export function wrapUser(http: AxiosInstance, data: UserProps): User {
+export function wrapUser<T = UserProps>(http: AxiosInstance, data: T) {
   const user = toPlainObject(copy(data))
   const userWithMethods = enhanceWithMethods(user, {})
   return freezeSys(userWithMethods)

--- a/lib/plain/endpoints/user.ts
+++ b/lib/plain/endpoints/user.ts
@@ -7,7 +7,8 @@ export const getForSpace = (http: AxiosInstance, params: GetSpaceParams & { user
   return raw.get<UserProps>(http, `/spaces/${params.spaceId}/users/${params.userId}`)
 }
 
-export const getCurrent = (http: AxiosInstance) => raw.get<UserProps>(http, `/users/me`)
+export const getCurrent = <T = UserProps>(http: AxiosInstance, params?: QueryParams) =>
+  raw.get<T>(http, `/users/me`, { params: params?.query })
 
 export const getManyForSpace = (http: AxiosInstance, params: GetSpaceParams & QueryParams) => {
   return raw.get<CollectionProp<UserProps>>(http, `/spaces/${params.spaceId}/users`, {

--- a/test/unit/create-contentful-api-test.js
+++ b/test/unit/create-contentful-api-test.js
@@ -167,6 +167,14 @@ describe('A createContentfulApi', () => {
         methodToTest: 'getCurrentUser',
       })
     })
+
+    test('API call getCurrentUser with extra params', async () => {
+      const { api, httpMock, entitiesMock } = setup(Promise.resolve({ data: userMock }))
+      entitiesMock.user.wrapUser.returns(userMock)
+
+      await api.getCurrentUser({ query: { foo: 'bar' } })
+      expect(httpMock.get.args[0][1].params).to.eql({ foo: 'bar' })
+    })
   })
 
   describe('with personal-access-token api', () => {


### PR DESCRIPTION
## Summary

Allow for query parameters to be passed to `/users/me` path to fetch additional fields

## Description

Currently the `getCurrentUser()` method does not accept additional params, meaning certain fields aren't returned by the API. This allows for query params to be passed, plus overriding the returned type

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation
