### PR TITLE
feat: add optional headers param to entry/asset GET

### DIFF
--- a/lib/plain/endpoints/asset.ts
+++ b/lib/plain/endpoints/asset.ts
@@ -16,13 +16,15 @@ import { QueryParams, CollectionProp, GetSpaceEnvironmentParams } from './common
 
 export const get = (
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { assetId: string } & QueryParams
+  params: GetSpaceEnvironmentParams & { assetId: string } & QueryParams,
+  headers?: Record<string, unknown>
 ) => {
   return raw.get<AssetProps>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/assets/${params.assetId}`,
     {
       params: normalizeSelect(params.query),
+      headers,
     }
   )
 }

--- a/lib/plain/endpoints/entry.ts
+++ b/lib/plain/endpoints/entry.ts
@@ -7,13 +7,15 @@ import { QueryParams, CollectionProp, KeyValueMap, GetSpaceEnvironmentParams } f
 
 export const get = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { entryId: string } & QueryParams
+  params: GetSpaceEnvironmentParams & { entryId: string } & QueryParams,
+  headers?: Record<string, unknown>
 ) => {
   return raw.get<EntryProps<T>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}`,
     {
       params: normalizeSelect(params.query),
+      headers,
     }
   )
 }


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

This PR adds the optional `headers` parameter to the entry and asset GET endpoints. 

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

This is required for requests made from clients still using ShareJS.

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
