### PR TITLE
fix: remove use of delay library from Bulk Actions and the project

### DIFF
--- a/lib/methods/bulk-action.ts
+++ b/lib/methods/bulk-action.ts
@@ -1,4 +1,3 @@
-import delay from 'delay'
 import {
   BulkAction,
   BulkActionPayload,
@@ -6,6 +5,7 @@ import {
   BulkActionStatus,
 } from '../entities/bulk-action'
 import { PlainClientAPI } from '../plain/common-types'
+import { sleep } from './utils'
 
 const DEFAULT_MAX_RETRIES = 30
 const DEFAULT_INITIAL_DELAY_MS = 1000
@@ -66,7 +66,7 @@ export async function pollBulkActionStatus(
   const throwOnFailedExecution = options?.throwOnFailedExecution ?? true
 
   // Initial delay for short-running BulkActions
-  await delay(initialDelayMs)
+  await sleep(initialDelayMs)
 
   while (retryCount < maxRetries && !done) {
     action = await getBulkActionFunction()
@@ -85,7 +85,7 @@ export async function pollBulkActionStatus(
       return action
     }
 
-    await delay(retryIntervalMs)
+    await sleep(retryIntervalMs)
     retryCount += 1
   }
 

--- a/lib/methods/utils.ts
+++ b/lib/methods/utils.ts
@@ -1,0 +1,4 @@
+/** Helper function that resolves a Promise after the specified duration (in milliseconds) */
+export function sleep(durationMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, durationMs))
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3343,12 +3343,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "argv": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
-      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
-      "dev": true
-    },
     "argv-formatter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
@@ -5299,19 +5293,6 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
-    "codecov": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.1.tgz",
-      "integrity": "sha512-Qm7ltx1pzLPsliZY81jyaQ80dcNR4/JpcX0IHCIWrHBXgseySqbdbYfkdiXd7o/xmzQpGRVCKGYeTrHUpn6Dcw==",
-      "dev": true,
-      "requires": {
-        "argv": "0.0.2",
-        "ignore-walk": "3.0.3",
-        "js-yaml": "3.14.0",
-        "teeny-request": "6.0.1",
-        "urlgrey": "0.4.4"
-      }
-    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -6074,12 +6055,6 @@
           "dev": true
         }
       }
-    },
-    "delay": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.0.tgz",
-      "integrity": "sha512-txgOrJu3OdtOfTiEOT2e76dJVfG/1dz2NZ4F0Pyt4UGZJryssMRp5vdM5wQoLwSOBNdrJv3F9PAhp/heqd7vrA==",
-      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -8480,39 +8455,6 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
-    "https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-      "dev": true,
-      "requires": {
-        "agent-base": "5",
-        "debug": "4"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
-      }
-    },
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -8710,15 +8652,6 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
-    },
-    "ignore-walk": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
-      "dev": true,
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
     },
     "iltorb": {
       "version": "2.4.5",
@@ -18838,15 +18771,6 @@
         "stream-shift": "^1.0.0"
       }
     },
-    "stream-events": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
-      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
-      "dev": true,
-      "requires": {
-        "stubs": "^3.0.0"
-      }
-    },
     "stream-http": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
@@ -19019,12 +18943,6 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
-    "stubs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
-      "dev": true
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -19155,19 +19073,6 @@
             "util-deprecate": "^1.0.1"
           }
         }
-      }
-    },
-    "teeny-request": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.1.tgz",
-      "integrity": "sha512-TAK0c9a00ELOqLrZ49cFxvPVogMUFaWY8dUsQc/0CuQPGF+BOxOQzXfE413BAk2kLomwNplvdtMpeaeGWmoc2g==",
-      "dev": true,
-      "requires": {
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.2.0",
-        "stream-events": "^1.0.5",
-        "uuid": "^3.3.2"
       }
     },
     "temp-dir": {
@@ -19941,12 +19846,6 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
-    },
-    "urlgrey": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
-      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
-      "dev": true
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "contentful-sdk-jsdoc": "^2.2.0",
     "core-js": "^2.5.7",
     "cz-conventional-changelog": "^3.3.0",
-    "delay": "^4.4.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.20.2",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,5 @@
 import { createClient } from '../lib/contentful-management'
-import delay from 'delay'
+import { sleep } from '../lib/methods/utils'
 
 const params = {}
 
@@ -68,7 +68,7 @@ export function waitForEnvironmentToBeReady(space, environment) {
   return space.getEnvironment(environment.sys.id).then((env) => {
     if (env.sys.status.sys.id !== 'ready') {
       console.log(`Environment ${environment.sys.id} is not ready yet. Waiting 1000ms...`)
-      return delay(1000).then(() => waitForEnvironmentToBeReady(space, env))
+      return sleep(1000).then(() => waitForEnvironmentToBeReady(space, env))
     }
     return env
   })

--- a/test/integration/bulk-action-integration.ts
+++ b/test/integration/bulk-action-integration.ts
@@ -11,7 +11,7 @@ import {
 } from '../../lib/entities/bulk-action'
 import { Environment } from '../../lib/entities/environment'
 import { Space } from '../../lib/entities/space'
-import { BulkActionFailedError, waitForBulkActionProcessing } from '../../lib/methods/bulk-action'
+import { waitForBulkActionProcessing } from '../../lib/methods/bulk-action'
 import { TestDefaults } from '../defaults'
 import { getDefaultSpace, getPlainClient } from '../helpers'
 import { makeLink, makeVersionedLink } from '../utils'


### PR DESCRIPTION
## Summary

- This PR removes the usage of `delay` in the SDK as it was primarily being used in `devDependencies`.

## Description

- Removes usage of `delay` in BulkAction
- Creates a simple `sleep` function that behaves the same
- Removes `delay` from `package.json`

## Motivation and Context

- A breaking behaviour was introduced on the release `7.17.0` where `delay` was being used outside of `devDependencies`.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
