### PR TITLE
feat(AppUpload): support AppUpload entity [EXT-2641]

### DIFF
--- a/lib/adapters/REST/endpoints/app-definition.ts
+++ b/lib/adapters/REST/endpoints/app-definition.ts
@@ -41,7 +41,7 @@ export const create: RestEndpoint<'AppDefinition', 'create'> = (
   return raw.post<AppDefinitionProps>(http, getBaseUrl(params), data)
 }
 
-export const update: RestEndpoint<'AppDefinition', 'update'> = async (
+export const update: RestEndpoint<'AppDefinition', 'update'> = (
   http: AxiosInstance,
   params: GetAppDefinitionParams,
   rawData: AppDefinitionProps,

--- a/lib/adapters/REST/endpoints/app-upload.ts
+++ b/lib/adapters/REST/endpoints/app-upload.ts
@@ -30,7 +30,7 @@ export const del: RestEndpoint<'AppUpload', 'delete'> = (
   return raw.del<void>(httpUpload, getAppUploadUrl(params))
 }
 
-export const create: RestEndpoint<'AppUpload', 'create'> = async (
+export const create: RestEndpoint<'AppUpload', 'create'> = (
   http: AxiosInstance,
   params: GetOrganizationParams,
   payload: { file: string | ArrayBuffer | Stream }
@@ -38,10 +38,6 @@ export const create: RestEndpoint<'AppUpload', 'create'> = async (
   const httpUpload = getUploadHttpClient(http)
 
   const { file } = payload
-
-  if (!file) {
-    return Promise.reject(new Error('Unable to locate a file to upload.'))
-  }
 
   return raw.post<AppUploadProps>(httpUpload, getBaseUrl(params), file, {
     headers: {

--- a/lib/adapters/REST/endpoints/app-upload.ts
+++ b/lib/adapters/REST/endpoints/app-upload.ts
@@ -3,15 +3,27 @@ import * as raw from './raw'
 import { GetAppUploadParams, GetOrganizationParams } from '../../../common-types'
 import { RestEndpoint } from '../types'
 import { AppUploadProps } from '../../../entities/app-upload'
+import { getUploadHttpClient } from '../../../upload-http-client'
 
 const getBaseUrl = (params: GetOrganizationParams) =>
   `/organizations/${params.organizationId}/app_uploads`
 
-const getAppUploadUrl = (params: GetAppUploadParams) => getBaseUrl(params) + `${params.uploadId}`
+const getAppUploadUrl = (params: GetAppUploadParams) => getBaseUrl(params) + `/${params.uploadId}`
 
 export const get: RestEndpoint<'AppUpload', 'get'> = (
   http: AxiosInstance,
   params: GetAppUploadParams
 ) => {
-  return raw.get<AppUploadProps>(http, getAppUploadUrl(params))
+  const httpUpload = getUploadHttpClient(http)
+
+  return raw.get<AppUploadProps>(httpUpload, getAppUploadUrl(params))
+}
+
+export const del: RestEndpoint<'AppUpload', 'delete'> = (
+  http: AxiosInstance,
+  params: GetAppUploadParams
+) => {
+  const httpUpload = getUploadHttpClient(http)
+
+  return raw.del<void>(httpUpload, getAppUploadUrl(params))
 }

--- a/lib/adapters/REST/endpoints/app-upload.ts
+++ b/lib/adapters/REST/endpoints/app-upload.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import fs from 'fs'
+import { Stream } from 'stream'
 import * as raw from './raw'
 import { GetAppUploadParams, GetOrganizationParams } from '../../../common-types'
 import { RestEndpoint } from '../types'
@@ -9,7 +9,8 @@ import { getUploadHttpClient } from '../../../upload-http-client'
 const getBaseUrl = (params: GetOrganizationParams) =>
   `/organizations/${params.organizationId}/app_uploads`
 
-const getAppUploadUrl = (params: GetAppUploadParams) => getBaseUrl(params) + `/${params.uploadId}`
+const getAppUploadUrl = (params: GetAppUploadParams) =>
+  `${getBaseUrl(params)}/${params.appUploadId}`
 
 export const get: RestEndpoint<'AppUpload', 'get'> = (
   http: AxiosInstance,
@@ -32,27 +33,17 @@ export const del: RestEndpoint<'AppUpload', 'delete'> = (
 export const create: RestEndpoint<'AppUpload', 'create'> = async (
   http: AxiosInstance,
   params: GetOrganizationParams,
-  data: { file: File }
+  payload: { file: string | ArrayBuffer | Stream }
 ) => {
   const httpUpload = getUploadHttpClient(http)
 
-  const { file } = data
+  const { file } = payload
 
   if (!file) {
     return Promise.reject(new Error('Unable to locate a file to upload.'))
   }
 
-  const data = fs.readFileSync(file)
-
-  const binary: string | ArrayBuffer | null = await new Promise((res) => {
-    const reader = new FileReader()
-    reader.onload = () => {
-      res(reader.result)
-    }
-    reader.readAsArrayBuffer(file)
-  })
-
-  return raw.post<AppUploadProps>(httpUpload, getBaseUrl(params), binary, {
+  return raw.post<AppUploadProps>(httpUpload, getBaseUrl(params), file, {
     headers: {
       'Content-Type': 'application/octet-stream',
     },

--- a/lib/adapters/REST/endpoints/app-upload.ts
+++ b/lib/adapters/REST/endpoints/app-upload.ts
@@ -1,0 +1,17 @@
+import type { AxiosInstance } from 'contentful-sdk-core'
+import * as raw from './raw'
+import { GetAppUploadParams, GetOrganizationParams } from '../../../common-types'
+import { RestEndpoint } from '../types'
+import { AppUploadProps } from '../../../entities/app-upload'
+
+const getBaseUrl = (params: GetOrganizationParams) =>
+  `/organizations/${params.organizationId}/app_uploads`
+
+const getAppUploadUrl = (params: GetAppUploadParams) => getBaseUrl(params) + `${params.uploadId}`
+
+export const get: RestEndpoint<'AppUpload', 'get'> = (
+  http: AxiosInstance,
+  params: GetAppUploadParams
+) => {
+  return raw.get<AppUploadProps>(http, getAppUploadUrl(params))
+}

--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -1,6 +1,7 @@
 import * as ApiKey from './api-key'
 import * as AppDefinition from './app-definition'
 import * as AppInstallation from './app-installation'
+import * as AppUpload from './app-upload'
 import * as Asset from './asset'
 import * as AssetKey from './asset-key'
 import * as ContentType from './content-type'
@@ -35,6 +36,7 @@ export default {
   ApiKey,
   AppDefinition,
   AppInstallation,
+  AppUpload,
   Asset,
   AssetKey,
   ContentType,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -203,6 +203,9 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Asset', 'processForAllLocales', UA>): MRReturn<'Asset', 'processForAllLocales'>
   (opts: MROpts<'Asset', 'processForLocale', UA>): MRReturn<'Asset', 'processForLocale'>
 
+  (opts: MROpts<'AppUpload', 'get', UA>): MRReturn<'AppUpload', 'get'>
+  (opts: MROpts<'AppUpload', 'delete', UA>): MRReturn<'AppUpload', 'delete'>
+
   (opts: MROpts<'AssetKey', 'create', UA>): MRReturn<'AssetKey', 'create'>
 
   (opts: MROpts<'ContentType', 'get', UA>): MRReturn<'ContentType', 'get'>
@@ -473,6 +476,10 @@ export type MRActions = {
     get: {
       params: GetAppUploadParams
       return: AppUploadProps
+    }
+    delete: {
+      params: GetAppUploadParams
+      return: void
     }
   }
   Asset: {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -205,6 +205,7 @@ type MRInternal<UA extends boolean> = {
 
   (opts: MROpts<'AppUpload', 'get', UA>): MRReturn<'AppUpload', 'get'>
   (opts: MROpts<'AppUpload', 'delete', UA>): MRReturn<'AppUpload', 'delete'>
+  (opts: MROpts<'AppUpload', 'create', UA>): MRReturn<'AppUpload', 'create'>
 
   (opts: MROpts<'AssetKey', 'create', UA>): MRReturn<'AssetKey', 'create'>
 
@@ -480,6 +481,11 @@ export type MRActions = {
     delete: {
       params: GetAppUploadParams
       return: void
+    }
+    create: {
+      params: GetOrganizationParams
+      payload: { file: File }
+      return: AppUploadProps
     }
   }
   Asset: {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -50,6 +50,7 @@ import {
   WebhookProps,
 } from './entities/webhook'
 import { AssetKeyProps, CreateAssetKeyProps } from './entities/asset-key'
+import { AppUploadProps } from './entities/app-upload'
 
 export interface DefaultElements<TPlainObject extends object = object> {
   toPlainObject(): TPlainObject
@@ -467,6 +468,12 @@ export type MRActions = {
       return: AppInstallationProps
     }
     delete: { params: GetAppInstallationParams; return: any }
+  }
+  AppUpload: {
+    get: {
+      params: GetAppUploadParams
+      return: AppUploadProps
+    }
   }
   Asset: {
     getMany: { params: GetSpaceEnvironmentParams & QueryParams; return: CollectionProp<AssetProps> }
@@ -1041,6 +1048,7 @@ export type GetWebhookParams = GetSpaceParams & { webhookDefinitionId: string }
 export type GetOrganizationMembershipProps = GetOrganizationParams & {
   organizationMembershipId: string
 }
+export type GetAppUploadParams = GetOrganizationParams & { uploadId: string }
 
 export type QueryParams = { query?: QueryOptions }
 export type PaginationQueryParams = { query?: PaginationQueryOptions }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -484,7 +484,7 @@ export type MRActions = {
     }
     create: {
       params: GetOrganizationParams
-      payload: { file: File }
+      payload: { file: string | ArrayBuffer | Stream }
       return: AppUploadProps
     }
   }
@@ -1061,7 +1061,7 @@ export type GetWebhookParams = GetSpaceParams & { webhookDefinitionId: string }
 export type GetOrganizationMembershipProps = GetOrganizationParams & {
   organizationMembershipId: string
 }
-export type GetAppUploadParams = GetOrganizationParams & { uploadId: string }
+export type GetAppUploadParams = GetOrganizationParams & { appUploadId: string }
 
 export type QueryParams = { query?: QueryOptions }
 export type PaginationQueryParams = { query?: PaginationQueryOptions }

--- a/lib/create-organization-api.ts
+++ b/lib/create-organization-api.ts
@@ -578,6 +578,21 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
       }).then((data) => wrapAppUpload(makeRequest, data))
     },
 
+    /**
+     * Creates an app upload
+     * @return Promise for an App Upload
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.createAppUpload('some_zip_file'))
+     * .then((appUpload) => console.log(appUpload))
+     * .catch(console.error)
+     * ```
+     */
     createAppUpload(file: string | ArrayBuffer | Stream) {
       const raw = this.toPlainObject() as OrganizationProp
 
@@ -585,7 +600,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
         entityType: 'AppUpload',
         action: 'create',
         params: { organizationId: raw.sys.id },
-        payload: file,
+        payload: { file },
       }).then((data) => wrapAppUpload(makeRequest, data))
     },
   }

--- a/lib/create-organization-api.ts
+++ b/lib/create-organization-api.ts
@@ -1,5 +1,6 @@
 import { createRequestConfig } from 'contentful-sdk-core'
 import entities from './entities'
+import { Stream } from 'stream'
 import { CreateTeamMembershipProps } from './entities/team-membership'
 import { CreateTeamProps } from './entities/team'
 import { CreateOrganizationInvitationProps } from './entities/organization-invitation'
@@ -29,6 +30,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
   const { wrapTeam, wrapTeamCollection } = entities.team
   const { wrapSpaceMembership, wrapSpaceMembershipCollection } = entities.spaceMembership
   const { wrapOrganizationInvitation } = entities.organizationInvitation
+  const { wrapAppUpload } = entities.appUpload
 
   return {
     /**
@@ -549,6 +551,42 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
         action: 'get',
         params: { organizationId: raw.sys.id, appDefinitionId: id },
       }).then((data) => wrapAppDefinition(makeRequest, data))
+    },
+
+    /**
+     * Gets an app upload
+     * @return Promise for an App Upload
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppUpload('<app_upload_id>'))
+     * .then((appUpload) => console.log(appUpload))
+     * .catch(console.error)
+     * ```
+     */
+    getAppUpload(appUploadId: string) {
+      const raw = this.toPlainObject() as OrganizationProp
+
+      return makeRequest({
+        entityType: 'AppUpload',
+        action: 'get',
+        params: { organizationId: raw.sys.id, appUploadId },
+      }).then((data) => wrapAppUpload(makeRequest, data))
+    },
+
+    createAppUpload(file: string | ArrayBuffer | Stream) {
+      const raw = this.toPlainObject() as OrganizationProp
+
+      return makeRequest({
+        entityType: 'AppUpload',
+        action: 'create',
+        params: { organizationId: raw.sys.id },
+        payload: file,
+      }).then((data) => wrapAppUpload(makeRequest, data))
     },
   }
 }

--- a/lib/entities/app-upload.ts
+++ b/lib/entities/app-upload.ts
@@ -1,5 +1,9 @@
+import { freezeSys, toPlainObject } from 'contentful-sdk-core'
+import copy from 'fast-copy'
 import { Except } from 'type-fest'
-import { BasicMetaSysProps, SysLink } from '../common-types'
+import { BasicMetaSysProps, SysLink, DefaultElements, MakeRequest } from '../common-types'
+import { wrapCollection } from '../common-utils'
+import enhanceWithMethods from '../enhance-with-methods'
 
 type AppUploadSys = Except<BasicMetaSysProps, 'version'>
 
@@ -9,3 +13,63 @@ export type AppUploadProps = {
     organization: SysLink
   }
 }
+
+export interface AppUpload extends AppUploadProps, DefaultElements<AppUploadProps> {
+  /**
+   * Deletes this object on the server.
+   * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
+   * @example ```javascript
+   * const contentful = require('contentful-management')
+   *
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
+   *
+   * client.getOrganization('<org_id>')
+   * .then((org) => org.getAppUpload('<app_upload_id>'))
+   * .then((appUpload) => appUpload.delete())
+   * .then(() => console.log(`App Upload deleted.`))
+   * .catch(console.error)
+   * ```
+   */
+  delete(): Promise<void>
+}
+
+function createAppUploadApi(makeRequest: MakeRequest) {
+  const getParams = (data: AppUploadProps) => ({
+    organizationId: data.sys.organization.sys.id,
+    appUploadId: data.sys.id,
+  })
+
+  return {
+    delete: function del() {
+      const data = this.toPlainObject() as AppUploadProps
+      return makeRequest({
+        entityType: 'AppUpload',
+        action: 'delete',
+        params: getParams(data),
+      })
+    },
+  }
+}
+
+/**
+ * @private
+ * @param makeRequest - function to make requests via an adapter
+ * @param data - Raw App Upload data
+ * @return Wrapped App Upload data
+ */
+export function wrapAppUpload(makeRequest: MakeRequest, data: AppUploadProps): AppUpload {
+  const appUpload = toPlainObject(copy(data))
+  const appUploadWithMethods = enhanceWithMethods(appUpload, createAppUploadApi(makeRequest))
+
+  return freezeSys(appUploadWithMethods)
+}
+
+/**
+ * @private
+ * @param makeRequest - function to make requests via an adapter
+ * @param data - Raw App Upload collection data
+ * @return Wrapped App Upload collection data
+ */
+export const wrapAppUploadCollection = wrapCollection(wrapAppUpload)

--- a/lib/entities/app-upload.ts
+++ b/lib/entities/app-upload.ts
@@ -1,0 +1,11 @@
+import { Except } from 'type-fest'
+import { BasicMetaSysProps, SysLink } from '../common-types'
+
+type AppUploadSys = Except<BasicMetaSysProps, 'version'>
+
+export type AppUploadProps = {
+  sys: AppUploadSys & {
+    expiresAt: string
+    organization: SysLink
+  }
+}

--- a/lib/entities/index.ts
+++ b/lib/entities/index.ts
@@ -1,6 +1,7 @@
 import * as apiKey from './api-key'
 import * as appDefinition from './app-definition'
 import * as appInstallation from './app-installation'
+import * as appUpload from './app-upload'
 import * as asset from './asset'
 import * as assetKey from './asset-key'
 import * as contentType from './content-type'
@@ -34,6 +35,7 @@ export default {
   apiKey,
   appDefinition,
   appInstallation,
+  appUpload,
   asset,
   assetKey,
   contentType,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -1,6 +1,7 @@
 export * from './common-types'
 
 export type { ApiKey, ApiKeyProps, CreateApiKeyProps } from './entities/api-key'
+export type { AppUploadProps, AppUpload } from './entities/app-upload'
 export type {
   AppDefinition,
   AppDefinitionProps,

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -280,7 +280,7 @@ export type PlainClientAPI = {
     delete(params: OptionalDefaults<GetAppUploadParams>): Promise<void>
     create(
       params: OptionalDefaults<GetOrganizationParams>,
-      data: { file: File }
+      data: { file: string | ArrayBuffer | Stream }
     ): Promise<AppUploadProps>
   }
   assetKey: {

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -280,7 +280,7 @@ export type PlainClientAPI = {
     delete(params: OptionalDefaults<GetAppUploadParams>): Promise<void>
     create(
       params: OptionalDefaults<GetOrganizationParams>,
-      data: { file: string | ArrayBuffer | Stream }
+      payload: { file: string | ArrayBuffer | Stream }
     ): Promise<AppUploadProps>
   }
   assetKey: {

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -277,6 +277,7 @@ export type PlainClientAPI = {
   }
   appUpload: {
     get(params: OptionalDefaults<GetAppUploadParams>): Promise<AppUploadProps>
+    delete(params: OptionalDefaults<GetAppUploadParams>): Promise<void>
   }
   assetKey: {
     create(

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -24,6 +24,7 @@ import {
   KeyValueMap,
   PaginationQueryParams,
   QueryParams,
+  GetAppUploadParams,
 } from '../common-types'
 import { ApiKeyProps, CreateApiKeyProps } from '../entities/api-key'
 import { AppDefinitionProps, CreateAppDefinitionProps } from '../entities/app-definition'
@@ -76,6 +77,7 @@ import {
 } from '../entities/webhook'
 import { DefaultParams, OptionalDefaults } from './wrappers/wrap'
 import { AssetKeyProps, CreateAssetKeyProps } from '../entities/asset-key'
+import { AppUploadProps } from '../entities/app-upload'
 
 export type PlainClientAPI = {
   raw: {
@@ -272,6 +274,9 @@ export type PlainClientAPI = {
       locale: string,
       processingOptions?: AssetProcessingForLocale
     ): Promise<AssetProps>
+  }
+  appUpload: {
+    get(params: OptionalDefaults<GetAppUploadParams>): Promise<AppUploadProps>
   }
   assetKey: {
     create(

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -278,6 +278,10 @@ export type PlainClientAPI = {
   appUpload: {
     get(params: OptionalDefaults<GetAppUploadParams>): Promise<AppUploadProps>
     delete(params: OptionalDefaults<GetAppUploadParams>): Promise<void>
+    create(
+      params: OptionalDefaults<GetOrganizationParams>,
+      data: { file: File }
+    ): Promise<AppUploadProps>
   }
   assetKey: {
     create(

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -143,6 +143,7 @@ export const createPlainClient = (
     },
     appUpload: {
       get: wrap(wrapParams, 'AppUpload', 'get'),
+      delete: wrap(wrapParams, 'AppUpload', 'delete'),
     },
     assetKey: {
       create: wrap(wrapParams, 'AssetKey', 'create'),

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -141,6 +141,9 @@ export const createPlainClient = (
           },
         }),
     },
+    appUpload: {
+      get: wrap(wrapParams, 'AppUpload', 'get'),
+    },
     assetKey: {
       create: wrap(wrapParams, 'AssetKey', 'create'),
     },

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -144,6 +144,7 @@ export const createPlainClient = (
     appUpload: {
       get: wrap(wrapParams, 'AppUpload', 'get'),
       delete: wrap(wrapParams, 'AppUpload', 'delete'),
+      create: wrap(wrapParams, 'AppUpload', 'create'),
     },
     assetKey: {
       create: wrap(wrapParams, 'AssetKey', 'create'),

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "npm run test:cover-unit && npm run test:cover-integration && npm run test:size",
     "test:cover-unit": "./node_modules/.bin/nyc --reporter=lcov --reporter=text --report-dir=coverage/unit npm run test:unit",
     "test:cover-integration": "./node_modules/.bin/nyc --reporter=lcov --reporter=text --report-dir=coverage/integration npm run test:integration",
-    "test:unit": "BABEL_ENV=test babel-node --extensions .ts --extensions .js ./node_modules/.bin/mocha './test/unit/**/app-upload-test.js' --config mocharc.js --require @babel/register",
+    "test:unit": "BABEL_ENV=test babel-node --extensions .ts --extensions .js ./node_modules/.bin/mocha './test/unit/**/*-test.js' --config mocharc.js --require @babel/register",
     "test:unit-watch": "BABEL_ENV=test babel-node --extensions .ts --extensions .js ./node_modules/.bin/mocha './test/unit/**/*-test.js' --config mocharc.js --watch --require @babel/register",
     "test:integration": "BABEL_ENV=test babel-node --extensions .ts --extensions .js ./node_modules/.bin/mocha './test/integration/*.js' --config mocharc.js --require @babel/register",
     "test:integration-watch": "BABEL_ENV=test babel-node --extensions .ts --extensions .js ./node_modules/.bin/mocha './test/integration/*.js' --config mocharc.js --watch --require @babel/register",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "npm run test:cover-unit && npm run test:cover-integration && npm run test:size",
     "test:cover-unit": "./node_modules/.bin/nyc --reporter=lcov --reporter=text --report-dir=coverage/unit npm run test:unit",
     "test:cover-integration": "./node_modules/.bin/nyc --reporter=lcov --reporter=text --report-dir=coverage/integration npm run test:integration",
-    "test:unit": "BABEL_ENV=test babel-node --extensions .ts --extensions .js ./node_modules/.bin/mocha './test/unit/**/*-test.js' --config mocharc.js --require @babel/register",
+    "test:unit": "BABEL_ENV=test babel-node --extensions .ts --extensions .js ./node_modules/.bin/mocha './test/unit/**/app-upload-test.js' --config mocharc.js --require @babel/register",
     "test:unit-watch": "BABEL_ENV=test babel-node --extensions .ts --extensions .js ./node_modules/.bin/mocha './test/unit/**/*-test.js' --config mocharc.js --watch --require @babel/register",
     "test:integration": "BABEL_ENV=test babel-node --extensions .ts --extensions .js ./node_modules/.bin/mocha './test/integration/*.js' --config mocharc.js --require @babel/register",
     "test:integration-watch": "BABEL_ENV=test babel-node --extensions .ts --extensions .js ./node_modules/.bin/mocha './test/integration/*.js' --config mocharc.js --watch --require @babel/register",

--- a/test/unit/create-organization-api-test.js
+++ b/test/unit/create-organization-api-test.js
@@ -2,17 +2,18 @@ import createOrganizationApi, {
   __RewireAPI__ as createOrganizationApiRewireApi,
 } from '../../lib/create-organization-api'
 import {
-  cloneMock,
   appDefinitionMock,
+  appUploadMock,
+  cloneMock,
+  organizationInvitationMock,
   organizationMembershipMock,
+  organizationMock,
+  setupEntitiesMock,
   spaceMembershipMock,
   teamMembershipMock,
-  teamSpaceMembershipMock,
-  setupEntitiesMock,
-  organizationInvitationMock,
   teamMock,
+  teamSpaceMembershipMock,
   userMock,
-  organizationMock,
 } from './mocks/entities'
 import {
   makeGetEntityTest,
@@ -385,5 +386,45 @@ describe('A createOrganizationApi', () => {
         items: [teamSpaceMembershipMock],
       })
     })
+  })
+
+  test('API call getAppUpload', async () => {
+    const { api, entitiesMock } = setup(Promise.resolve({}))
+    entitiesMock['appUpload']['wrapAppUpload'].returns(appUploadMock)
+    return api['getAppUpload']('upload-id').then((result) => {
+      expect(result).eql(appUploadMock)
+    })
+  })
+
+  test('API call getAppUpload fails', async () => {
+    const error = cloneMock('error')
+    const { api } = setup(Promise.reject(error))
+
+    api['getAppUpload']('app-upload-id').then(
+      () => {},
+      (errorResponse) => {
+        expect(errorResponse).eql(error)
+      }
+    )
+  })
+
+  test('API call createAppUpload', async () => {
+    const { api, entitiesMock } = setup(Promise.resolve({}))
+    entitiesMock['appUpload']['wrapAppUpload'].returns(appUploadMock)
+    return api['createAppUpload']('content-of-zip-file').then((result) => {
+      expect(result).eql(appUploadMock)
+    })
+  })
+
+  test('API call createAppUpload fails', async () => {
+    const error = cloneMock('error')
+    const { api } = setup(Promise.reject(error))
+
+    api['createAppUpload']('content-of-zip-file').then(
+      () => {},
+      (errorResponse) => {
+        expect(errorResponse).eql(error)
+      }
+    )
   })
 })

--- a/test/unit/entities/app-upload-test.js
+++ b/test/unit/entities/app-upload-test.js
@@ -1,0 +1,38 @@
+import { wrapAppUpload, wrapAppUploadCollection } from '../../../lib/entities/app-upload'
+import setupMakeRequest from '../mocks/makeRequest'
+import { describe, test } from 'mocha'
+import {
+  entityCollectionWrappedTest,
+  entityWrappedTest,
+  failingActionTest,
+  entityDeleteTest,
+} from '../test-creators/instance-entity-methods'
+import { appUploadMock } from '../mocks/entities'
+
+function setup(promise) {
+  return {
+    makeRequest: setupMakeRequest(promise),
+    entityMock: appUploadMock,
+  }
+}
+
+describe('Entity AppUpload', () => {
+  test('AppUpload is wrapped', async () => {
+    return entityWrappedTest(setup, { wrapperMethod: wrapAppUpload })
+  })
+
+  test('AppUpload collection is wrapped', async () => {
+    return entityCollectionWrappedTest(setup, { wrapperMethod: wrapAppUploadCollection })
+  })
+
+  test('AppUpload delete', async () => {
+    return entityDeleteTest(setup, {
+      wrapperMethod: wrapAppUpload,
+      actionMethod: 'delete',
+    })
+  })
+
+  test('AppUpload delete fails', async () => {
+    return failingActionTest(setup, { wrapperMethod: wrapAppUpload, actionMethod: 'delete' })
+  })
+})

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -72,6 +72,13 @@ const appDefinitionMock = {
   ],
 }
 
+const appUploadMock = {
+  sys: Object.assign(cloneDeep(sysMock), {
+    type: 'AppUpload',
+    organization: { sys: { id: 'organization-id' } },
+  }),
+}
+
 const contentTypeMock = {
   sys: Object.assign(cloneDeep(sysMock), {
     type: 'ContentType',
@@ -452,6 +459,7 @@ export const scheduledActionCollectionMock = {
 const mocks = {
   link: linkMock,
   sys: sysMock,
+  appUpload: appUploadMock,
   contentType: contentTypeMock,
   editorInterface: editorInterfaceMock,
   entry: entryMock,
@@ -504,6 +512,10 @@ function setupEntitiesMock(rewiredModuleApi) {
     appDefinition: {
       wrapAppDefinition: sinon.stub(),
       wrapAppDefinitionCollection: sinon.stub(),
+    },
+    appUpload: {
+      wrapAppUpload: sinon.stub(),
+      wrapAppUploadCollection: sinon.stub(),
     },
     space: {
       wrapSpace: sinon.stub(),
@@ -626,6 +638,7 @@ function setupEntitiesMock(rewiredModuleApi) {
 export {
   appInstallationMock,
   appDefinitionMock,
+  appUploadMock,
   linkMock,
   sysMock,
   spaceMock,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
       "ClientParams",
 
       "ApiKey",
+      "AppUpload",
       "AppDefinition",
       "AppInstalation",
       "Asset",


### PR DESCRIPTION
## Summary

Introducing the `AppBundle` entity with the following methods:

- create
- get
- delete


## Description

Added the entity to the flat and nested client and exported all relevant types. Also adjusted the `Organziation` API to support the `AppUpload` entity for the nested client.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [x] The new method is added to the documentation
