### PR TITLE
test: add tests for new adapter architecture

### DIFF
--- a/lib/adapters/REST/endpoints/raw.ts
+++ b/lib/adapters/REST/endpoints/raw.ts
@@ -53,8 +53,11 @@ export function del<T = any>(http: AxiosInstance, url: string, config?: AxiosReq
     .then((response) => response.data, errorHandler)
 }
 
-// TODO: this is broken
-export function http<T = any>(http: AxiosInstance, url: string, config?: AxiosRequestConfig) {
+export function http<T = any>(
+  http: AxiosInstance,
+  url: string,
+  config?: Omit<AxiosRequestConfig, 'url'>
+) {
   return http(url, {
     baseURL: getBaseUrl(http),
     ...config,

--- a/lib/adapters/REST/rest-adapter.ts
+++ b/lib/adapters/REST/rest-adapter.ts
@@ -1,7 +1,6 @@
 import axios from 'axios'
 import { AxiosInstance, createHttpClient, CreateHttpClientParams } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import { omit } from 'lodash'
 import { Adapter, MakeRequestOptions } from '../../common-types'
 import endpoints from './endpoints'
 

--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -32,7 +32,7 @@ interface UserAgentParams {
   feature?: string
 }
 
-export type ClientParams = RestAdapterParams & AdapterParams & UserAgentParams
+export type ClientParams = (RestAdapterParams | AdapterParams) & UserAgentParams
 
 /**
  * Create a client instance

--- a/lib/create-adapter.ts
+++ b/lib/create-adapter.ts
@@ -13,8 +13,8 @@ export type AdapterParams = {
 /**
  * @private
  */
-export function createAdapter(params: RestAdapterParams & AdapterParams): Adapter {
-  if (params.apiAdapter) {
+export function createAdapter(params: RestAdapterParams | AdapterParams): Adapter {
+  if ('apiAdapter' in params) {
     return params.apiAdapter
   } else {
     return new RestAdapter(params)

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -344,12 +344,12 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    rawRequest: function rawRequest(opts: AxiosRequestConfig & { url: string }) {
+    rawRequest: function rawRequest({ url, ...config }: AxiosRequestConfig & { url: string }) {
       return makeRequest({
         entityType: 'Http',
         action: 'request',
-        params: { url: opts.url, config: opts },
-      }).then((response) => response.data, errorHandler)
+        params: { url, config },
+      })
     },
   }
 }

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -7,7 +7,6 @@ import { CreatePersonalAccessTokenProps } from './entities/personal-access-token
 import { Space, SpaceProps } from './entities/space'
 import { UsageQuery } from './entities/usage'
 import { UserProps } from './entities/user'
-import errorHandler from './error-handler'
 
 export type ClientAPI = ReturnType<typeof createClientApi>
 

--- a/test/unit/contentful-management-test.js
+++ b/test/unit/contentful-management-test.js
@@ -1,0 +1,84 @@
+import { describe, it, beforeEach, afterEach } from 'mocha'
+import { createClient, __Rewire__, __ResetDependency__ } from '../../lib/contentful-management'
+import sinon from 'sinon'
+import { expect } from 'chai'
+import { version } from '../../package.json'
+
+describe('Contentful Management', () => {
+  let createPlainClientMock
+  let createContentfulApiMock
+  let makeRequestMock
+
+  beforeEach(() => {
+    createPlainClientMock = sinon.stub()
+    __Rewire__('createPlainClient', createPlainClientMock)
+
+    createContentfulApiMock = sinon.stub()
+    __Rewire__('createContentfulApi', createContentfulApiMock)
+
+    makeRequestMock = sinon.stub()
+    __Rewire__('createAdapter', () => ({ makeRequest: makeRequestMock }))
+  })
+
+  afterEach(() => {
+    __ResetDependency__('createPlainClient')
+    __ResetDependency__('createContentfulApi')
+    __ResetDependency__('createAdapter')
+  })
+
+  it('creates nested client', () => {
+    createClient({ accessToken: 'token' })
+
+    expect(createPlainClientMock.notCalled).to.be.ok
+    expect(createContentfulApiMock.called).to.be.ok
+  })
+
+  it('creates plain client', () => {
+    createClient({ accessToken: 'token' }, { type: 'plain' })
+
+    expect(createPlainClientMock.called).to.be.ok
+    expect(createContentfulApiMock.notCalled).to.be.ok
+  })
+
+  it('generates the correct default user agent', () => {
+    createClient({ accessToken: 'token' })
+
+    expect(makeRequestMock.notCalled).to.be.ok
+
+    const makeRequestWithUserAgent = createContentfulApiMock.args[0][0]
+    makeRequestWithUserAgent()
+
+    expect(makeRequestMock.called).to.be.ok
+
+    const userAgent = makeRequestMock.args[0][0].userAgent
+    const userAgentParts = userAgent.split('; ')
+    expect(userAgentParts).to.have.lengthOf(3)
+    expect(userAgentParts[0]).to.match(/^sdk contentful-management\.js\/.+/)
+    expect(userAgentParts[1]).to.match(/^platform (.+\/.+|browser)/)
+    expect(userAgentParts[2]).to.match(/^os .+/)
+  })
+
+  it('generates the correct user agent', () => {
+    createClient({
+      accessToken: 'token',
+      application: 'myApplication/1.1.1',
+      integration: 'myIntegration/1.0.0',
+      feature: 'some-feature',
+    })
+
+    expect(makeRequestMock.notCalled).to.be.ok
+
+    const makeRequestWithUserAgent = createContentfulApiMock.args[0][0]
+    makeRequestWithUserAgent()
+
+    expect(makeRequestMock.called).to.be.ok
+
+    const userAgent = makeRequestMock.args[0][0].userAgent
+    const userAgentParts = userAgent.split('; ')
+    expect(userAgentParts).to.have.lengthOf(6)
+    expect(userAgentParts[0]).to.eq('app myApplication/1.1.1')
+    expect(userAgentParts[1]).to.eq('integration myIntegration/1.0.0')
+    expect(userAgentParts[2]).to.eq('feature some-feature')
+    expect(userAgentParts[3]).to.eq(`sdk contentful-management.js/${version}`)
+  })
+})

--- a/test/unit/create-adapter-test.js
+++ b/test/unit/create-adapter-test.js
@@ -1,0 +1,37 @@
+import { expect } from 'chai'
+import { describe, it, beforeEach, afterEach } from 'mocha'
+import { RestAdapter } from '../../lib/adapters/REST/rest-adapter'
+import { createAdapter, __Rewire__, __ResetDependency__ } from '../../lib/create-adapter'
+import sinon from 'sinon'
+
+describe('createAdapter', () => {
+  it('returns adapter if provided', () => {
+    const apiAdapter = new RestAdapter({ accessToken: 'token' })
+
+    const createdAdapter = createAdapter({
+      apiAdapter,
+    })
+
+    expect(createdAdapter).to.eq(apiAdapter)
+  })
+
+  describe('creates RestAdapter', () => {
+    const fakeAdapter = { makeRequest: sinon.stub() }
+    let restAdapterConstructorMock = sinon.stub().returns(fakeAdapter)
+
+    beforeEach(() => {
+      __Rewire__('RestAdapter', restAdapterConstructorMock)
+    })
+
+    afterEach(() => {
+      __ResetDependency__('RestAdapter')
+    })
+
+    it('if no apiAdapter is provided', () => {
+      const createdAdapter = createAdapter({ accessToken: 'token' })
+
+      expect(restAdapterConstructorMock.called).to.be.ok
+      expect(createdAdapter).to.eq(fakeAdapter)
+    })
+  })
+})

--- a/test/unit/create-contentful-api-test.js
+++ b/test/unit/create-contentful-api-test.js
@@ -224,11 +224,7 @@ describe('A createContentfulApi', () => {
 
   describe('with raw api', () => {
     test('API call rawRequest', async () => {
-      const makeRequest = sinon.stub().resolves({
-        data: {
-          response: true,
-        },
-      })
+      const makeRequest = sinon.stub().resolves({ response: true })
 
       const api = createContentfulApi(makeRequest)
 
@@ -243,7 +239,6 @@ describe('A createContentfulApi', () => {
       expect(makeRequest.args[0][0].params).to.eql({
         url: 'url',
         config: {
-          url: 'url',
           opts: true,
         },
       })


### PR DESCRIPTION
Add tests for `createClient` & `createAdapter`.
Also, this PR fixes an issue when using `client.rawRequest`.