### PR TITLE
feat: optional params for user.getCurrent()

### DIFF
--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -65,7 +65,9 @@ export const createPlainClient = (params: ClientParams, defaults?: DefaultParams
     user: {
       getManyForSpace: wrap(wrapParams, endpoints.user.getManyForSpace),
       getForSpace: wrap(wrapParams, endpoints.user.getForSpace),
-      getCurrent: wrapHttp(http, endpoints.user.getCurrent),
+      getCurrent: (...args: RestParamsType<typeof endpoints.user.getCurrent>) => {
+        return endpoints.user.getCurrent(http, ...args)
+      },
       getForOrganization: wrap(wrapParams, endpoints.user.getForOrganization),
       getManyForOrganization: wrap(wrapParams, endpoints.user.getManyForOrganization),
     },


### PR DESCRIPTION
## Summary

I have noticed that optional params that were added to uset.getCurrent() weren't exposed and typed.
In this PR we fix that

## Description

I was  not able to use wrap() wrapper because that would add unnecessary default params, which aren't supported by the getCurrent() function.
I was not able to use werapHttp() because it didn't support any params, and adjusting it wasn't possible due to genric types, so I ended up with a custom wrapping types

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
