### PR TITLE
feat(AppBundle): support AppBundle entity [EXT-2641]

### DIFF
--- a/lib/adapters/REST/endpoints/app-bundle.ts
+++ b/lib/adapters/REST/endpoints/app-bundle.ts
@@ -8,7 +8,7 @@ import {
   QueryParams,
 } from '../../../common-types'
 import { RestEndpoint } from '../types'
-import { AppBundleProps } from '../../../entities/app-bundle'
+import { AppBundleProps, CreateAppBundleProps } from '../../../entities/app-bundle'
 
 const getBaseUrl = (params: GetAppDefinitionParams) =>
   `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/app_bundles`
@@ -37,4 +37,21 @@ export const del: RestEndpoint<'AppBundle', 'delete'> = (
   params: GetAppBundleParams
 ) => {
   return raw.del<void>(http, getAppBundleUrl(params))
+}
+
+export const create = (
+  http: AxiosInstance,
+  params: GetAppDefinitionParams & { appUploadId: string }
+) => {
+  const payload: CreateAppBundleProps = {
+    upload: {
+      sys: {
+        type: 'Link',
+        linkType: 'AppUpload',
+        id: params.appUploadId,
+      },
+    },
+  }
+
+  return raw.post<AppBundleProps>(http, getBaseUrl(params), payload)
 }

--- a/lib/adapters/REST/endpoints/app-bundle.ts
+++ b/lib/adapters/REST/endpoints/app-bundle.ts
@@ -14,7 +14,7 @@ const getBaseUrl = (params: GetAppDefinitionParams) =>
   `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/app_bundles`
 
 const getAppBundleUrl = (params: GetAppBundleParams) =>
