### PR TITLE
fix: type issues in wrap.d.ts

### DIFF
--- a/lib/plain/wrappers/wrap.ts
+++ b/lib/plain/wrappers/wrap.ts
@@ -21,14 +21,14 @@ export type WrapParams = {
 export type WrapFn<
   ET extends keyof MRActions,
   Action extends keyof MRActions[ET],
-  Params = 'params' extends keyof MROpts<ET, Action, false>
-    ? MROpts<ET, Action, false>['params']
+  Params = 'params' extends keyof MRActions[ET][Action]
+    ? MRActions[ET][Action]['params']
     : undefined,
-  Payload = 'payload' extends keyof MROpts<ET, Action, false>
-    ? MROpts<ET, Action, false>['payload']
+  Payload = 'payload' extends keyof MRActions[ET][Action]
+    ? MRActions[ET][Action]['payload']
     : undefined,
-  Headers = 'headers' extends keyof MROpts<ET, Action, false>
-    ? MROpts<ET, Action, false>['headers']
+  Headers = 'headers' extends keyof MRActions[ET][Action]
+    ? MRActions[ET][Action]['headers']
     : undefined,
   Return = MRReturn<ET, Action>
 > = Params extends undefined


### PR DESCRIPTION
TypeScript generates very complicated typings for `wrap.ts`: https://unpkg.com/contentful-management@7.13.0/dist/typings/plain/wrappers/wrap.d.ts. These typings cause errors when using `contentful-management` in a TypeScript project as TypeScript cannot parse them (see #775).

I don't know what's the underlying issue of the problem.

This PR fixes the type errors by simplifying the type definition of `WrapFn`. The previous types were unnecessarily complex by using `MROpts`. The new types use `MRActions` directly which results in the same level of type safety but with a less complex output.

