### PR TITLE
feat(AppHosting):  support AppBundle and AppUpload entities [EXT-2641]

### DIFF
--- a/lib/adapters/REST/endpoints/app-bundle.ts
+++ b/lib/adapters/REST/endpoints/app-bundle.ts
@@ -1,0 +1,61 @@
+import { AxiosInstance } from 'contentful-sdk-core'
+import * as raw from './raw'
+import { normalizeSelect } from './utils'
+import {
+  CollectionProp,
+  GetAppBundleParams,
+  GetAppDefinitionParams,
+  QueryParams,
+} from '../../../common-types'
+import { RestEndpoint } from '../types'
+import { AppBundleProps, CreateAppBundleProps } from '../../../entities/app-bundle'
+
+const getBaseUrl = (params: GetAppDefinitionParams) =>
+  `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/app_bundles`
+
+const getAppBundleUrl = (params: GetAppBundleParams) =>
+  `${getBaseUrl(params)}/${params.appBundleId}`
+
+export const get: RestEndpoint<'AppBundle', 'get'> = (
+  http: AxiosInstance,
+  params: GetAppBundleParams
+) => {
+  return raw.get<AppBundleProps>(http, getAppBundleUrl(params))
+}
+
+export const getMany: RestEndpoint<'AppBundle', 'getMany'> = (
+  http: AxiosInstance,
+  params: GetAppDefinitionParams & QueryParams
+) => {
+  return raw.get<CollectionProp<AppBundleProps>>(http, getBaseUrl(params), {
+    params: normalizeSelect(params.query),
+  })
+}
+
+export const del: RestEndpoint<'AppBundle', 'delete'> = (
+  http: AxiosInstance,
+  params: GetAppBundleParams
+) => {
+  return raw.del<void>(http, getAppBundleUrl(params))
+}
+
+export const create: RestEndpoint<'AppBundle', 'create'> = (
+  http: AxiosInstance,
+  params: GetAppDefinitionParams,
+  payload: CreateAppBundleProps
+) => {
+  const { appUploadId, comment } = payload
+
+  const data = {
+    upload: {
+      sys: {
+        type: 'Link',
+        linkType: 'AppUpload',
+        id: appUploadId,
+      },
+    },
+    comment,
+  }
+
+  return raw.post<AppBundleProps>(http, getBaseUrl(params), data)
+}

--- a/lib/adapters/REST/endpoints/app-definition.ts
+++ b/lib/adapters/REST/endpoints/app-definition.ts
@@ -40,7 +40,7 @@ export const create: RestEndpoint<'AppDefinition', 'create'> = (
   return raw.post(http, getBaseUrl(params), data)
 }
 
