### PR TITLE
fix: correctly set payload & headers when using raw.post & raw.put

### DIFF
--- a/lib/adapters/REST/endpoints/http.ts
+++ b/lib/adapters/REST/endpoints/http.ts
@@ -15,7 +15,7 @@ export const post: RestEndpoint<'Http', 'post'> = <T = any>(
   { url, config }: { url: string; config?: AxiosRequestConfig },
   payload?: any
 ) => {
-  return raw.post<T>(http, url, config, payload)
+  return raw.post<T>(http, url, payload, config)
 }
 
 export const put: RestEndpoint<'Http', 'put'> = <T = any>(
@@ -23,7 +23,7 @@ export const put: RestEndpoint<'Http', 'put'> = <T = any>(
   { url, config }: { url: string; config?: AxiosRequestConfig },
   payload?: any
 ) => {
-  return raw.put<T>(http, url, config, payload)
+  return raw.put<T>(http, url, payload, config)
 }
 
 export const del: RestEndpoint<'Http', 'delete'> = <T = any>(

--- a/test/unit/adapters/REST/endpoints/http-test.js
+++ b/test/unit/adapters/REST/endpoints/http-test.js
@@ -1,0 +1,87 @@
+import { expect } from 'chai'
+import { describe, test } from 'mocha'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+
+function setup(promise, params = {}) {
+  return setupRestAdapter(promise, params)
+}
+
+describe('Rest Http', () => {
+  const URL = '/some/random/endpoint'
+  const CONFIG = {
+    headers: {
+      'X-Random-Headers': 'random value',
+    },
+  }
+  const PAYLOAD = 'some random payload'
+
+  test('get', async () => {
+    const { httpMock, adapterMock: adapter } = setup()
+
+    await adapter.makeRequest({
+      entityType: 'Http',
+      action: 'get',
+      params: { url: URL, config: CONFIG },
+    })
+
+    expect(httpMock.get.args[0][0]).to.equal(URL)
+    expect(httpMock.get.args[0][1]).to.contain(CONFIG)
+  })
+
+  test('post', async () => {
+    const { httpMock, adapterMock: adapter } = setup()
+
+    await adapter.makeRequest({
+      entityType: 'Http',
+      action: 'post',
+      params: { url: URL, config: CONFIG },
+      payload: PAYLOAD,
+    })
+
+    expect(httpMock.post.args[0][0]).to.equal(URL)
+    expect(httpMock.post.args[0][1]).to.equal(PAYLOAD)
+    expect(httpMock.post.args[0][2]).to.contain(CONFIG)
+  })
+
+  test('put', async () => {
+    const { httpMock, adapterMock: adapter } = setup()
+
+    await adapter.makeRequest({
+      entityType: 'Http',
+      action: 'put',
+      params: { url: URL, config: CONFIG },
+      payload: PAYLOAD,
+    })
+
+    expect(httpMock.put.args[0][0]).to.equal(URL)
+    expect(httpMock.put.args[0][1]).to.equal(PAYLOAD)
+    expect(httpMock.put.args[0][2]).to.contain(CONFIG)
+  })
+
+  test('delete', async () => {
+    const { httpMock, adapterMock: adapter } = setup()
+
+    await adapter.makeRequest({
+      entityType: 'Http',
+      action: 'delete',
+      params: { url: URL, config: CONFIG },
+    })
+
+    expect(httpMock.delete.args[0][0]).to.equal(URL)
+    expect(httpMock.delete.args[0][1]).to.contain(CONFIG)
+  })
+  test('request', async () => {
+    const { httpMock, adapterMock: adapter } = setup()
+
+    const requestConfig = { ...CONFIG, method: 'put' }
+    await adapter.makeRequest({
+      entityType: 'Http',
+      action: 'request',
+      params: { url: URL, config: requestConfig },
+      payload: PAYLOAD,
+    })
+
+    expect(httpMock.args[0][0]).to.equal(URL)
+    expect(httpMock.args[0][1]).to.contain(requestConfig)
+  })
+})

--- a/test/unit/mocks/http.js
+++ b/test/unit/mocks/http.js
@@ -1,17 +1,17 @@
 import sinon from 'sinon'
 
 export default function setupHttpMock(promise = Promise.resolve({ data: {} })) {
-  const mock = {
-    get: sinon.stub().returns(promise),
-    post: sinon.stub().returns(promise),
-    put: sinon.stub().returns(promise),
-    delete: sinon.stub().returns(promise),
-    defaults: {
-      baseURL: 'https://api.contentful.com/spaces/',
-    },
-    httpClientParams: {
-      hostUpload: 'upload.contentful.com',
-    },
+  const mock = sinon.stub().returns(promise)
+
+  mock.get = sinon.stub().returns(promise)
+  mock.post = sinon.stub().returns(promise)
+  mock.put = sinon.stub().returns(promise)
+  mock.delete = sinon.stub().returns(promise)
+  mock.defaults = {
+    baseURL: 'https://api.contentful.com/spaces/',
+  }
+  mock.httpClientParams = {
+    hostUpload: 'upload.contentful.com',
   }
 
   mock.cloneWithNewParams = () => mock


### PR DESCRIPTION
## Summary

v7.13 introduced a bug where the payload and the axios configuration for `raw.post` and `raw.put` was not set correctly.
The error was a wrong argument order.

This PR fixes the invalid order and adds unit tests to prevent this from happening again.

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation
