### PR TITLE
ci: dont build twice for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ jobs:
     steps:
       - checkout
       - run: npm install
-      - run: npm run build
       - run: npm run semantic-release
 workflows:
   version: 2


### PR DESCRIPTION
## Summary

There is a `presemantic-release` script taking care of building.
