### PR TITLE
chore: add CHANGELOG.md linking to releases page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+The changelog is automatically updated using
+[semantic-release](https://github.com/semantic-release/semantic-release). You
+can see it on the [releases page](https://github.com/contentful/contentful-management.js/releases).


### PR DESCRIPTION
Adds a static changelog file linking to the github releases page of this repo.