-export const update: RestEndpoint<'AppDefinition', 'update'> = async (
+export const update: RestEndpoint<'AppDefinition', 'update'> = (
   http: AxiosInstance,
   params: GetAppDefinitionParams,
   rawData: AppDefinitionProps,

--- a/lib/adapters/REST/endpoints/app-definition.ts
+++ b/lib/adapters/REST/endpoints/app-definition.ts
@@ -4,7 +4,6 @@ import copy from 'fast-copy'
 import { normalizeSelect } from './utils'
 import { GetAppDefinitionParams, GetOrganizationParams, QueryParams } from '../../../common-types'
 import { AppDefinitionProps, CreateAppDefinitionProps } from '../../../entities/app-definition'
-import { CollectionProp } from '../../../common-types'
 import { RestEndpoint } from '../types'
 
 const getBaseUrl = (params: GetOrganizationParams) =>
@@ -17,7 +16,7 @@ export const get: RestEndpoint<'AppDefinition', 'get'> = (
   http: AxiosInstance,
   params: GetAppDefinitionParams & QueryParams
 ) => {
-  return raw.get<AppDefinitionProps>(http, getAppDefinitionUrl(params), {
+  return raw.get(http, getAppDefinitionUrl(params), {
     params: normalizeSelect(params.query),
   })
 }
@@ -26,7 +25,7 @@ export const getMany: RestEndpoint<'AppDefinition', 'getMany'> = (
   http: AxiosInstance,
   params: GetOrganizationParams & QueryParams
 ) => {
-  return raw.get<CollectionProp<AppDefinitionProps>>(http, getBaseUrl(params), {
+  return raw.get(http, getBaseUrl(params), {
     params: params.query,
   })
 }
@@ -38,7 +37,7 @@ export const create: RestEndpoint<'AppDefinition', 'create'> = (
 ) => {
   const data = copy(rawData)
 
-  return raw.post<AppDefinitionProps>(http, getBaseUrl(params), data)
+  return raw.post(http, getBaseUrl(params), data)
 }
 
 export const update: RestEndpoint<'AppDefinition', 'update'> = async (
@@ -51,7 +50,7 @@ export const update: RestEndpoint<'AppDefinition', 'update'> = async (
 
   delete data.sys
 
-  return raw.put<AppDefinitionProps>(http, getAppDefinitionUrl(params), data, {
+  return raw.put(http, getAppDefinitionUrl(params), data, {
     headers: {
       'X-Contentful-Version': rawData.sys.version ?? 0,
       ...headers,

--- a/lib/adapters/REST/endpoints/app-upload.ts
+++ b/lib/adapters/REST/endpoints/app-upload.ts
@@ -1,0 +1,47 @@
+import type { AxiosInstance } from 'contentful-sdk-core'
+import { Stream } from 'stream'
+import * as raw from './raw'
+import { GetAppUploadParams, GetOrganizationParams } from '../../../common-types'
+import { RestEndpoint } from '../types'
+import { AppUploadProps } from '../../../entities/app-upload'
+import { getUploadHttpClient } from '../../../upload-http-client'
+
+const getBaseUrl = (params: GetOrganizationParams) =>
+  `/organizations/${params.organizationId}/app_uploads`
+
+const getAppUploadUrl = (params: GetAppUploadParams) =>
+  `${getBaseUrl(params)}/${params.appUploadId}`
+
+export const get: RestEndpoint<'AppUpload', 'get'> = (
+  http: AxiosInstance,
+  params: GetAppUploadParams
+) => {
+  const httpUpload = getUploadHttpClient(http)
+
+  return raw.get<AppUploadProps>(httpUpload, getAppUploadUrl(params))
+}
+
+export const del: RestEndpoint<'AppUpload', 'delete'> = (
+  http: AxiosInstance,
+  params: GetAppUploadParams
+) => {
+  const httpUpload = getUploadHttpClient(http)
+
+  return raw.del<void>(httpUpload, getAppUploadUrl(params))
+}
+
+export const create: RestEndpoint<'AppUpload', 'create'> = (
+  http: AxiosInstance,
+  params: GetOrganizationParams,
+  payload: { file: string | ArrayBuffer | Stream }
+) => {
+  const httpUpload = getUploadHttpClient(http)
+
+  const { file } = payload
+
+  return raw.post<AppUploadProps>(httpUpload, getBaseUrl(params), file, {
+    headers: {
+      'Content-Type': 'application/octet-stream',
+    },
+  })
+}

--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -1,4 +1,5 @@
 import * as ApiKey from './api-key'
+import * as AppBundle from './app-bundle'
 import * as AppDefinition from './app-definition'
 import * as AppInstallation from './app-installation'
 import * as Asset from './asset'
@@ -33,6 +34,7 @@ import * as Webhook from './webhook'
 
 export default {
   ApiKey,
+  AppBundle,
   AppDefinition,
   AppInstallation,
   Asset,

--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -2,6 +2,7 @@ import * as ApiKey from './api-key'
 import * as AppBundle from './app-bundle'
 import * as AppDefinition from './app-definition'
 import * as AppInstallation from './app-installation'
+import * as AppUpload from './app-upload'
 import * as Asset from './asset'
 import * as AssetKey from './asset-key'
 import * as ContentType from './content-type'
@@ -37,6 +38,7 @@ export default {
   AppBundle,
   AppDefinition,
   AppInstallation,
+  AppUpload,
   Asset,
   AssetKey,
   ContentType,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1,5 +1,6 @@
 import { AxiosRequestConfig } from 'axios'
 import { Stream } from 'stream'
+import { AppBundleProps, CreateAppBundleProps } from './entities/app-bundle'
 import { ApiKeyProps, CreateApiKeyProps } from './entities/api-key'
 import { AppDefinitionProps, CreateAppDefinitionProps } from './entities/app-definition'
 import { AppInstallationProps, CreateAppInstallationProps } from './entities/app-installation'
@@ -169,6 +170,11 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Http', 'put', UA>): MRReturn<'Http', 'put'>
   (opts: MROpts<'Http', 'delete', UA>): MRReturn<'Http', 'delete'>
   (opts: MROpts<'Http', 'request', UA>): MRReturn<'Http', 'request'>
+
+  (opts: MROpts<'AppBundle', 'get', UA>): MRReturn<'AppBundle', 'get'>
+  (opts: MROpts<'AppBundle', 'getMany', UA>): MRReturn<'AppBundle', 'getMany'>
+  (opts: MROpts<'AppBundle', 'delete', UA>): MRReturn<'AppBundle', 'delete'>
+  (opts: MROpts<'AppBundle', 'create', UA>): MRReturn<'AppBundle', 'create'>
 
   (opts: MROpts<'ApiKey', 'get', UA>): MRReturn<'ApiKey', 'get'>
   (opts: MROpts<'ApiKey', 'getMany', UA>): MRReturn<'ApiKey', 'getMany'>
@@ -408,6 +414,19 @@ export type MRActions = {
     put: { params: { url: string; config?: AxiosRequestConfig }; payload: any; return: any }
     delete: { params: { url: string; config?: AxiosRequestConfig }; return: any }
     request: { params: { url: string; config?: AxiosRequestConfig }; return: any }
+  }
+  AppBundle: {
+    get: { params: GetAppBundleParams; return: AppBundleProps }
+    getMany: {
+      params: GetAppDefinitionParams & QueryParams
+      return: CollectionProp<AppBundleProps>
+    }
+    delete: { params: GetAppBundleParams; return: void }
+    create: {
+      params: GetAppDefinitionParams
+      payload: CreateAppBundleProps
+      return: AppBundleProps
+    }
   }
   ApiKey: {
     get: { params: GetSpaceParams & { apiKeyId: string }; return: ApiKeyProps }
@@ -1020,22 +1039,23 @@ export interface MakeRequestOptions {
   userAgent: string
 }
 
-export type GetSpaceParams = { spaceId: string }
-export type GetSpaceEnvironmentParams = { spaceId: string; environmentId: string }
-export type GetOrganizationParams = { organizationId: string }
-export type GetTeamParams = { organizationId: string; teamId: string }
+export type GetAppBundleParams = GetAppDefinitionParams & { appBundleId: string }
 export type GetAppDefinitionParams = GetOrganizationParams & { appDefinitionId: string }
 export type GetAppInstallationParams = GetSpaceEnvironmentParams & { appDefinitionId: string }
 export type GetContentTypeParams = GetSpaceEnvironmentParams & { contentTypeId: string }
 export type GetEditorInterfaceParams = GetSpaceEnvironmentParams & { contentTypeId: string }
-export type GetSpaceEnvAliasParams = GetSpaceParams & { environmentAliasId: string }
+export type GetExtensionParams = GetSpaceEnvironmentParams & { extensionId: string }
+export type GetOrganizationParams = { organizationId: string }
 export type GetSnapshotForContentTypeParams = GetSpaceEnvironmentParams & { contentTypeId: string }
 export type GetSnapshotForEntryParams = GetSpaceEnvironmentParams & { entryId: string }
+export type GetSpaceEnvAliasParams = GetSpaceParams & { environmentAliasId: string }
+export type GetSpaceEnvironmentParams = { spaceId: string; environmentId: string }
 export type GetSpaceMembershipProps = GetSpaceParams & { spaceMembershipId: string }
+export type GetSpaceParams = { spaceId: string }
 export type GetTagParams = GetSpaceEnvironmentParams & { tagId: string }
 export type GetTeamMembershipParams = GetTeamParams & { teamMembershipId: string }
+export type GetTeamParams = { organizationId: string; teamId: string }
 export type GetTeamSpaceMembershipParams = GetSpaceParams & { teamSpaceMembershipId: string }
-export type GetExtensionParams = GetSpaceEnvironmentParams & { extensionId: string }
 export type GetWebhookCallDetailsUrl = GetWebhookParams & { callId: string }
 export type GetWebhookParams = GetSpaceParams & { webhookDefinitionId: string }
 export type GetOrganizationMembershipProps = GetOrganizationParams & {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -51,6 +51,7 @@ import {
   WebhookProps,
 } from './entities/webhook'
 import { AssetKeyProps, CreateAssetKeyProps } from './entities/asset-key'
+import { AppUploadProps } from './entities/app-upload'
 
 export interface DefaultElements<TPlainObject extends object = object> {
   toPlainObject(): TPlainObject
@@ -207,6 +208,10 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Asset', 'createFromFiles', UA>): MRReturn<'Asset', 'createFromFiles'>
   (opts: MROpts<'Asset', 'processForAllLocales', UA>): MRReturn<'Asset', 'processForAllLocales'>
   (opts: MROpts<'Asset', 'processForLocale', UA>): MRReturn<'Asset', 'processForLocale'>
+
+  (opts: MROpts<'AppUpload', 'get', UA>): MRReturn<'AppUpload', 'get'>
+  (opts: MROpts<'AppUpload', 'delete', UA>): MRReturn<'AppUpload', 'delete'>
+  (opts: MROpts<'AppUpload', 'create', UA>): MRReturn<'AppUpload', 'create'>
 
   (opts: MROpts<'AssetKey', 'create', UA>): MRReturn<'AssetKey', 'create'>
 
@@ -486,6 +491,21 @@ export type MRActions = {
       return: AppInstallationProps
     }
     delete: { params: GetAppInstallationParams; return: any }
+  }
+  AppUpload: {
+    get: {
+      params: GetAppUploadParams
+      return: AppUploadProps
+    }
+    delete: {
+      params: GetAppUploadParams
+      return: void
+    }
+    create: {
+      params: GetOrganizationParams
+      payload: { file: string | ArrayBuffer | Stream }
+      return: AppUploadProps
+    }
   }
   Asset: {
     getMany: { params: GetSpaceEnvironmentParams & QueryParams; return: CollectionProp<AssetProps> }
@@ -1061,6 +1081,7 @@ export type GetWebhookParams = GetSpaceParams & { webhookDefinitionId: string }
 export type GetOrganizationMembershipProps = GetOrganizationParams & {
   organizationMembershipId: string
 }
+export type GetAppUploadParams = GetOrganizationParams & { appUploadId: string }
 
 export type QueryParams = { query?: QueryOptions }
 export type PaginationQueryParams = { query?: PaginationQueryOptions }

--- a/lib/create-app-definition-api.ts
+++ b/lib/create-app-definition-api.ts
@@ -1,0 +1,158 @@
+import { MakeRequest, QueryOptions } from './common-types'
+import entities from './entities'
+import { CreateAppBundleProps } from './entities/app-bundle'
+import { AppDefinitionProps, wrapAppDefinition } from './entities/app-definition'
+
+export type ContentfulAppDefinitionAPI = ReturnType<typeof createAppDefinitionApi>
+
+export default function createAppDefinitionApi(makeRequest: MakeRequest) {
+  const { wrapAppBundle, wrapAppBundleCollection } = entities.appBundle
+
+  const getParams = (data: AppDefinitionProps) => ({
+    appDefinitionId: data.sys.id,
+    organizationId: data.sys.organization.sys.id,
+  })
+
+  return {
+    /**
+     * Sends an update to the server with any changes made to the object's properties
+     * @return Object returned from the server with updated changes.
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppDefinition('<app_def_id>'))
+     * .then((appDefinition) => {
+     *   appDefinition.name = 'New App Definition name'
+     *   return appDefinition.update()
+     * })
+     * .then((appDefinition) => console.log(`App Definition ${appDefinition.sys.id} updated.`))
+     * .catch(console.error)
+     * ```
+     */
+    update: function update() {
+      const data = this.toPlainObject() as AppDefinitionProps
+      return makeRequest({
+        entityType: 'AppDefinition',
+        action: 'update',
+        params: getParams(data),
+        headers: {},
+        payload: data,
+      }).then((data) => wrapAppDefinition(makeRequest, data))
+    },
+
+    /**
+     * Deletes this object on the server.
+     * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppDefinition('<app_def_id>'))
+     * .then((appDefinition) => appDefinition.delete())
+     * .then(() => console.log(`App Definition deleted.`))
+     * .catch(console.error)
+     * ```
+     */
+    delete: function del() {
+      const data = this.toPlainObject() as AppDefinitionProps
+      return makeRequest({
+        entityType: 'AppDefinition',
+        action: 'delete',
+        params: getParams(data),
+      })
+    },
+
+    /**
+     * Gets an app bundle
+     * @param id - AppBundle ID
+     * @return Promise for an AppBundle
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppDefinition('<app_def_id>'))
+     * .then((appDefinition) => appDefinition.getAppBundle('<app_upload_id>')
+     * .then((appBundle) => console.log(appBundle))
+     * .catch(console.error)
+     * ```
+     */
+    getAppBundle(id: string) {
+      const raw = this.toPlainObject() as AppDefinitionProps
+      return makeRequest({
+        entityType: 'AppBundle',
+        action: 'get',
+        params: {
+          appBundleId: id,
+          appDefinitionId: raw.sys.id,
+          organizationId: raw.sys.organization.sys.id,
+        },
+      }).then((data) => wrapAppBundle(makeRequest, data))
+    },
+
+    /**
+     * Gets a collection of AppBundles
+     * @return Promise for a collection of AppBundles
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppDefinition('<app_def_id>'))
+     * .then((appDefinition) => appDefinition.getAppBundles()
+     * .then((response) => console.log(response.items))
+     * .catch(console.error)
+     * ```
+     */
+    getAppBundles(query: QueryOptions = {}) {
+      const raw = this.toPlainObject() as AppDefinitionProps
+      return makeRequest({
+        entityType: 'AppBundle',
+        action: 'getMany',
+        params: { organizationId: raw.sys.organization.sys.id, appDefinitionId: raw.sys.id, query },
+      }).then((data) => wrapAppBundleCollection(makeRequest, data))
+    },
+
+    /**
+     * Creates an app bundle
+     * @param Object representation of the App Bundle to be created
+     * @return Promise for the newly created AppBundle
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppDefinition('<app_def_id>'))
+     * .then((appDefinition) => appDefinition.createAppBundle('<app_upload_id>')
+     * .then((appBundle) => console.log(appBundle))
+     * .catch(console.error)
+     * ```
+     */
+    createAppBundle(data: CreateAppBundleProps) {
+      const raw = this.toPlainObject() as AppDefinitionProps
+      return makeRequest({
+        entityType: 'AppBundle',
+        action: 'create',
+        params: {
+          appDefinitionId: raw.sys.id,
+          organizationId: raw.sys.organization.sys.id,
+        },
+        payload: data,
+      }).then((data) => wrapAppBundle(makeRequest, data))
+    },
+  }
+}

--- a/lib/create-organization-api.ts
+++ b/lib/create-organization-api.ts
@@ -1,5 +1,6 @@
 import { createRequestConfig } from 'contentful-sdk-core'
 import entities from './entities'
+import { Stream } from 'stream'
 import { CreateTeamMembershipProps } from './entities/team-membership'
 import { CreateTeamProps } from './entities/team'
 import { CreateOrganizationInvitationProps } from './entities/organization-invitation'
@@ -29,6 +30,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
   const { wrapTeam, wrapTeamCollection } = entities.team
   const { wrapSpaceMembership, wrapSpaceMembershipCollection } = entities.spaceMembership
   const { wrapOrganizationInvitation } = entities.organizationInvitation
+  const { wrapAppUpload } = entities.appUpload
 
   return {
     /**
@@ -549,6 +551,57 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
         action: 'get',
         params: { organizationId: raw.sys.id, appDefinitionId: id },
       }).then((data) => wrapAppDefinition(makeRequest, data))
+    },
+
+    /**
+     * Gets an app upload
+     * @return Promise for an App Upload
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppUpload('<app_upload_id>'))
+     * .then((appUpload) => console.log(appUpload))
+     * .catch(console.error)
+     * ```
+     */
+    getAppUpload(appUploadId: string) {
+      const raw = this.toPlainObject() as OrganizationProp
+
+      return makeRequest({
+        entityType: 'AppUpload',
+        action: 'get',
+        params: { organizationId: raw.sys.id, appUploadId },
+      }).then((data) => wrapAppUpload(makeRequest, data))
+    },
+
+    /**
+     * Creates an app upload
+     * @return Promise for an App Upload
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.createAppUpload('some_zip_file'))
+     * .then((appUpload) => console.log(appUpload))
+     * .catch(console.error)
+     * ```
+     */
+    createAppUpload(file: string | ArrayBuffer | Stream) {
+      const raw = this.toPlainObject() as OrganizationProp
+
+      return makeRequest({
+        entityType: 'AppUpload',
+        action: 'create',
+        params: { organizationId: raw.sys.id },
+        payload: { file },
+      }).then((data) => wrapAppUpload(makeRequest, data))
     },
   }
 }

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -1,0 +1,99 @@
+import { freezeSys, toPlainObject } from 'contentful-sdk-core'
+import copy from 'fast-copy'
+import { Except } from 'type-fest'
+import { wrapCollection } from '../common-utils'
+import { BasicMetaSysProps, DefaultElements, Link, MakeRequest, SysLink } from '../common-types'
+import enhanceWithMethods from '../enhance-with-methods'
+
+type AppBundleSys = Except<BasicMetaSysProps, 'version'> & {
+  appDefinition: SysLink
+  organization: SysLink
+}
+
+export type AppBundleFile = {
+  name: string
+  size: number
+  md5: string
+}
+
+export type CreateAppBundleProps = {
+  appUploadId: string
+  comment?: string
+}
+
+export type AppBundleProps = {
+  /**
+   * System metadata
+   */
+  sys: AppBundleSys
+  /**
+   * List of all the files that are in this bundle
+   */
+  files: AppBundleFile[]
+  /**
+   * A comment that describes this bundle
+   */
+  comment?: string
+}
+
+export interface AppBundle extends AppBundleProps, DefaultElements<AppBundleProps> {
+  /**
+   * Deletes this object on the server.
+   * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
+   * @example ```javascript
+   * const contentful = require('contentful-management')
+   *
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
+   *
+   * client.getOrganization('<org_id>')
+   * .then((org) => org.getAppDefinition('<app_def_id>'))
+   * .then((appDefinition) => appDefinition.getAppBundle('<app-bundle-id>'))
+   * .then((appBundle) => appBundle.delete())
+   * .catch(console.error)
+   * ```
+   */
+  delete(): Promise<void>
+}
+
+function createAppBundleApi(makeRequest: MakeRequest) {
+  const getParams = (data: AppBundleProps) => ({
+    organizationId: data.sys.organization.sys.id,
+    appDefinitionId: data.sys.appDefinition.sys.id,
+    appBundleId: data.sys.id,
+  })
+
+  return {
+    delete: function del() {
+      const data = this.toPlainObject() as AppBundleProps
+      return makeRequest({
+        entityType: 'AppBundle',
+        action: 'delete',
+        params: getParams(data),
+      })
+    },
+  }
+}
+
+/**
+ * @private
+ * @param makeRequest - function to make requests via an adapter
+ * @param data - Raw App Bundle data
+ * @return Wrapped App Bundle data
+ */
+export function wrapAppBundle(makeRequest: MakeRequest, data: AppBundleProps): AppBundle {
+  const appBundle = toPlainObject(copy(data))
+
+  const appBundleWithMethods = enhanceWithMethods(appBundle, createAppBundleApi(makeRequest))
+
+  return freezeSys(appBundleWithMethods)
+}
+
+/**
+ * @private
+ * @param makeRequest - function to make requests via an adapter
+ * @param data - Raw App Bundle collection data
+ * @return Wrapped App Bundle collection data
+ */
+export const wrapAppBundleCollection = wrapCollection(wrapAppBundle)

--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -3,6 +3,7 @@ import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import { DefaultElements, BasicMetaSysProps, SysLink, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
+import createAppDefinitionApi, { ContentfulAppDefinitionAPI } from '../create-app-definition-api'
 import { SetOptional, Except } from 'type-fest'
 import { FieldType } from './field-type'
 import { ParameterDefinition } from './widget-parameters'
@@ -60,76 +61,9 @@ export type CreateAppDefinitionProps = SetOptional<
   'src' | 'locations'
 >
 
-export interface AppDefinition extends AppDefinitionProps, DefaultElements<AppDefinitionProps> {
-  /**
-   * Deletes this object on the server.
-   * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
-   * @example ```javascript
-   * const contentful = require('contentful-management')
-   *
-   * const client = contentful.createClient({
-   *   accessToken: '<content_management_api_key>'
-   * })
-   *
-   * client.getOrganization('<org_id>')
-   * .then((org) => org.getAppDefinition('<app_def_id>'))
-   * .then((appDefinition) => appDefinition.delete())
-   * .then(() => console.log(`App Definition deleted.`))
-   * .catch(console.error)
-   * ```
-   */
-  delete(): Promise<void>
-  /**
-   * Sends an update to the server with any changes made to the object's properties
-   * @return Object returned from the server with updated changes.
-   * @example ```javascript
-   * const contentful = require('contentful-management')
-   *
-   * const client = contentful.createClient({
-   *   accessToken: '<content_management_api_key>'
-   * })
-   *
-   * client.getOrganization('<org_id>')
-   * .then((org) => org.getAppDefinition('<app_def_id>'))
-   * .then((appDefinition) => {
-   *   appDefinition.name = 'New App Definition name'
-   *   return appDefinition.update()
-   * })
-   * .then((appDefinition) => console.log(`App Definition ${appDefinition.sys.id} updated.`))
-   * .catch(console.error)
-   * ```
-   */
-  update(): Promise<AppDefinition>
-}
-
-function createAppDefinitionApi(makeRequest: MakeRequest) {
-  const getParams = (data: AppDefinitionProps) => ({
-    appDefinitionId: data.sys.id,
-    organizationId: data.sys.organization.sys.id,
-  })
-
-  return {
-    update: function update() {
-      const data = this.toPlainObject() as AppDefinitionProps
-      return makeRequest({
-        entityType: 'AppDefinition',
-        action: 'update',
-        params: getParams(data),
-        headers: {},
-        payload: data,
-      }).then((data) => wrapAppDefinition(makeRequest, data))
-    },
-
-    delete: function del() {
-      const data = this.toPlainObject() as AppDefinitionProps
-      return makeRequest({
-        entityType: 'AppDefinition',
-        action: 'delete',
-        params: getParams(data),
-      })
-    },
-  }
-}
+export type AppDefinition = ContentfulAppDefinitionAPI &
+  AppDefinitionProps &
+  DefaultElements<AppDefinitionProps>
 
 /**
  * @private

--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -1,6 +1,6 @@
 import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
-import { DefaultElements, BasicMetaSysProps, SysLink, MakeRequest } from '../common-types'
+import { DefaultElements, BasicMetaSysProps, SysLink, MakeRequest, Link } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
 import createAppDefinitionApi, { ContentfulAppDefinitionAPI } from '../create-app-definition-api'
@@ -45,6 +45,10 @@ export type AppDefinitionProps = {
    */
   src?: string
   /**
+   * Link to an AppBundle
+   */
+  bundle?: Link<'AppBundle'>
+  /**
    * Locations where the app can be installed
    */
   locations?: AppLocation[]
@@ -57,7 +61,7 @@ export type AppDefinitionProps = {
 }
 
 export type CreateAppDefinitionProps = SetOptional<
-  Except<AppDefinitionProps, 'sys'>,
+  Except<AppDefinitionProps, 'sys' | 'bundle'>,
   'src' | 'locations'
 >
 

--- a/lib/entities/app-upload.ts
+++ b/lib/entities/app-upload.ts
@@ -1,0 +1,75 @@
+import { freezeSys, toPlainObject } from 'contentful-sdk-core'
+import copy from 'fast-copy'
+import { Except } from 'type-fest'
+import { BasicMetaSysProps, SysLink, DefaultElements, MakeRequest } from '../common-types'
+import { wrapCollection } from '../common-utils'
+import enhanceWithMethods from '../enhance-with-methods'
+
+type AppUploadSys = Except<BasicMetaSysProps, 'version'>
+
+export type AppUploadProps = {
+  sys: AppUploadSys & {
+    expiresAt: string
+    organization: SysLink
+  }
+}
+
+export interface AppUpload extends AppUploadProps, DefaultElements<AppUploadProps> {
+  /**
+   * Deletes this object on the server.
+   * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
+   * @example ```javascript
+   * const contentful = require('contentful-management')
+   *
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
+   *
+   * client.getOrganization('<org_id>')
+   * .then((org) => org.getAppUpload('<app_upload_id>'))
+   * .then((appUpload) => appUpload.delete())
+   * .then(() => console.log(`App Upload deleted.`))
+   * .catch(console.error)
+   * ```
+   */
+  delete(): Promise<void>
+}
+
+function createAppUploadApi(makeRequest: MakeRequest) {
+  const getParams = (data: AppUploadProps) => ({
+    organizationId: data.sys.organization.sys.id,
+    appUploadId: data.sys.id,
+  })
+
+  return {
+    delete: function del() {
+      const data = this.toPlainObject() as AppUploadProps
+      return makeRequest({
+        entityType: 'AppUpload',
+        action: 'delete',
+        params: getParams(data),
+      })
+    },
+  }
+}
+
+/**
+ * @private
+ * @param makeRequest - function to make requests via an adapter
+ * @param data - Raw App Upload data
+ * @return Wrapped App Upload data
+ */
+export function wrapAppUpload(makeRequest: MakeRequest, data: AppUploadProps): AppUpload {
+  const appUpload = toPlainObject(copy(data))
+  const appUploadWithMethods = enhanceWithMethods(appUpload, createAppUploadApi(makeRequest))
+
+  return freezeSys(appUploadWithMethods)
+}
+
+/**
+ * @private
+ * @param makeRequest - function to make requests via an adapter
+ * @param data - Raw App Upload collection data
+ * @return Wrapped App Upload collection data
+ */
+export const wrapAppUploadCollection = wrapCollection(wrapAppUpload)

--- a/lib/entities/index.ts
+++ b/lib/entities/index.ts
@@ -2,6 +2,7 @@ import * as apiKey from './api-key'
 import * as appBundle from './app-bundle'
 import * as appDefinition from './app-definition'
 import * as appInstallation from './app-installation'
+import * as appUpload from './app-upload'
 import * as asset from './asset'
 import * as assetKey from './asset-key'
 import * as contentType from './content-type'
@@ -36,6 +37,7 @@ export default {
   apiKey,
   appDefinition,
   appInstallation,
+  appUpload,
   asset,
   assetKey,
   contentType,

--- a/lib/entities/index.ts
+++ b/lib/entities/index.ts
@@ -1,4 +1,5 @@
 import * as apiKey from './api-key'
+import * as appBundle from './app-bundle'
 import * as appDefinition from './app-definition'
 import * as appInstallation from './app-installation'
 import * as asset from './asset'
@@ -31,6 +32,7 @@ import * as user from './user'
 import * as webhook from './webhook'
 
 export default {
+  appBundle,
   apiKey,
   appDefinition,
   appInstallation,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -7,6 +7,7 @@ export type {
   CreateAppBundleProps,
 } from './entities/app-bundle'
 export type { ApiKey, ApiKeyProps, CreateApiKeyProps } from './entities/api-key'
+export type { AppUploadProps, AppUpload } from './entities/app-upload'
 export type {
   AppDefinition,
   AppDefinitionProps,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -1,5 +1,11 @@
 export * from './common-types'
 
+export type {
+  AppBundle,
+  AppBundleProps,
+  AppBundleFile,
+  CreateAppBundleProps,
+} from './entities/app-bundle'
 export type { ApiKey, ApiKeyProps, CreateApiKeyProps } from './entities/api-key'
 export type {
   AppDefinition,

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -24,6 +24,7 @@ import {
   KeyValueMap,
   PaginationQueryParams,
   QueryParams,
+  GetAppUploadParams,
   GetAppBundleParams,
 } from '../common-types'
 import { ApiKeyProps, CreateApiKeyProps } from '../entities/api-key'
@@ -77,6 +78,7 @@ import {
 } from '../entities/webhook'
 import { DefaultParams, OptionalDefaults } from './wrappers/wrap'
 import { AssetKeyProps, CreateAssetKeyProps } from '../entities/asset-key'
+import { AppUploadProps } from '../entities/app-upload'
 import { AppBundleProps, CreateAppBundleProps } from '../entities/app-bundle'
 
 export type PlainClientAPI = {
@@ -285,6 +287,14 @@ export type PlainClientAPI = {
       locale: string,
       processingOptions?: AssetProcessingForLocale
     ): Promise<AssetProps>
+  }
+  appUpload: {
+    get(params: OptionalDefaults<GetAppUploadParams>): Promise<AppUploadProps>
+    delete(params: OptionalDefaults<GetAppUploadParams>): Promise<void>
+    create(
+      params: OptionalDefaults<GetOrganizationParams>,
+      payload: { file: string | ArrayBuffer | Stream }
+    ): Promise<AppUploadProps>
   }
   assetKey: {
     create(

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -24,6 +24,7 @@ import {
   KeyValueMap,
   PaginationQueryParams,
   QueryParams,
+  GetAppBundleParams,
 } from '../common-types'
 import { ApiKeyProps, CreateApiKeyProps } from '../entities/api-key'
 import { AppDefinitionProps, CreateAppDefinitionProps } from '../entities/app-definition'
@@ -76,6 +77,7 @@ import {
 } from '../entities/webhook'
 import { DefaultParams, OptionalDefaults } from './wrappers/wrap'
 import { AssetKeyProps, CreateAssetKeyProps } from '../entities/asset-key'
+import { AppBundleProps, CreateAppBundleProps } from '../entities/app-bundle'
 
 export type PlainClientAPI = {
   raw: {
@@ -85,6 +87,17 @@ export type PlainClientAPI = {
     put<T = unknown>(url: string, payload?: any, config?: AxiosRequestConfig): Promise<T>
     delete<T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T>
     http<T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T>
+  }
+  appBundle: {
+    get(params: OptionalDefaults<GetAppBundleParams>): Promise<AppBundleProps>
+    getMany(
+      params: OptionalDefaults<GetAppDefinitionParams & QueryParams>
+    ): Promise<CollectionProp<AppBundleProps>>
+    delete(params: OptionalDefaults<GetAppBundleParams>): Promise<void>
+    create(
+      params: OptionalDefaults<GetAppDefinitionParams>,
+      payload: CreateAppBundleProps
+    ): Promise<AppBundleProps>
   }
   editorInterface: {
     get(params: OptionalDefaults<GetEditorInterfaceParams>): Promise<EditorInterfaceProps>

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -47,6 +47,12 @@ export const createPlainClient = (
           params: { url, config },
         }),
     },
+    appBundle: {
+      get: wrap(wrapParams, 'AppBundle', 'get'),
+      getMany: wrap(wrapParams, 'AppBundle', 'getMany'),
+      delete: wrap(wrapParams, 'AppBundle', 'delete'),
+      create: wrap(wrapParams, 'AppBundle', 'create'),
+    },
     editorInterface: {
       get: wrap(wrapParams, 'EditorInterface', 'get'),
       getMany: wrap(wrapParams, 'EditorInterface', 'getMany'),

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -147,6 +147,11 @@ export const createPlainClient = (
           },
         }),
     },
+    appUpload: {
+      get: wrap(wrapParams, 'AppUpload', 'get'),
+      delete: wrap(wrapParams, 'AppUpload', 'delete'),
+      create: wrap(wrapParams, 'AppUpload', 'create'),
+    },
     assetKey: {
       create: wrap(wrapParams, 'AssetKey', 'create'),
     },

--- a/test/unit/create-app-definition-api-test.js
+++ b/test/unit/create-app-definition-api-test.js
@@ -1,0 +1,123 @@
+import { expect } from 'chai'
+import { afterEach, describe, test } from 'mocha'
+import { toPlainObject } from 'contentful-sdk-core'
+import createAppDefinitionApi, {
+  __RewireAPI__ as createAppDefinitionApiRewireApi,
+} from '../../lib/create-app-definition-api'
+import { appBundleMock, appDefinitionMock, setupEntitiesMock } from './mocks/entities'
+import setupMakeRequest from './mocks/makeRequest'
+import {
+  makeGetCollectionTest,
+  makeGetEntityTest,
+  makeEntityMethodFailingTest,
+} from './test-creators/static-entity-methods'
+
+function setup(promise) {
+  const entitiesMock = setupEntitiesMock(createAppDefinitionApiRewireApi)
+  const makeRequest = setupMakeRequest(promise)
+  const api = createAppDefinitionApi(makeRequest)
+
+  api.toPlainObject = () => appDefinitionMock
+
+  return {
+    api,
+    makeRequest,
+    entitiesMock,
+  }
+}
+
+describe('createAppDefinitionApi', () => {
+  afterEach(() => {
+    createAppDefinitionApiRewireApi.__ResetDependency__('entities')
+  })
+
+  test('API call delete', async () => {
+    const { api } = setup(Promise.resolve({}))
+    expect(await api.delete()).to.not.throw
+  })
+
+  test('API call update', async () => {
+    const responseData = {
+      sys: {
+        id: 'id',
+        type: 'AppDefinition',
+        organization: {
+          sys: {
+            type: 'Link',
+            linkType: 'Organization',
+            id: 'org-id',
+          },
+        },
+      },
+      name: 'Updated Name',
+    }
+
+    let { api, makeRequest, entitiesMock } = setup(Promise.resolve(responseData))
+    entitiesMock.appDefinition.wrapAppDefinition.returns(responseData)
+
+    // mocks data that would exist
+    api.sys = {
+      id: 'id',
+      type: 'AppDefinition',
+      organization: {
+        sys: {
+          type: 'Link',
+          linkType: 'Organization',
+          id: 'org-id',
+        },
+      },
+    }
+
+    api = toPlainObject(api)
+
+    api.name = 'Updated Name'
+    return api.update().then((r) => {
+      expect(r).eql(responseData, 'app definition is wrapped')
+      expect(makeRequest.args[0][0].payload.name).equals('Updated Name', 'data is sent')
+    })
+  })
+
+  test('API call getAppBundle', async () => {
+    return makeGetEntityTest(setup, {
+      entityType: 'appBundle',
+      mockToReturn: appBundleMock,
+      methodToTest: 'getAppBundle',
+    })
+  })
+
+  test('API call getAppBundle fails', async () => {
+    return makeEntityMethodFailingTest(setup, {
+      methodToTest: 'getAppBundle',
+    })
+  })
+
+  test('API call getAppBundles', async () => {
+    return makeGetCollectionTest(setup, {
+      entityType: 'appBundle',
+      mockToReturn: appBundleMock,
+      methodToTest: 'getAppBundles',
+    })
+  })
+
+  test('API call getAppBundles fails', async () => {
+    return makeEntityMethodFailingTest(setup, {
+      methodToTest: 'getAppBundles',
+    })
+  })
+
+  test('API call createAppBundle', async () => {
+    const { api, entitiesMock } = setup(Promise.resolve({}))
+
+    entitiesMock['appBundle']['wrapAppBundle'].returns(appBundleMock)
+
+    return api['createAppBundle']({ appBundleId: 'id' }).then((result) => {
+      expect(result).equals(appBundleMock)
+    })
+  })
+
+  test('API call createAppBundle fails', async () => {
+    return makeEntityMethodFailingTest(setup, {
+      methodToTest: 'createAppBundle',
+    })
+  })
+})

--- a/test/unit/create-organization-api-test.js
+++ b/test/unit/create-organization-api-test.js
@@ -2,17 +2,18 @@ import createOrganizationApi, {
   __RewireAPI__ as createOrganizationApiRewireApi,
 } from '../../lib/create-organization-api'
 import {
-  cloneMock,
   appDefinitionMock,
+  appUploadMock,
+  cloneMock,
+  organizationInvitationMock,
   organizationMembershipMock,
+  organizationMock,
+  setupEntitiesMock,
   spaceMembershipMock,
   teamMembershipMock,
-  teamSpaceMembershipMock,
-  setupEntitiesMock,
-  organizationInvitationMock,
   teamMock,
+  teamSpaceMembershipMock,
   userMock,
-  organizationMock,
 } from './mocks/entities'
 import {
   makeGetEntityTest,
@@ -385,5 +386,45 @@ describe('A createOrganizationApi', () => {
         items: [teamSpaceMembershipMock],
       })
     })
+  })
+
+  test('API call getAppUpload', async () => {
+    const { api, entitiesMock } = setup(Promise.resolve({}))
+    entitiesMock['appUpload']['wrapAppUpload'].returns(appUploadMock)
+    return api['getAppUpload']('upload-id').then((result) => {
+      expect(result).eql(appUploadMock)
+    })
+  })
+
+  test('API call getAppUpload fails', async () => {
+    const error = cloneMock('error')
+    const { api } = setup(Promise.reject(error))
+
+    api['getAppUpload']('app-upload-id').then(
+      () => {},
+      (errorResponse) => {
+        expect(errorResponse).eql(error)
+      }
+    )
+  })
+
+  test('API call createAppUpload', async () => {
+    const { api, entitiesMock } = setup(Promise.resolve({}))
+    entitiesMock['appUpload']['wrapAppUpload'].returns(appUploadMock)
+    return api['createAppUpload']('content-of-zip-file').then((result) => {
+      expect(result).eql(appUploadMock)
+    })
+  })
+
+  test('API call createAppUpload fails', async () => {
+    const error = cloneMock('error')
+    const { api } = setup(Promise.reject(error))
+
+    api['createAppUpload']('content-of-zip-file').then(
+      () => {},
+      (errorResponse) => {
+        expect(errorResponse).eql(error)
+      }
+    )
   })
 })

--- a/test/unit/entities/app-bundle-test.js
+++ b/test/unit/entities/app-bundle-test.js
@@ -1,0 +1,34 @@
+import { cloneMock } from '../mocks/entities'
+import setupMakeRequest from '../mocks/makeRequest'
+import { wrapAppBundle, wrapAppBundleCollection } from '../../../lib/entities/app-bundle'
+import {
+  entityCollectionWrappedTest,
+  entityWrappedTest,
+  entityDeleteTest,
+} from '../test-creators/instance-entity-methods'
+import { describe, test } from 'mocha'
+
+function setup(promise) {
+  return {
+    makeRequest: setupMakeRequest(promise),
+    entityMock: cloneMock('appBundle'),
+  }
+}
+
+describe('Entity AppBundle', () => {
+  test('AppBundle is wrapped', async () => {
+    return entityWrappedTest(setup, { wrapperMethod: wrapAppBundle })
+  })
+
+  test('AppBundle collection is wrapped', async () => {
+    return entityCollectionWrappedTest(setup, {
+      wrapperMethod: wrapAppBundleCollection,
+    })
+  })
+
+  test('AppBundle delete', async () => {
+    return entityDeleteTest(setup, {
+      wrapperMethod: wrapAppBundle,
+    })
+  })
+})

--- a/test/unit/entities/app-upload-test.js
+++ b/test/unit/entities/app-upload-test.js
@@ -1,0 +1,38 @@
+import { wrapAppUpload, wrapAppUploadCollection } from '../../../lib/entities/app-upload'
+import setupMakeRequest from '../mocks/makeRequest'
+import { describe, test } from 'mocha'
+import {
+  entityCollectionWrappedTest,
+  entityWrappedTest,
+  failingActionTest,
+  entityDeleteTest,
+} from '../test-creators/instance-entity-methods'
+import { appUploadMock } from '../mocks/entities'
+
+function setup(promise) {
+  return {
+    makeRequest: setupMakeRequest(promise),
+    entityMock: appUploadMock,
+  }
+}
+
+describe('Entity AppUpload', () => {
+  test('AppUpload is wrapped', async () => {
+    return entityWrappedTest(setup, { wrapperMethod: wrapAppUpload })
+  })
+
+  test('AppUpload collection is wrapped', async () => {
+    return entityCollectionWrappedTest(setup, { wrapperMethod: wrapAppUploadCollection })
+  })
+
+  test('AppUpload delete', async () => {
+    return entityDeleteTest(setup, {
+      wrapperMethod: wrapAppUpload,
+      actionMethod: 'delete',
+    })
+  })
+
+  test('AppUpload delete fails', async () => {
+    return failingActionTest(setup, { wrapperMethod: wrapAppUpload, actionMethod: 'delete' })
+  })
+})

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -92,6 +92,13 @@ const appDefinitionMock = {
   ],
 }
 
+const appUploadMock = {
+  sys: Object.assign(cloneDeep(sysMock), {
+    type: 'AppUpload',
+    organization: { sys: { id: 'organization-id' } },
+  }),
+}
+
 const contentTypeMock = {
   sys: Object.assign(cloneDeep(sysMock), {
     type: 'ContentType',
@@ -474,6 +481,7 @@ const mocks = {
   appBundle: appBundleMock,
   appDefinition: appDefinitionMock,
   appInstallation: appInstallationMock,
+  appUpload: appUploadMock,
   asset: assetMock,
   assetKey: assetKeyMock,
   assetWithTags: assetMockWithTags,
@@ -525,6 +533,10 @@ function setupEntitiesMock(rewiredModuleApi) {
     appDefinition: {
       wrapAppDefinition: sinon.stub(),
       wrapAppDefinitionCollection: sinon.stub(),
+    },
+    appUpload: {
+      wrapAppUpload: sinon.stub(),
+      wrapAppUploadCollection: sinon.stub(),
     },
     appBundle: {
       wrapAppBundle: sinon.stub(),
@@ -652,6 +664,7 @@ export {
   appBundleMock,
   appInstallationMock,
   appDefinitionMock,
+  appUploadMock,
   linkMock,
   sysMock,
   spaceMock,

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -54,6 +54,26 @@ const personalAccessTokenMock = {
   scopes: ['content_management_manage'],
 }
 
+const appBundleMock = {
+  sys: Object.assign(cloneDeep(sysMock), {
+    type: 'AppBundle',
+    organization: { sys: { id: 'organziation-id' } },
+    appDefinition: { sys: { id: 'app-definition-id' } },
+  }),
+  files: [
+    {
+      name: 'build/asset-manifest.json',
+      size: 1066,
+      md5: '38OsiWdvD1sZJzEXx8jiaA==',
+    },
+    {
+      name: 'build/index.html',
+      size: 2010,
+      md5: 'xkXIzwdDGA4ynvPYBpvRww==',
+    },
+  ],
+}
+
 const appDefinitionMock = {
   sys: Object.assign(cloneDeep(sysMock), {
     type: 'AppDefinition',
@@ -450,40 +470,41 @@ export const scheduledActionCollectionMock = {
 }
 
 const mocks = {
-  link: linkMock,
-  sys: sysMock,
+  apiKey: apiKeyMock,
+  appBundle: appBundleMock,
+  appDefinition: appDefinitionMock,
+  appInstallation: appInstallationMock,
+  asset: assetMock,
+  assetKey: assetKeyMock,
+  assetWithTags: assetMockWithTags,
   contentType: contentTypeMock,
   editorInterface: editorInterfaceMock,
   entry: entryMock,
   entryWithTags: entryMockWithTags,
-  snapshot: snapShotMock,
-  asset: assetMock,
-  assetWithTags: assetMockWithTags,
-  assetKey: assetKeyMock,
+  environmentAlias: environmentAliasMock,
+  error: errorMock,
+  extension: extensionMock,
+  link: linkMock,
   locale: localeMock,
-  webhook: webhookMock,
+  organization: organizationMock,
+  organizationInvitation: organizationInvitationMock,
+  organizationMembership: organizationMembershipMock,
+  personalAccessToken: personalAccessTokenMock,
+  previewApiKey: previewApiKeyMock,
+  role: roleMock,
+  scheduledAction: scheduledActionMock,
+  snapshot: snapShotMock,
   spaceMember: spaceMemberMock,
   spaceMembership: spaceMembershipMock,
-  teamSpaceMembership: teamSpaceMembershipMock,
-  organizationMembership: organizationMembershipMock,
+  sys: sysMock,
+  tag: tagMock,
   team: teamMock,
   teamMembership: teamMembershipMock,
-  organizationInvitation: organizationInvitationMock,
-  role: roleMock,
-  apiKey: apiKeyMock,
-  previewApiKey: previewApiKeyMock,
-  error: errorMock,
+  teamSpaceMembership: teamSpaceMembershipMock,
   upload: uploadMock,
-  organization: organizationMock,
-  extension: extensionMock,
-  appDefinition: appDefinitionMock,
-  appInstallation: appInstallationMock,
-  user: userMock,
-  personalAccessToken: personalAccessTokenMock,
   usage: usageMock,
-  environmentAlias: environmentAliasMock,
-  tag: tagMock,
-  scheduledAction: scheduledActionMock,
+  user: userMock,
+  webhook: webhookMock,
 }
 
 function cloneMock(name) {
@@ -504,6 +525,10 @@ function setupEntitiesMock(rewiredModuleApi) {
     appDefinition: {
       wrapAppDefinition: sinon.stub(),
       wrapAppDefinitionCollection: sinon.stub(),
+    },
+    appBundle: {
+      wrapAppBundle: sinon.stub(),
+      wrapAppBundleCollection: sinon.stub(),
     },
     space: {
       wrapSpace: sinon.stub(),
@@ -624,6 +649,7 @@ function setupEntitiesMock(rewiredModuleApi) {
 }
 
 export {
+  appBundleMock,
   appInstallationMock,
   appDefinitionMock,
   linkMock,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
       "ClientParams",
 
       "ApiKey",
+      "AppUpload",
       "AppDefinition",
       "AppInstalation",
       "AppBundle",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
       "ApiKey",
       "AppDefinition",
       "AppInstalation",
+      "AppBundle",
       "Asset",
       "AssetKey",
       "ContentType",


### PR DESCRIPTION
## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

This PR introduces the AppBundle and AppHosting entities to the SDK

<!-- Describe your changes in detail -->


## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