-  getBaseUrl(params) + `/${params.appBundleId}`
+  `${getBaseUrl(params)}/${params.appBundleId}`
 
 export const get: RestEndpoint<'AppBundle', 'get'> = (
   http: AxiosInstance,

--- a/lib/adapters/REST/endpoints/app-bundle.ts
+++ b/lib/adapters/REST/endpoints/app-bundle.ts
@@ -1,0 +1,40 @@
+import { AxiosInstance } from 'contentful-sdk-core'
+import * as raw from './raw'
+import { normalizeSelect } from './utils'
+import {
+  CollectionProp,
+  GetAppBundleParams,
+  GetAppDefinitionParams,
+  QueryParams,
+} from '../../../common-types'
+import { RestEndpoint } from '../types'
+import { AppBundleProps } from '../../../entities/app-bundle'
+
+const getBaseUrl = (params: GetAppDefinitionParams) =>
+  `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/app_bundles`
+
+const getAppBundleUrl = (params: GetAppBundleParams) =>
+  getBaseUrl(params) + `/${params.appBundleId}`
+
+export const get: RestEndpoint<'AppBundle', 'get'> = (
+  http: AxiosInstance,
+  params: GetAppBundleParams
+) => {
+  return raw.get<AppBundleProps>(http, getAppBundleUrl(params))
+}
+
+export const getMany: RestEndpoint<'AppBundle', 'getMany'> = (
+  http: AxiosInstance,
+  params: GetAppDefinitionParams & QueryParams
+) => {
+  return raw.get<CollectionProp<AppBundleProps>>(http, getBaseUrl(params), {
+    params: normalizeSelect(params.query),
+  })
+}
+
+export const del: RestEndpoint<'AppBundle', 'delete'> = (
+  http: AxiosInstance,
+  params: GetAppBundleParams
+) => {
+  return raw.del<void>(http, getAppBundleUrl(params))
+}

--- a/lib/adapters/REST/endpoints/app-bundle.ts
+++ b/lib/adapters/REST/endpoints/app-bundle.ts
@@ -42,11 +42,11 @@ export const del: RestEndpoint<'AppBundle', 'delete'> = (
 export const create = (
   http: AxiosInstance,
   params: GetAppDefinitionParams,
-  payload: { appUploadId: string; comment?: string }
+  payload: CreateAppBundleProps
 ) => {
   const { appUploadId, comment } = payload
 
-  const data: CreateAppBundleProps = {
+  const data = {
     upload: {
       sys: {
         type: 'Link',

--- a/lib/adapters/REST/endpoints/app-bundle.ts
+++ b/lib/adapters/REST/endpoints/app-bundle.ts
@@ -41,17 +41,21 @@ export const del: RestEndpoint<'AppBundle', 'delete'> = (
 
 export const create = (
   http: AxiosInstance,
-  params: GetAppDefinitionParams & { appUploadId: string }
+  params: GetAppDefinitionParams,
+  payload: { appUploadId: string; comment?: string }
 ) => {
-  const payload: CreateAppBundleProps = {
+  const { appUploadId, comment } = payload
+
+  const data: CreateAppBundleProps = {
     upload: {
       sys: {
         type: 'Link',
         linkType: 'AppUpload',
-        id: params.appUploadId,
+        id: appUploadId,
       },
     },
+    comment,
   }
 
-  return raw.post<AppBundleProps>(http, getBaseUrl(params), payload)
+  return raw.post<AppBundleProps>(http, getBaseUrl(params), data)
 }

--- a/lib/adapters/REST/endpoints/app-bundle.ts
+++ b/lib/adapters/REST/endpoints/app-bundle.ts
@@ -39,7 +39,7 @@ export const del: RestEndpoint<'AppBundle', 'delete'> = (
   return raw.del<void>(http, getAppBundleUrl(params))
 }
 
-export const create = (
+export const create: RestEndpoint<'AppBundle', 'create'> = (
   http: AxiosInstance,
   params: GetAppDefinitionParams,
   payload: CreateAppBundleProps

--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -1,4 +1,5 @@
 import * as ApiKey from './api-key'
+import * as AppBundle from './app-bundle'
 import * as AppDefinition from './app-definition'
 import * as AppInstallation from './app-installation'
 import * as Asset from './asset'
@@ -33,6 +34,7 @@ import * as Webhook from './webhook'
 
 export default {
   ApiKey,
+  AppBundle,
   AppDefinition,
   AppInstallation,
   Asset,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -417,7 +417,10 @@ export type MRActions = {
   }
   AppBundle: {
     get: { params: GetAppBundleParams; return: AppBundleProps }
-    getMany: { params: GetAppDefinitionParams; return: CollectionProp<AppBundleProps> }
+    getMany: {
+      params: GetAppDefinitionParams & QueryParams
+      return: CollectionProp<AppBundleProps>
+    }
     delete: { params: GetAppBundleParams; return: void }
     create: { params: GetAppBundleParams & { appUploadId: string }; return: AppBundleProps }
   }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -422,7 +422,11 @@ export type MRActions = {
       return: CollectionProp<AppBundleProps>
     }
     delete: { params: GetAppBundleParams; return: void }
-    create: { params: GetAppBundleParams & { appUploadId: string }; return: AppBundleProps }
+    create: {
+      params: GetAppDefinitionParams
+      payload: { appUploadId: string }
+      return: AppBundleProps
+    }
   }
   ApiKey: {
     get: { params: GetSpaceParams & { apiKeyId: string }; return: ApiKeyProps }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -174,6 +174,7 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'AppBundle', 'get', UA>): MRReturn<'AppBundle', 'get'>
   (opts: MROpts<'AppBundle', 'getMany', UA>): MRReturn<'AppBundle', 'getMany'>
   (opts: MROpts<'AppBundle', 'delete', UA>): MRReturn<'AppBundle', 'delete'>
+  (opts: MROpts<'AppBundle', 'create', UA>): MRReturn<'AppBundle', 'create'>
 
   (opts: MROpts<'ApiKey', 'get', UA>): MRReturn<'ApiKey', 'get'>
   (opts: MROpts<'ApiKey', 'getMany', UA>): MRReturn<'ApiKey', 'getMany'>
@@ -418,6 +419,7 @@ export type MRActions = {
     get: { params: GetAppBundleParams; return: AppBundleProps }
     getMany: { params: GetAppDefinitionParams; return: CollectionProp<AppBundleProps> }
     delete: { params: GetAppBundleParams; return: void }
+    create: { params: GetAppBundleParams & { appUploadId: string }; return: AppBundleProps }
   }
   ApiKey: {
     get: { params: GetSpaceParams & { apiKeyId: string }; return: ApiKeyProps }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -424,7 +424,7 @@ export type MRActions = {
     delete: { params: GetAppBundleParams; return: void }
     create: {
       params: GetAppDefinitionParams
-      payload: { appUploadId: string }
+      payload: { appUploadId: string; comment?: string }
       return: AppBundleProps
     }
   }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1,6 +1,6 @@
 import { AxiosRequestConfig } from 'axios'
 import { Stream } from 'stream'
-import { AppBundleProps } from './entities/app-bundle'
+import { AppBundleProps, CreateAppBundleProps } from './entities/app-bundle'
 import { ApiKeyProps, CreateApiKeyProps } from './entities/api-key'
 import { AppDefinitionProps, CreateAppDefinitionProps } from './entities/app-definition'
 import { AppInstallationProps, CreateAppInstallationProps } from './entities/app-installation'
@@ -424,7 +424,7 @@ export type MRActions = {
     delete: { params: GetAppBundleParams; return: void }
     create: {
       params: GetAppDefinitionParams
-      payload: { appUploadId: string; comment?: string }
+      payload: CreateAppBundleProps
       return: AppBundleProps
     }
   }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1,5 +1,6 @@
 import { AxiosRequestConfig } from 'axios'
 import { Stream } from 'stream'
+import { AppBundleProps } from './entities/app-bundle'
 import { ApiKeyProps, CreateApiKeyProps } from './entities/api-key'
 import { AppDefinitionProps, CreateAppDefinitionProps } from './entities/app-definition'
 import { AppInstallationProps, CreateAppInstallationProps } from './entities/app-installation'
@@ -169,6 +170,10 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Http', 'put', UA>): MRReturn<'Http', 'put'>
   (opts: MROpts<'Http', 'delete', UA>): MRReturn<'Http', 'delete'>
   (opts: MROpts<'Http', 'request', UA>): MRReturn<'Http', 'request'>
+
+  (opts: MROpts<'AppBundle', 'get', UA>): MRReturn<'AppBundle', 'get'>
+  (opts: MROpts<'AppBundle', 'getMany', UA>): MRReturn<'AppBundle', 'getMany'>
+  (opts: MROpts<'AppBundle', 'delete', UA>): MRReturn<'AppBundle', 'delete'>
 
   (opts: MROpts<'ApiKey', 'get', UA>): MRReturn<'ApiKey', 'get'>
   (opts: MROpts<'ApiKey', 'getMany', UA>): MRReturn<'ApiKey', 'getMany'>
@@ -408,6 +413,11 @@ export type MRActions = {
     put: { params: { url: string; config?: AxiosRequestConfig }; payload: any; return: any }
     delete: { params: { url: string; config?: AxiosRequestConfig }; return: any }
     request: { params: { url: string; config?: AxiosRequestConfig }; return: any }
+  }
+  AppBundle: {
+    get: { params: GetAppBundleParams; return: AppBundleProps }
+    getMany: { params: GetAppDefinitionParams; return: CollectionProp<AppBundleProps> }
+    delete: { params: GetAppBundleParams; return: void }
   }
   ApiKey: {
     get: { params: GetSpaceParams & { apiKeyId: string }; return: ApiKeyProps }
@@ -1020,22 +1030,23 @@ export interface MakeRequestOptions {
   userAgent: string
 }
 
-export type GetSpaceParams = { spaceId: string }
-export type GetSpaceEnvironmentParams = { spaceId: string; environmentId: string }
-export type GetOrganizationParams = { organizationId: string }
-export type GetTeamParams = { organizationId: string; teamId: string }
+export type GetAppBundleParams = GetAppDefinitionParams & { appBundleId: string }
 export type GetAppDefinitionParams = GetOrganizationParams & { appDefinitionId: string }
 export type GetAppInstallationParams = GetSpaceEnvironmentParams & { appDefinitionId: string }
 export type GetContentTypeParams = GetSpaceEnvironmentParams & { contentTypeId: string }
 export type GetEditorInterfaceParams = GetSpaceEnvironmentParams & { contentTypeId: string }
-export type GetSpaceEnvAliasParams = GetSpaceParams & { environmentAliasId: string }
+export type GetExtensionParams = GetSpaceEnvironmentParams & { extensionId: string }
+export type GetOrganizationParams = { organizationId: string }
 export type GetSnapshotForContentTypeParams = GetSpaceEnvironmentParams & { contentTypeId: string }
 export type GetSnapshotForEntryParams = GetSpaceEnvironmentParams & { entryId: string }
+export type GetSpaceEnvAliasParams = GetSpaceParams & { environmentAliasId: string }
+export type GetSpaceEnvironmentParams = { spaceId: string; environmentId: string }
 export type GetSpaceMembershipProps = GetSpaceParams & { spaceMembershipId: string }
+export type GetSpaceParams = { spaceId: string }
 export type GetTagParams = GetSpaceEnvironmentParams & { tagId: string }
 export type GetTeamMembershipParams = GetTeamParams & { teamMembershipId: string }
+export type GetTeamParams = { organizationId: string; teamId: string }
 export type GetTeamSpaceMembershipParams = GetSpaceParams & { teamSpaceMembershipId: string }
-export type GetExtensionParams = GetSpaceEnvironmentParams & { extensionId: string }
 export type GetWebhookCallDetailsUrl = GetWebhookParams & { callId: string }
 export type GetWebhookParams = GetSpaceParams & { webhookDefinitionId: string }
 export type GetOrganizationMembershipProps = GetOrganizationParams & {

--- a/lib/create-app-definition-api.ts
+++ b/lib/create-app-definition-api.ts
@@ -1,5 +1,6 @@
 import { MakeRequest, QueryOptions } from './common-types'
 import entities from './entities'
+import { CreateAppBundleProps } from './entities/app-bundle'
 import { AppDefinitionProps, wrapAppDefinition } from './entities/app-definition'
 
 export type ContentfulAppDefinitionAPI = ReturnType<typeof createAppDefinitionApi>
@@ -141,7 +142,7 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    createAppBundle(appUploadId: string, comment?: string) {
+    createAppBundle(data: CreateAppBundleProps) {
       const raw = this.toPlainObject() as AppDefinitionProps
       return makeRequest({
         entityType: 'AppBundle',
@@ -150,7 +151,7 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
           appDefinitionId: raw.sys.id,
           organizationId: raw.sys.organization.sys.id,
         },
-        payload: { appUploadId, comment },
+        payload: data,
       }).then((data) => wrapAppBundle(makeRequest, data))
     },
   }

--- a/lib/create-app-definition-api.ts
+++ b/lib/create-app-definition-api.ts
@@ -14,34 +14,6 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
 
   return {
     /**
-     * Deletes this object on the server.
-     * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
-     * @example ```javascript
-     * const contentful = require('contentful-management')
-     *
-     * const client = contentful.createClient({
-     *   accessToken: '<content_management_api_key>'
-     * })
-     *
-     * client.getOrganization('<org_id>')
-     * .then((org) => org.getAppDefinition('<app_def_id>'))
-     * .then((appDefinition) => appDefinition.delete())
-     * .then(() => console.log(`App Definition deleted.`))
-     * .catch(console.error)
-     * ```
-     */
-    update: function update() {
-      const data = this.toPlainObject() as AppDefinitionProps
-      return makeRequest({
-        entityType: 'AppDefinition',
-        action: 'update',
-        params: getParams(data),
-        headers: {},
-        payload: data,
-      }).then((data) => wrapAppDefinition(makeRequest, data))
-    },
-
-    /**
      * Sends an update to the server with any changes made to the object's properties
      * @return Object returned from the server with updated changes.
      * @example ```javascript
@@ -61,6 +33,34 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
+    update: function update() {
+      const data = this.toPlainObject() as AppDefinitionProps
+      return makeRequest({
+        entityType: 'AppDefinition',
+        action: 'update',
+        params: getParams(data),
+        headers: {},
+        payload: data,
+      }).then((data) => wrapAppDefinition(makeRequest, data))
+    },
+
+    /**
+     * Deletes this object on the server.
+     * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppDefinition('<app_def_id>'))
+     * .then((appDefinition) => appDefinition.delete())
+     * .then(() => console.log(`App Definition deleted.`))
+     * .catch(console.error)
+     * ```
+     */
     delete: function del() {
       const data = this.toPlainObject() as AppDefinitionProps
       return makeRequest({
@@ -70,6 +70,23 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
       })
     },
 
+    /**
+     * Gets an app bundle
+     * @param id - AppBundle ID
+     * @return Promise for an AppBundle
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppDefinition('<app_def_id>'))
+     * .then((appDefinition) => appDefinition.getAppBundle('<app_upload_id>')
+     * .then((appBundle) => console.log(appBundle))
+     * .catch(console.error)
+     * ```
+     */
     getAppBundle(id: string) {
       const raw = this.toPlainObject() as AppDefinitionProps
       return makeRequest({
@@ -83,6 +100,22 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
       }).then((data) => wrapAppBundle(makeRequest, data))
     },
 
+    /**
+     * Gets a collection of AppBundles
+     * @return Promise for a collection of AppBundles
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppDefinition('<app_def_id>'))
+     * .then((appDefinition) => appDefinition.getAppBundles()
+     * .then((response) => console.log(response.items))
+     * .catch(console.error)
+     * ```
+     */
     getAppBundles(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as AppDefinitionProps
       return makeRequest({
@@ -90,6 +123,35 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
         action: 'getMany',
         params: { organizationId: raw.sys.organization.sys.id, appDefinitionId: raw.sys.id, query },
       }).then((data) => wrapAppBundleCollection(makeRequest, data))
+    },
+
+    /**
+     * Creates an app bundle
+     * @param Object representation of the App Bundle to be created
+     * @return Promise for the newly created AppBundle
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppDefinition('<app_def_id>'))
+     * .then((appDefinition) => appDefinition.createAppBundle('<app_upload_id>')
+     * .then((appBundle) => console.log(appBundle))
+     * .catch(console.error)
+     * ```
+     */
+    createAppBundle(appUploadId: string) {
+      const raw = this.toPlainObject() as AppDefinitionProps
+      return makeRequest({
+        entityType: 'AppBundle',
+        action: 'create',
+        params: {
+          appDefinitionId: raw.sys.id,
+          organizationId: raw.sys.organization.sys.id,
+        },
+        payload: { appUploadId },
+      }).then((data) => wrapAppBundle(makeRequest, data))
     },
   }
 }

--- a/lib/create-app-definition-api.ts
+++ b/lib/create-app-definition-api.ts
@@ -141,7 +141,7 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    createAppBundle(appUploadId: string) {
+    createAppBundle(appUploadId: string, comment?: string) {
       const raw = this.toPlainObject() as AppDefinitionProps
       return makeRequest({
         entityType: 'AppBundle',
@@ -150,7 +150,7 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
           appDefinitionId: raw.sys.id,
           organizationId: raw.sys.organization.sys.id,
         },
-        payload: { appUploadId },
+        payload: { appUploadId, comment },
       }).then((data) => wrapAppBundle(makeRequest, data))
     },
   }

--- a/lib/create-app-definition-api.ts
+++ b/lib/create-app-definition-api.ts
@@ -1,0 +1,95 @@
+import { MakeRequest, QueryOptions } from './common-types'
+import entities from './entities'
+import { AppDefinitionProps, wrapAppDefinition } from './entities/app-definition'
+
+export type ContentfulAppDefinitionAPI = ReturnType<typeof createAppDefinitionApi>
+
+export default function createAppDefinitionApi(makeRequest: MakeRequest) {
+  const { wrapAppBundle, wrapAppBundleCollection } = entities.appBundle
+
+  const getParams = (data: AppDefinitionProps) => ({
+    appDefinitionId: data.sys.id,
+    organizationId: data.sys.organization.sys.id,
+  })
+
+  return {
+    /**
+     * Deletes this object on the server.
+     * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppDefinition('<app_def_id>'))
+     * .then((appDefinition) => appDefinition.delete())
+     * .then(() => console.log(`App Definition deleted.`))
+     * .catch(console.error)
+     * ```
+     */
+    update: function update() {
+      const data = this.toPlainObject() as AppDefinitionProps
+      return makeRequest({
+        entityType: 'AppDefinition',
+        action: 'update',
+        params: getParams(data),
+        headers: {},
+        payload: data,
+      }).then((data) => wrapAppDefinition(makeRequest, data))
+    },
+
+    /**
+     * Sends an update to the server with any changes made to the object's properties
+     * @return Object returned from the server with updated changes.
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppDefinition('<app_def_id>'))
+     * .then((appDefinition) => {
+     *   appDefinition.name = 'New App Definition name'
+     *   return appDefinition.update()
+     * })
+     * .then((appDefinition) => console.log(`App Definition ${appDefinition.sys.id} updated.`))
+     * .catch(console.error)
+     * ```
+     */
+    delete: function del() {
+      const data = this.toPlainObject() as AppDefinitionProps
+      return makeRequest({
+        entityType: 'AppDefinition',
+        action: 'delete',
+        params: getParams(data),
+      })
+    },
+
+    getAppBundle(id: string) {
+      const raw = this.toPlainObject() as AppDefinitionProps
+      return makeRequest({
+        entityType: 'AppBundle',
+        action: 'get',
+        params: {
+          appBundleId: id,
+          appDefinitionId: raw.sys.id,
+          organizationId: raw.sys.organization.sys.id,
+        },
+      }).then((data) => wrapAppBundle(makeRequest, data))
+    },
+
+    getAppBundles(query: QueryOptions = {}) {
+      const raw = this.toPlainObject() as AppDefinitionProps
+      return makeRequest({
+        entityType: 'AppBundle',
+        action: 'getMany',
+        params: { organizationId: raw.sys.organization.sys.id, appDefinitionId: raw.sys.id, query },
+      }).then((data) => wrapAppBundleCollection(makeRequest, data))
+    },
+  }
+}

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -44,8 +44,8 @@ export interface AppBundle extends AppBundleProps, DefaultElements<AppBundleProp
    *
    * client.getOrganization('<org_id>')
    * .then((org) => org.getAppDefinition('<app_def_id>'))
-   * .then((appDefinition) => appDefinition.delete())
-   * .then(() => console.log(`App Definition deleted.`))
+   * .then((appDefinition) => appDefinition.getAppBundle('<app-bundle-id>'))
+   * .then((appBundle) => appBundle.delete())
    * .catch(console.error)
    * ```
    */

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -17,7 +17,7 @@ export type AppBundleFile = {
 }
 
 export type CreateAppBundleProps = {
-  upload: Link<'AppUpload'>
+  appUploadId: string
   comment?: string
 }
 

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -10,7 +10,7 @@ type AppBundleSys = Except<BasicMetaSysProps, 'version'> & {
   organization: SysLink
 }
 
-type File = {
+export type File = {
   name: string
   size: number
   md5: string

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -1,6 +1,5 @@
-import { freezeSys } from 'contentful-sdk-core'
+import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import { toPlainObject } from 'lodash'
 import { Except } from 'type-fest'
 import { wrapCollection } from '../common-utils'
 import { BasicMetaSysProps, DefaultElements, Link, MakeRequest, SysLink } from '../common-types'

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -1,0 +1,18 @@
+import { Except } from 'type-fest'
+import { BasicMetaSysProps, SysLink } from '../common-types'
+
+type AppBundleSys = Except<BasicMetaSysProps, 'version'> & {
+  appDefinition: SysLink
+  organization: SysLink
+}
+
+type File = {
+  name: string
+  size: number
+  md5: string
+}
+
+export type AppBundleProps = {
+  sys: AppBundleSys
+  files: File[]
+}

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -10,7 +10,7 @@ type AppBundleSys = Except<BasicMetaSysProps, 'version'> & {
   organization: SysLink
 }
 
-export type File = {
+export type AppBundleFile = {
   name: string
   size: number
   md5: string
@@ -28,7 +28,7 @@ export type AppBundleProps = {
   /**
    * List of all the files that are in a bundle
    */
-  files: File[]
+  files: AppBundleFile[]
 }
 
 export interface AppBundle extends AppBundleProps, DefaultElements<AppBundleProps> {

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -1,5 +1,10 @@
+import { freezeSys } from 'contentful-sdk-core'
+import copy from 'fast-copy'
+import { toPlainObject } from 'lodash'
 import { Except } from 'type-fest'
-import { BasicMetaSysProps, Link, SysLink } from '../common-types'
+import { wrapCollection } from '../common-utils'
+import { BasicMetaSysProps, DefaultElements, Link, MakeRequest, SysLink } from '../common-types'
+import enhanceWithMethods from '../enhance-with-methods'
 
 type AppBundleSys = Except<BasicMetaSysProps, 'version'> & {
   appDefinition: SysLink
@@ -26,3 +31,65 @@ export type AppBundleProps = {
    */
   files: File[]
 }
+
+export interface AppBundle extends AppBundleProps, DefaultElements<AppBundleProps> {
+  /**
+   * Deletes this object on the server.
+   * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
+   * @example ```javascript
+   * const contentful = require('contentful-management')
+   *
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
+   *
+   * client.getOrganization('<org_id>')
+   * .then((org) => org.getAppDefinition('<app_def_id>'))
+   * .then((appDefinition) => appDefinition.delete())
+   * .then(() => console.log(`App Definition deleted.`))
+   * .catch(console.error)
+   * ```
+   */
+  delete(): Promise<void>
+}
+
+function createAppBundleApi(makeRequest: MakeRequest) {
+  const getParams = (data: AppBundleProps) => ({
+    organizationId: data.sys.organization.sys.id,
+    appDefinitionId: data.sys.appDefinition.sys.id,
+    appBundleId: data.sys.id,
+  })
+
+  return {
+    delete: function del() {
+      const data = this.toPlainObject() as AppBundleProps
+      return makeRequest({
+        entityType: 'AppBundle',
+        action: 'delete',
+        params: getParams(data),
+      })
+    },
+  }
+}
+
+/**
+ * @private
+ * @param makeRequest - function to make requests via an adapter
+ * @param data - Raw App Bundle data
+ * @return Wrapped App Bundle data
+ */
+export function wrapAppBundle(makeRequest: MakeRequest, data: AppBundleProps): AppBundle {
+  const appBundle = toPlainObject(copy(data))
+
+  const appBundleWithMethods = enhanceWithMethods(appBundle, createAppBundleApi(makeRequest))
+
+  return freezeSys(appBundleWithMethods)
+}
+
+/**
+ * @private
+ * @param makeRequest - function to make requests via an adapter
+ * @param data - Raw App Bundle collection data
+ * @return Wrapped App Bundle collection data
+ */
+export const wrapAppBundleCollection = wrapCollection(wrapAppBundle)

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -1,5 +1,5 @@
 import { Except } from 'type-fest'
-import { BasicMetaSysProps, SysLink } from '../common-types'
+import { BasicMetaSysProps, Link, SysLink } from '../common-types'
 
 type AppBundleSys = Except<BasicMetaSysProps, 'version'> & {
   appDefinition: SysLink
@@ -12,7 +12,17 @@ type File = {
   md5: string
 }
 
+export type CreateAppBundleProps = {
+  upload: Link<'AppUpload'>
+}
+
 export type AppBundleProps = {
+  /**
+   * System metadata
+   */
   sys: AppBundleSys
+  /**
+   * List of all the files that are in a bundle
+   */
   files: File[]
 }

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -26,7 +26,7 @@ export type AppBundleProps = {
    */
   sys: AppBundleSys
   /**
-   * List of all the files that are in a bundle
+   * List of all the files that are in this bundle
    */
   files: AppBundleFile[]
 }

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -18,6 +18,7 @@ export type AppBundleFile = {
 
 export type CreateAppBundleProps = {
   upload: Link<'AppUpload'>
+  comment?: string
 }
 
 export type AppBundleProps = {
@@ -29,6 +30,10 @@ export type AppBundleProps = {
    * List of all the files that are in this bundle
    */
   files: AppBundleFile[]
+  /**
+   * A comment that describes this bundle
+   */
+  comment?: string
 }
 
 export interface AppBundle extends AppBundleProps, DefaultElements<AppBundleProps> {

--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -3,6 +3,7 @@ import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import { DefaultElements, BasicMetaSysProps, SysLink, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
+import createAppDefinitionApi, { ContentfulAppDefinitionAPI } from '../create-app-definition-api'
 import { SetOptional, Except } from 'type-fest'
 import { FieldType } from './field-type'
 import { ParameterDefinition } from './widget-parameters'
@@ -60,76 +61,9 @@ export type CreateAppDefinitionProps = SetOptional<
   'src' | 'locations'
 >
 
-export interface AppDefinition extends AppDefinitionProps, DefaultElements<AppDefinitionProps> {
-  /**
-   * Deletes this object on the server.
-   * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
-   * @example ```javascript
-   * const contentful = require('contentful-management')
-   *
-   * const client = contentful.createClient({
-   *   accessToken: '<content_management_api_key>'
-   * })
-   *
-   * client.getOrganization('<org_id>')
-   * .then((org) => org.getAppDefinition('<app_def_id>'))
-   * .then((appDefinition) => appDefinition.delete())
-   * .then(() => console.log(`App Definition deleted.`))
-   * .catch(console.error)
-   * ```
-   */
-  delete(): Promise<void>
-  /**
-   * Sends an update to the server with any changes made to the object's properties
-   * @return Object returned from the server with updated changes.
-   * @example ```javascript
-   * const contentful = require('contentful-management')
-   *
-   * const client = contentful.createClient({
-   *   accessToken: '<content_management_api_key>'
-   * })
-   *
-   * client.getOrganization('<org_id>')
-   * .then((org) => org.getAppDefinition('<app_def_id>'))
-   * .then((appDefinition) => {
-   *   appDefinition.name = 'New App Definition name'
-   *   return appDefinition.update()
-   * })
-   * .then((appDefinition) => console.log(`App Definition ${appDefinition.sys.id} updated.`))
-   * .catch(console.error)
-   * ```
-   */
-  update(): Promise<AppDefinition>
-}
-
-function createAppDefinitionApi(makeRequest: MakeRequest) {
-  const getParams = (data: AppDefinitionProps) => ({
-    appDefinitionId: data.sys.id,
-    organizationId: data.sys.organization.sys.id,
-  })
-
-  return {
-    update: function update() {
-      const data = this.toPlainObject() as AppDefinitionProps
-      return makeRequest({
-        entityType: 'AppDefinition',
-        action: 'update',
-        params: getParams(data),
-        headers: {},
-        payload: data,
-      }).then((data) => wrapAppDefinition(makeRequest, data))
-    },
-
-    delete: function del() {
-      const data = this.toPlainObject() as AppDefinitionProps
-      return makeRequest({
-        entityType: 'AppDefinition',
-        action: 'delete',
-        params: getParams(data),
-      })
-    },
-  }
-}
+export type AppDefinition = ContentfulAppDefinitionAPI &
+  AppDefinitionProps &
+  DefaultElements<AppDefinitionProps>
 
 /**
  * @private

--- a/lib/entities/index.ts
+++ b/lib/entities/index.ts
@@ -1,4 +1,5 @@
 import * as apiKey from './api-key'
+import * as appBundle from './app-bundle'
 import * as appDefinition from './app-definition'
 import * as appInstallation from './app-installation'
 import * as asset from './asset'
@@ -31,6 +32,7 @@ import * as user from './user'
 import * as webhook from './webhook'
 
 export default {
+  appBundle,
   apiKey,
   appDefinition,
   appInstallation,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -1,6 +1,11 @@
 export * from './common-types'
 
-export type { AppBundle, AppBundleProps, AppBundleFile } from './entities/app-bundle'
+export type {
+  AppBundle,
+  AppBundleProps,
+  AppBundleFile,
+  CreateAppBundleProps,
+} from './entities/app-bundle'
 export type { ApiKey, ApiKeyProps, CreateApiKeyProps } from './entities/api-key'
 export type {
   AppDefinition,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -1,5 +1,6 @@
 export * from './common-types'
 
+export type { AppBundle, AppBundleProps, File } from './entities/app-bundle'
 export type { ApiKey, ApiKeyProps, CreateApiKeyProps } from './entities/api-key'
 export type {
   AppDefinition,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -1,6 +1,6 @@
 export * from './common-types'
 
-export type { AppBundle, AppBundleProps, File } from './entities/app-bundle'
+export type { AppBundle, AppBundleProps, AppBundleFile } from './entities/app-bundle'
 export type { ApiKey, ApiKeyProps, CreateApiKeyProps } from './entities/api-key'
 export type {
   AppDefinition,

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -77,7 +77,7 @@ import {
 } from '../entities/webhook'
 import { DefaultParams, OptionalDefaults } from './wrappers/wrap'
 import { AssetKeyProps, CreateAssetKeyProps } from '../entities/asset-key'
-import { AppBundleProps } from '../entities/app-bundle'
+import { AppBundleProps, CreateAppBundleProps } from '../entities/app-bundle'
 
 export type PlainClientAPI = {
   raw: {
@@ -96,7 +96,7 @@ export type PlainClientAPI = {
     delete(params: OptionalDefaults<GetAppBundleParams>): Promise<void>
     create(
       params: OptionalDefaults<GetAppDefinitionParams>,
-      payload: { appUploadId: string; comment?: string }
+      payload: CreateAppBundleProps
     ): Promise<AppBundleProps>
   }
   editorInterface: {

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -94,6 +94,9 @@ export type PlainClientAPI = {
       params: OptionalDefaults<GetAppDefinitionParams & QueryParams>
     ): Promise<CollectionProp<AppBundleProps>>
     delete(params: OptionalDefaults<GetAppBundleParams>): Promise<void>
+    create(
+      params: OptionalDefaults<GetAppDefinitionParams & { appUploadId: string }>
+    ): Promise<AppBundleProps>
   }
   editorInterface: {
     get(params: OptionalDefaults<GetEditorInterfaceParams>): Promise<EditorInterfaceProps>

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -95,7 +95,8 @@ export type PlainClientAPI = {
     ): Promise<CollectionProp<AppBundleProps>>
     delete(params: OptionalDefaults<GetAppBundleParams>): Promise<void>
     create(
-      params: OptionalDefaults<GetAppDefinitionParams & { appUploadId: string }>
+      params: OptionalDefaults<GetAppDefinitionParams>,
+      payload: { appUploadId: string }
     ): Promise<AppBundleProps>
   }
   editorInterface: {

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -96,7 +96,7 @@ export type PlainClientAPI = {
     delete(params: OptionalDefaults<GetAppBundleParams>): Promise<void>
     create(
       params: OptionalDefaults<GetAppDefinitionParams>,
-      payload: { appUploadId: string }
+      payload: { appUploadId: string; comment?: string }
     ): Promise<AppBundleProps>
   }
   editorInterface: {

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -24,6 +24,7 @@ import {
   KeyValueMap,
   PaginationQueryParams,
   QueryParams,
+  GetAppBundleParams,
 } from '../common-types'
 import { ApiKeyProps, CreateApiKeyProps } from '../entities/api-key'
 import { AppDefinitionProps, CreateAppDefinitionProps } from '../entities/app-definition'
@@ -76,6 +77,7 @@ import {
 } from '../entities/webhook'
 import { DefaultParams, OptionalDefaults } from './wrappers/wrap'
 import { AssetKeyProps, CreateAssetKeyProps } from '../entities/asset-key'
+import { AppBundleProps } from '../entities/app-bundle'
 
 export type PlainClientAPI = {
   raw: {
@@ -85,6 +87,13 @@ export type PlainClientAPI = {
     put<T = unknown>(url: string, payload?: any, config?: AxiosRequestConfig): Promise<T>
     delete<T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T>
     http<T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T>
+  }
+  appBundle: {
+    get(params: OptionalDefaults<GetAppBundleParams>): Promise<AppBundleProps>
+    getMany(
+      params: OptionalDefaults<GetAppDefinitionParams & QueryParams>
+    ): Promise<CollectionProp<AppBundleProps>>
+    delete(params: OptionalDefaults<GetAppBundleParams>): Promise<void>
   }
   editorInterface: {
     get(params: OptionalDefaults<GetEditorInterfaceParams>): Promise<EditorInterfaceProps>

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -47,6 +47,11 @@ export const createPlainClient = (
           params: { url, config },
         }),
     },
+    appBundle: {
+      get: wrap(wrapParams, 'AppBundle', 'get'),
+      getMany: wrap(wrapParams, 'AppBundle', 'getMany'),
+      delete: wrap(wrapParams, 'AppBundle', 'delete'),
+    },
     editorInterface: {
       get: wrap(wrapParams, 'EditorInterface', 'get'),
       getMany: wrap(wrapParams, 'EditorInterface', 'getMany'),

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -51,6 +51,7 @@ export const createPlainClient = (
       get: wrap(wrapParams, 'AppBundle', 'get'),
       getMany: wrap(wrapParams, 'AppBundle', 'getMany'),
       delete: wrap(wrapParams, 'AppBundle', 'delete'),
+      create: wrap(wrapParams, 'AppBundle', 'create'),
     },
     editorInterface: {
       get: wrap(wrapParams, 'EditorInterface', 'get'),

--- a/test/unit/create-app-definition-api-test.js
+++ b/test/unit/create-app-definition-api-test.js
@@ -1,0 +1,123 @@
+import { expect } from 'chai'
+import { afterEach, describe, test } from 'mocha'
+import { toPlainObject } from 'contentful-sdk-core'
+import createAppDefinitionApi, {
+  __RewireAPI__ as createAppDefinitionApiRewireApi,
+} from '../../lib/create-app-definition-api'
+import { appBundleMock, appDefinitionMock, setupEntitiesMock } from './mocks/entities'
+import setupMakeRequest from './mocks/makeRequest'
+import {
+  makeGetCollectionTest,
+  makeGetEntityTest,
+  makeEntityMethodFailingTest,
+} from './test-creators/static-entity-methods'
+
+function setup(promise) {
+  const entitiesMock = setupEntitiesMock(createAppDefinitionApiRewireApi)
+  const makeRequest = setupMakeRequest(promise)
+  const api = createAppDefinitionApi(makeRequest)
+
+  api.toPlainObject = () => appDefinitionMock
+
+  return {
+    api,
+    makeRequest,
+    entitiesMock,
+  }
+}
+
+describe('createAppDefinitionApi', () => {
+  afterEach(() => {
+    createAppDefinitionApiRewireApi.__ResetDependency__('entities')
+  })
+
+  test('API call delete', async () => {
+    const { api } = setup(Promise.resolve({}))
+    expect(await api.delete()).to.not.throw
+  })
+
+  test('API call update', async () => {
+    const responseData = {
+      sys: {
+        id: 'id',
+        type: 'AppDefinition',
+        organization: {
+          sys: {
+            type: 'Link',
+            linkType: 'Organization',
+            id: 'org-id',
+          },
+        },
+      },
+      name: 'Updated Name',
+    }
+
+    let { api, makeRequest, entitiesMock } = setup(Promise.resolve(responseData))
+    entitiesMock.appDefinition.wrapAppDefinition.returns(responseData)
+
+    // mocks data that would exist
+    api.sys = {
+      id: 'id',
+      type: 'AppDefinition',
+      organization: {
+        sys: {
+          type: 'Link',
+          linkType: 'Organization',
+          id: 'org-id',
+        },
+      },
+    }
+
+    api = toPlainObject(api)
+
+    api.name = 'Updated Name'
+    return api.update().then((r) => {
+      expect(r).eql(responseData, 'app definition is wrapped')
+      expect(makeRequest.args[0][0].payload.name).equals('Updated Name', 'data is sent')
+    })
+  })
+
+  test('API call getAppBundle', async () => {
+    return makeGetEntityTest(setup, {
+      entityType: 'appBundle',
+      mockToReturn: appBundleMock,
+      methodToTest: 'getAppBundle',
+    })
+  })
+
+  test('API call getAppBundle fails', async () => {
+    return makeEntityMethodFailingTest(setup, {
+      methodToTest: 'getAppBundle',
+    })
+  })
+
+  test('API call getAppBundles', async () => {
+    return makeGetCollectionTest(setup, {
+      entityType: 'appBundle',
+      mockToReturn: appBundleMock,
+      methodToTest: 'getAppBundles',
+    })
+  })
+
+  test('API call getAppBundles fails', async () => {
+    return makeEntityMethodFailingTest(setup, {
+      methodToTest: 'getAppBundles',
+    })
+  })
+
+  test('API call createAppBundle', async () => {
+    const { api, entitiesMock } = setup(Promise.resolve({}))
+
+    entitiesMock['appBundle']['wrapAppBundle'].returns(appBundleMock)
+
+    return api['createAppBundle']({ appBundleId: 'id' }).then((result) => {
+      expect(result).equals(appBundleMock)
+    })
+  })
+
+  test('API call createAppBundle fails', async () => {
+    return makeEntityMethodFailingTest(setup, {
+      methodToTest: 'createAppBundle',
+    })
+  })
+})

--- a/test/unit/entities/app-bundle-test.js
+++ b/test/unit/entities/app-bundle-test.js
@@ -1,0 +1,34 @@
+import { cloneMock } from '../mocks/entities'
+import setupMakeRequest from '../mocks/makeRequest'
+import { wrapAppBundle, wrapAppBundleCollection } from '../../../lib/entities/app-bundle'
+import {
+  entityCollectionWrappedTest,
+  entityWrappedTest,
+  entityDeleteTest,
+} from '../test-creators/instance-entity-methods'
+import { describe, test } from 'mocha'
+
+function setup(promise) {
+  return {
+    makeRequest: setupMakeRequest(promise),
+    entityMock: cloneMock('appBundle'),
+  }
+}
+
+describe('Entity AppBundle', () => {
+  test('AppBundle is wrapped', async () => {
+    return entityWrappedTest(setup, { wrapperMethod: wrapAppBundle })
+  })
+
+  test('AppBundle collection is wrapped', async () => {
+    return entityCollectionWrappedTest(setup, {
+      wrapperMethod: wrapAppBundleCollection,
+    })
+  })
+
+  test('AppBundle delete', async () => {
+    return entityDeleteTest(setup, {
+      wrapperMethod: wrapAppBundle,
+    })
+  })
+})

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -54,6 +54,26 @@ const personalAccessTokenMock = {
   scopes: ['content_management_manage'],
 }
 
+const appBundleMock = {
+  sys: Object.assign(cloneDeep(sysMock), {
+    type: 'AppBundle',
+    organization: { sys: { id: 'organziation-id' } },
+    appDefinition: { sys: { id: 'app-definition-id' } },
+  }),
+  files: [
+    {
+      name: 'build/asset-manifest.json',
+      size: 1066,
+      md5: '38OsiWdvD1sZJzEXx8jiaA==',
+    },
+    {
+      name: 'build/index.html',
+      size: 2010,
+      md5: 'xkXIzwdDGA4ynvPYBpvRww==',
+    },
+  ],
+}
+
 const appDefinitionMock = {
   sys: Object.assign(cloneDeep(sysMock), {
     type: 'AppDefinition',
@@ -450,40 +470,41 @@ export const scheduledActionCollectionMock = {
 }
 
 const mocks = {
-  link: linkMock,
-  sys: sysMock,
+  apiKey: apiKeyMock,
+  appBundle: appBundleMock,
+  appDefinition: appDefinitionMock,
+  appInstallation: appInstallationMock,
+  asset: assetMock,
+  assetKey: assetKeyMock,
+  assetWithTags: assetMockWithTags,
   contentType: contentTypeMock,
   editorInterface: editorInterfaceMock,
   entry: entryMock,
   entryWithTags: entryMockWithTags,
-  snapshot: snapShotMock,
-  asset: assetMock,
-  assetWithTags: assetMockWithTags,
-  assetKey: assetKeyMock,
+  environmentAlias: environmentAliasMock,
+  error: errorMock,
+  extension: extensionMock,
+  link: linkMock,
   locale: localeMock,
-  webhook: webhookMock,
+  organization: organizationMock,
+  organizationInvitation: organizationInvitationMock,
+  organizationMembership: organizationMembershipMock,
+  personalAccessToken: personalAccessTokenMock,
+  previewApiKey: previewApiKeyMock,
+  role: roleMock,
+  scheduledAction: scheduledActionMock,
+  snapshot: snapShotMock,
   spaceMember: spaceMemberMock,
   spaceMembership: spaceMembershipMock,
-  teamSpaceMembership: teamSpaceMembershipMock,
-  organizationMembership: organizationMembershipMock,
+  sys: sysMock,
+  tag: tagMock,
   team: teamMock,
   teamMembership: teamMembershipMock,
-  organizationInvitation: organizationInvitationMock,
-  role: roleMock,
-  apiKey: apiKeyMock,
-  previewApiKey: previewApiKeyMock,
-  error: errorMock,
+  teamSpaceMembership: teamSpaceMembershipMock,
   upload: uploadMock,
-  organization: organizationMock,
-  extension: extensionMock,
-  appDefinition: appDefinitionMock,
-  appInstallation: appInstallationMock,
-  user: userMock,
-  personalAccessToken: personalAccessTokenMock,
   usage: usageMock,
-  environmentAlias: environmentAliasMock,
-  tag: tagMock,
-  scheduledAction: scheduledActionMock,
+  user: userMock,
+  webhook: webhookMock,
 }
 
 function cloneMock(name) {
@@ -504,6 +525,10 @@ function setupEntitiesMock(rewiredModuleApi) {
     appDefinition: {
       wrapAppDefinition: sinon.stub(),
       wrapAppDefinitionCollection: sinon.stub(),
+    },
+    appBundle: {
+      wrapAppBundle: sinon.stub(),
+      wrapAppBundleCollection: sinon.stub(),
     },
     space: {
       wrapSpace: sinon.stub(),
@@ -624,6 +649,7 @@ function setupEntitiesMock(rewiredModuleApi) {
 }
 
 export {
+  appBundleMock,
   appInstallationMock,
   appDefinitionMock,
   linkMock,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
       "ApiKey",
       "AppDefinition",
       "AppInstalation",
+      "AppBundle",
       "Asset",
       "AssetKey",
       "ContentType",


### PR DESCRIPTION
## Summary

Introducing the `AppBundle` entity with the following methods:
 - create
 - get
 - getMany
 - delete

## Description

Added the entity to the flat and nested client and exported all relevant types. Also adjusted the `AppDefinition` API to support the `AppBundle` entity for the nested client.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
