### PR TITLE
feat: [PEN-1508] add entry patch support

### DIFF
--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -1,5 +1,6 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
+import { OpPatch } from 'json-patch'
 import {
   CollectionProp,
   GetSpaceEnvironmentParams,
@@ -33,6 +34,26 @@ export const getMany: RestEndpoint<'Entry', 'getMany'> = <T extends KeyValueMap 
     `/spaces/${params.spaceId}/environments/${params.environmentId}/entries`,
     {
       params: normalizeSelect(params.query),
+    }
+  )
+}
+
+export const patch: RestEndpoint<'Entry', 'patch'> = <T extends KeyValueMap = KeyValueMap>(
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams & { entryId: string; version: number },
+  data: OpPatch[],
+  headers?: Record<string, unknown>
+) => {
+  return raw.patch<EntryProps<T>>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}`,
+    data,
+    {
+      headers: {
+        'X-Contentful-Version': params.version,
+        'Content-Type': 'application/json-patch+json',
+        ...headers,
+      },
     }
   )
 }

--- a/lib/adapters/REST/endpoints/raw.ts
+++ b/lib/adapters/REST/endpoints/raw.ts
@@ -16,6 +16,20 @@ export function get<T = any>(http: AxiosInstance, url: string, config?: AxiosReq
     .then((response) => response.data, errorHandler)
 }
 
+export function patch<T = any>(
+  http: AxiosInstance,
+  url: string,
+  payload?: any,
+  config?: AxiosRequestConfig
+) {
+  return http
+    .patch<T>(url, payload, {
+      baseURL: getBaseUrl(http),
+      ...config,
+    })
+    .then((response) => response.data, errorHandler)
+}
+
 export function post<T = any>(
   http: AxiosInstance,
   url: string,

--- a/lib/adapters/REST/rest-adapter.ts
+++ b/lib/adapters/REST/rest-adapter.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import { AxiosInstance, createHttpClient, CreateHttpClientParams } from 'contentful-sdk-core'
 import copy from 'fast-copy'
+import { OpPatch } from 'json-patch'
 import { Adapter, MakeRequestOptions } from '../../common-types'
 import endpoints from './endpoints'
 
@@ -55,7 +56,7 @@ export class RestAdapter implements Adapter {
     const endpoint: (
       http: AxiosInstance,
       params?: Record<string, unknown>,
-      payload?: Record<string, unknown>,
+      payload?: Record<string, unknown> | OpPatch[],
       headers?: Record<string, unknown>
     ) => Promise<R> =
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -52,6 +52,7 @@ import {
 } from './entities/webhook'
 import { AssetKeyProps, CreateAssetKeyProps } from './entities/asset-key'
 import { AppUploadProps } from './entities/app-upload'
+import { OpPatch } from 'json-patch'
 
 export interface DefaultElements<TPlainObject extends object = object> {
   toPlainObject(): TPlainObject
@@ -167,6 +168,7 @@ export type KeyValueMap = Record<string, any>
 
 type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Http', 'get', UA>): MRReturn<'Http', 'get'>
+  (opts: MROpts<'Http', 'patch', UA>): MRReturn<'Http', 'patch'>
   (opts: MROpts<'Http', 'post', UA>): MRReturn<'Http', 'post'>
   (opts: MROpts<'Http', 'put', UA>): MRReturn<'Http', 'put'>
   (opts: MROpts<'Http', 'delete', UA>): MRReturn<'Http', 'delete'>
@@ -246,6 +248,7 @@ type MRInternal<UA extends boolean> = {
 
   (opts: MROpts<'Entry', 'getMany', UA>): MRReturn<'Entry', 'getMany'>
   (opts: MROpts<'Entry', 'get', UA>): MRReturn<'Entry', 'get'>
+  (opts: MROpts<'Entry', 'patch', UA>): MRReturn<'Entry', 'patch'>
   (opts: MROpts<'Entry', 'update', UA>): MRReturn<'Entry', 'update'>
   (opts: MROpts<'Entry', 'delete', UA>): MRReturn<'Entry', 'delete'>
   (opts: MROpts<'Entry', 'publish', UA>): MRReturn<'Entry', 'publish'>
@@ -415,6 +418,7 @@ export interface Adapter {
 export type MRActions = {
   Http: {
     get: { params: { url: string; config?: AxiosRequestConfig }; return: any }
+    patch: { params: { url: string; config?: AxiosRequestConfig }; payload: any; return: any }
     post: { params: { url: string; config?: AxiosRequestConfig }; payload: any; return: any }
     put: { params: { url: string; config?: AxiosRequestConfig }; payload: any; return: any }
     delete: { params: { url: string; config?: AxiosRequestConfig }; return: any }
@@ -654,6 +658,12 @@ export type MRActions = {
     }
     get: {
       params: GetSpaceEnvironmentParams & { entryId: string } & QueryParams
+      return: EntryProps<any>
+    }
+    patch: {
+      params: GetSpaceEnvironmentParams & { entryId: string; version: number }
+      payload: OpPatch[]
+      headers?: Record<string, unknown>
       return: EntryProps<any>
     }
     update: {
@@ -1054,7 +1064,7 @@ export interface MakeRequestOptions {
   entityType: keyof MRActions
   action: string
   params?: Record<string, unknown>
-  payload?: Record<string, unknown>
+  payload?: Record<string, unknown> | OpPatch[]
   headers?: Record<string, unknown>
   userAgent: string
 }

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -80,12 +80,14 @@ import { DefaultParams, OptionalDefaults } from './wrappers/wrap'
 import { AssetKeyProps, CreateAssetKeyProps } from '../entities/asset-key'
 import { AppUploadProps } from '../entities/app-upload'
 import { AppBundleProps, CreateAppBundleProps } from '../entities/app-bundle'
+import { OpPatch } from 'json-patch'
 
 export type PlainClientAPI = {
   raw: {
     getDefaultParams(): DefaultParams | undefined
     get<T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T>
     post<T = unknown>(url: string, payload?: any, config?: AxiosRequestConfig): Promise<T>
+    patch<T = unknown>(url: string, payload?: any, config?: AxiosRequestConfig): Promise<T>
     put<T = unknown>(url: string, payload?: any, config?: AxiosRequestConfig): Promise<T>
     delete<T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T>
     http<T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T>
@@ -211,6 +213,11 @@ export type PlainClientAPI = {
     update<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>,
       rawData: EntryProps<T>,
+      headers?: Record<string, unknown>
+    ): Promise<EntryProps<T>>
+    patch<T extends KeyValueMap = KeyValueMap>(
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>,
+      rawData: OpPatch[],
       headers?: Record<string, unknown>
     ): Promise<EntryProps<T>>
     delete(params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>): Promise<any>

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -20,6 +20,13 @@ export const createPlainClient = (
           action: 'get',
           params: { url, config },
         }),
+      patch: (url, payload, config) =>
+        makeRequest({
+          entityType: 'Http',
+          action: 'patch',
+          params: { url, config },
+          payload,
+        }),
       post: (url, payload, config) =>
         makeRequest({
           entityType: 'Http',
@@ -105,6 +112,7 @@ export const createPlainClient = (
       getMany: wrap(wrapParams, 'Entry', 'getMany'),
       get: wrap(wrapParams, 'Entry', 'get'),
       update: wrap(wrapParams, 'Entry', 'update'),
+      patch: wrap(wrapParams, 'Entry', 'patch'),
       delete: wrap(wrapParams, 'Entry', 'delete'),
       publish: wrap(wrapParams, 'Entry', 'publish'),
       unpublish: wrap(wrapParams, 'Entry', 'unpublish'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -2705,6 +2705,11 @@
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
+    "@types/json-patch": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/json-patch/-/json-patch-0.0.30.tgz",
+      "integrity": "sha512-MhCUjojzDhVLnZnxwPwa+rETFRDQ0ffjxYdrqOP6TBO2O0/Z64PV5tNeYApo4bc4y4frbWOrRwv/eEkXlI13Rw=="
+    },
     "@types/json-schema": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "tonic-example.js"
   ],
   "dependencies": {
+    "@types/json-patch": "0.0.30",
     "axios": "^0.21.0",
     "contentful-sdk-core": "^6.7.0",
     "fast-copy": "^2.1.0",

--- a/test/integration/entry-integration.js
+++ b/test/integration/entry-integration.js
@@ -316,7 +316,7 @@ describe('Entry Api', () => {
         .then((unpublishedContentType) => unpublishedContentType.delete())
     })
 
-    test('Create, update, publish, unpublish, archive, unarchive and delete entry', async () => {
+    test('Create, update, patch, publish, unpublish, archive, unarchive and delete entry', async () => {
       return environment
         .createEntry(contentType.sys.id, { fields: { title: { 'en-US': 'this is the title' } } })
         .then((entry) => {
@@ -331,14 +331,25 @@ describe('Entry Api', () => {
                 'title has changed',
                 'updated title'
               )
-              return updatedEntry.unpublish().then((unpublishedEntry) => {
-                expect(unpublishedEntry.isDraft(), 'entry is back in draft').ok
-                return unpublishedEntry.archive().then((archivedEntry) => {
-                  expect(archivedEntry.isArchived(), 'entry is archived').ok
-                  return archivedEntry.unarchive().then((unarchivedEntry) => {
-                    expect(unarchivedEntry.isArchived(), 'entry is not archived anymore').not.ok
-                    expect(unarchivedEntry.isDraft(), 'entry is back in draft').ok
-                    return unarchivedEntry.delete()
+              const patchOp = {
+                op: 'replace',
+                path: '/fields/title/en-US',
+                value: 'title was patched',
+              }
+              return updatedEntry.patch([patchOp]).then((patchedEntry) => {
+                expect(patchedEntry.fields.title['en-US']).equals(
+                  'title was patched',
+                  'updated title'
+                )
+                return patchedEntry.unpublish().then((unpublishedEntry) => {
+                  expect(unpublishedEntry.isDraft(), 'entry is back in draft').ok
+                  return unpublishedEntry.archive().then((archivedEntry) => {
+                    expect(archivedEntry.isArchived(), 'entry is archived').ok
+                    return archivedEntry.unarchive().then((unarchivedEntry) => {
+                      expect(unarchivedEntry.isArchived(), 'entry is not archived anymore').not.ok
+                      expect(unarchivedEntry.isDraft(), 'entry is back in draft').ok
+                      return unarchivedEntry.delete()
+                    })
                   })
                 })
               })

--- a/test/unit/entities/entry-test.js
+++ b/test/unit/entities/entry-test.js
@@ -4,6 +4,7 @@ import { wrapEntry, wrapEntryCollection } from '../../../lib/entities/entry'
 import {
   entityWrappedTest,
   entityCollectionWrappedTest,
+  entityPatchTest,
   entityUpdateTest,
   entityDeleteTest,
   entityPublishTest,
@@ -35,6 +36,12 @@ describe('Entity Entry', () => {
   test('Entry collection is wrapped', async () => {
     return entityCollectionWrappedTest(setup, {
       wrapperMethod: wrapEntryCollection,
+    })
+  })
+
+  test('Entry patch', async () => {
+    return entityPatchTest(setup, {
+      wrapperMethod: wrapEntry,
     })
   })
 

--- a/test/unit/test-creators/instance-entity-methods.js
+++ b/test/unit/test-creators/instance-entity-methods.js
@@ -15,6 +15,13 @@ export function entityCollectionWrappedTest(setup, { wrapperMethod }) {
   expect(entity.toPlainObject()).eql(collection)
 }
 
+export async function entityPatchTest(setup, { wrapperMethod }) {
+  const { makeRequest, entityMock } = setup()
+  const entity = wrapperMethod(makeRequest, entityMock)
+  const response = await entity.patch([])
+  expect(response.toPlainObject, 'response is wrapped').to.be.ok
+}
+
 export async function entityUpdateTest(setup, { wrapperMethod }) {
   await entityActionTest(setup, { wrapperMethod, actionMethod: 'update' })
 }


### PR DESCRIPTION
## Summary

Adds support for [patching an entry](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/entries/entry/patch-an-entry/console/curl).

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [ ] The new method is added to the documentation
