### PR TITLE
fix(plain-client): tag param types

### DIFF
--- a/lib/adapters/REST/endpoints/tag.ts
+++ b/lib/adapters/REST/endpoints/tag.ts
@@ -6,7 +6,13 @@ import {
   GetTagParams,
   QueryParams,
 } from '../../../common-types'
-import { CreateTagProps, TagProps, TagVisibility } from '../../../entities/tag'
+import {
+  CreateTagParams,
+  CreateTagProps,
+  DeleteTagParams,
+  TagProps,
+  UpdateTagProps,
+} from '../../../entities/tag'
 import { RestEndpoint } from '../types'
 import * as raw from './raw'
 
@@ -28,7 +34,7 @@ export const getMany: RestEndpoint<'Tag', 'getMany'> = (
 
 export const createWithId: RestEndpoint<'Tag', 'createWithId'> = (
   http: AxiosInstance,
-  { visibility, ...params }: GetTagParams & { visibility?: TagVisibility },
+  { visibility, ...params }: CreateTagParams,
   rawData: CreateTagProps
 ) => {
   const data = copy(rawData)
@@ -40,7 +46,7 @@ export const createWithId: RestEndpoint<'Tag', 'createWithId'> = (
 export const update: RestEndpoint<'Tag', 'update'> = (
   http: AxiosInstance,
   params: GetTagParams,
-  rawData: TagProps,
+  rawData: UpdateTagProps,
   headers?: Record<string, unknown>
 ) => {
   const data = copy(rawData)
@@ -56,7 +62,7 @@ export const update: RestEndpoint<'Tag', 'update'> = (
 
 export const del: RestEndpoint<'Tag', 'delete'> = (
   http: AxiosInstance,
-  { version, ...params }: GetTagParams & { version: number }
+  { version, ...params }: DeleteTagParams
 ) => {
   return raw.del(http, getTagUrl(params), { headers: { 'X-Contentful-Version': version } })
 }

--- a/lib/entities/tag.ts
+++ b/lib/entities/tag.ts
@@ -1,6 +1,6 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import { DefaultElements, MakeRequest, MetaSysProps, SysLink } from '../common-types'
+import { DefaultElements, GetTagParams, MakeRequest, MetaSysProps, SysLink } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 
@@ -22,6 +22,10 @@ export type TagProps = {
 }
 
 export type CreateTagProps = Omit<TagProps, 'sys'>
+export type UpdateTagProps = Omit<TagProps, 'sys'> & { sys: Pick<TagSysProps, 'version'> }
+
+export type CreateTagParams = GetTagParams & { visibility?: TagVisibility }
+export type DeleteTagParams = GetTagParams & { version: number }
 
 export type TagCollectionProps = {
   sys: {

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -61,7 +61,7 @@ import { SnapshotProps } from '../entities/snapshot'
 import { SpaceProps } from '../entities/space'
 import { SpaceMemberProps } from '../entities/space-member'
 import { CreateSpaceMembershipProps, SpaceMembershipProps } from '../entities/space-membership'
-import { CreateTagProps, TagProps } from '../entities/tag'
+import { CreateTagProps, TagProps, UpdateTagProps } from '../entities/tag'
 import { CreateTeamProps, TeamProps } from '../entities/team'
 import { CreateTeamMembershipProps, TeamMembershipProps } from '../entities/team-membership'
 import {
@@ -539,7 +539,7 @@ export type PlainClientAPI = {
     createWithId(params: OptionalDefaults<GetTagParams>, rawData: CreateTagProps): Promise<TagProps>
     update(
       params: OptionalDefaults<GetTagParams>,
-      rawData: TagProps,
+      rawData: UpdateTagProps,
       headers?: Record<string, unknown>
     ): Promise<TagProps>
     delete(params: OptionalDefaults<GetTagParams>, version: number): Promise<any>


### PR DESCRIPTION
While interacting with the plain client, I figured out that the provided types are wrong (my bad in the first place as I did the types for `Tag`).

This PR introduces dedicated types for tag `create`, ùpdate` and `delete`.
