### PR TITLE
feat: add optional headers param to entry/asset GET

### DIFF
--- a/lib/adapters/REST/endpoints/asset.ts
+++ b/lib/adapters/REST/endpoints/asset.ts
@@ -17,7 +17,7 @@ import { normalizeSelect } from './utils'
 export const get: RestEndpoint<'Asset', 'get'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { assetId: string } & QueryParams,
-  _rawData?: never,
+  rawData?: unknown,
   headers?: Record<string, unknown>
 ) => {
   return raw.get<AssetProps>(

--- a/lib/adapters/REST/endpoints/asset.ts
+++ b/lib/adapters/REST/endpoints/asset.ts
@@ -16,13 +16,16 @@ import { normalizeSelect } from './utils'
 
 export const get: RestEndpoint<'Asset', 'get'> = (
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { assetId: string } & QueryParams
+  params: GetSpaceEnvironmentParams & { assetId: string } & QueryParams,
+  _rawData?: never,
+  headers?: Record<string, unknown>
 ) => {
   return raw.get<AssetProps>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/assets/${params.assetId}`,
     {
       params: normalizeSelect(params.query),
+      headers: { ...headers },
     }
   )
 }

--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -14,13 +14,16 @@ import { normalizeSelect } from './utils'
 
 export const get: RestEndpoint<'Entry', 'get'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { entryId: string } & QueryParams
+  params: GetSpaceEnvironmentParams & { entryId: string } & QueryParams,
+  _rawData?: never,
+  headers?: Record<string, unknown>
 ) => {
   return raw.get<EntryProps<T>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}`,
     {
       params: normalizeSelect(params.query),
+      headers: { ...headers },
     }
   )
 }

--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -15,7 +15,7 @@ import { normalizeSelect } from './utils'
 export const get: RestEndpoint<'Entry', 'get'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { entryId: string } & QueryParams,
-  _rawData?: never,
+  rawData?: unknown,
   headers?: Record<string, unknown>
 ) => {
   return raw.get<EntryProps<T>>(

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -209,7 +209,7 @@ export type PlainClientAPI = {
     ): Promise<CollectionProp<EntryProps<T>>>
     get<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>,
-      _rawData?: never,
+      rawData?: unknown,
       headers?: Record<string, unknown>
     ): Promise<EntryProps<T>>
     update<T extends KeyValueMap = KeyValueMap>(
@@ -253,7 +253,7 @@ export type PlainClientAPI = {
     ): Promise<CollectionProp<AssetProps>>
     get(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string } & QueryParams>,
-      _rawData?: never,
+      rawData?: unknown,
       headers?: Record<string, unknown>
     ): Promise<AssetProps>
     update(

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -208,7 +208,9 @@ export type PlainClientAPI = {
       params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>
     ): Promise<CollectionProp<EntryProps<T>>>
     get<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>,
+      _rawData?: never,
+      headers?: Record<string, unknown>
     ): Promise<EntryProps<T>>
     update<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>,
@@ -250,7 +252,9 @@ export type PlainClientAPI = {
       params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>
     ): Promise<CollectionProp<AssetProps>>
     get(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string } & QueryParams>
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string } & QueryParams>,
+      _rawData?: never,
+      headers?: Record<string, unknown>
     ): Promise<AssetProps>
     update(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string }>,


### PR DESCRIPTION
## Summary

Add an optional `headers` parameter to `entry.get` and `asset.get` in the plain client

## Motivation and Context

In order for our shared `EntityRepo` to work with the plain client it needs the ability to set those headers


## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

