### PR TITLE
feat: add entry references to entry and environment methods []

### DIFF
--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -178,3 +178,15 @@ export const createWithId: RestEndpoint<'Entry', 'createWithId'> = <
     }
   )
 }
+
+export const references: RestEndpoint<'Entry', 'references'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams & { entryId: string; maxDepth: number }
+): Promise<CollectionProp<EntryProps>> => {
+  const { spaceId, environmentId, entryId, maxDepth = 2 } = params
+
+  return raw.get<CollectionProp<EntryProps>>(
+    http,
+    `/spaces/${spaceId}/environments/${environmentId}/entries/${entryId}/references?include=${maxDepth}`
+  )
+}

--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -182,10 +182,10 @@ export const createWithId: RestEndpoint<'Entry', 'createWithId'> = <
 export const references: RestEndpoint<'Entry', 'references'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { entryId: string; maxDepth?: number }
-): Promise<EntryReferenceProps<EntryProps>> => {
+): Promise<EntryReferenceProps> => {
   const { spaceId, environmentId, entryId, maxDepth = 2 } = params
 
-  return raw.get<EntryReferenceProps<EntryProps>>(
+  return raw.get<EntryReferenceProps>(
     http,
     `/spaces/${spaceId}/environments/${environmentId}/entries/${entryId}/references?include=${maxDepth}`
   )

--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -7,7 +7,7 @@ import {
   KeyValueMap,
   QueryParams,
 } from '../../../common-types'
-import { CreateEntryProps, EntryProps } from '../../../entities/entry'
+import { CreateEntryProps, EntryProps, EntryReferenceProps } from '../../../entities/entry'
 import { RestEndpoint } from '../types'
 import * as raw from './raw'
 import { normalizeSelect } from './utils'
@@ -181,11 +181,11 @@ export const createWithId: RestEndpoint<'Entry', 'createWithId'> = <
 
 export const references: RestEndpoint<'Entry', 'references'> = (
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { entryId: string; maxDepth: number }
-): Promise<CollectionProp<EntryProps>> => {
+  params: GetSpaceEnvironmentParams & { entryId: string; maxDepth?: number }
+): Promise<EntryReferenceProps<EntryProps>> => {
   const { spaceId, environmentId, entryId, maxDepth = 2 } = params
 
-  return raw.get<CollectionProp<EntryProps>>(
+  return raw.get<EntryReferenceProps<EntryProps>>(
     http,
     `/spaces/${spaceId}/environments/${environmentId}/entries/${entryId}/references?include=${maxDepth}`
   )

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -743,7 +743,7 @@ export type MRActions = {
     }
     references: {
       params: GetSpaceEnvironmentParams & { entryId: string; maxDepth?: number }
-      return: EntryReferenceProps<EntryProps>
+      return: EntryReferenceProps
     }
   }
   Extension: {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -13,7 +13,7 @@ import {
 } from './entities/asset'
 import { ContentTypeProps, CreateContentTypeProps } from './entities/content-type'
 import { EditorInterfaceProps } from './entities/editor-interface'
-import { CreateEntryProps, EntryProps } from './entities/entry'
+import { CreateEntryProps, EntryProps, EntryReferenceProps } from './entities/entry'
 import { CreateEnvironmentProps, EnvironmentProps } from './entities/environment'
 import { CreateEnvironmentAliasProps, EnvironmentAliasProps } from './entities/environment-alias'
 import { CreateLocaleProps, LocaleProps } from './entities/locale'
@@ -154,9 +154,6 @@ export interface CollectionProp<TObj> {
   skip: number
   limit: number
   items: TObj[]
-  includes?: {
-    [key: string]: TObj[]
-  }
 }
 
 export interface Collection<T, TPlain>
@@ -746,7 +743,7 @@ export type MRActions = {
     }
     references: {
       params: GetSpaceEnvironmentParams & { entryId: string; maxDepth: number }
-      return: CollectionProp<EntryProps>
+      return: EntryReferenceProps<EntryProps>
     }
   }
   Extension: {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -742,7 +742,7 @@ export type MRActions = {
       return: EntryProps<any>
     }
     references: {
-      params: GetSpaceEnvironmentParams & { entryId: string; maxDepth: number }
+      params: GetSpaceEnvironmentParams & { entryId: string; maxDepth?: number }
       return: EntryReferenceProps<EntryProps>
     }
   }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -276,6 +276,7 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Entry', 'unarchive', UA>): MRReturn<'Entry', 'unarchive'>
   (opts: MROpts<'Entry', 'create', UA>): MRReturn<'Entry', 'create'>
   (opts: MROpts<'Entry', 'createWithId', UA>): MRReturn<'Entry', 'createWithId'>
+  (opts: MROpts<'Entry', 'references', UA>): MRReturn<'Entry', 'references'>
 
   (opts: MROpts<'Extension', 'get', UA>): MRReturn<'Extension', 'get'>
   (opts: MROpts<'Extension', 'getMany', UA>): MRReturn<'Extension', 'getMany'>
@@ -739,6 +740,10 @@ export type MRActions = {
       params: GetSpaceEnvironmentParams & { entryId: string; contentTypeId: string }
       payload: CreateEntryProps<any>
       return: EntryProps<any>
+    }
+    references: {
+      params: GetSpaceEnvironmentParams & { entryId: string; maxDepth: number }
+      return: CollectionProp<EntryProps>
     }
   }
   Extension: {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -154,6 +154,9 @@ export interface CollectionProp<TObj> {
   skip: number
   limit: number
   items: TObj[]
+  includes?: {
+    [key: string]: TObj[]
+  }
 }
 
 export interface Collection<T, TPlain>

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -787,6 +787,8 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((space) => space.getEnvironment('<environment_id>'))
      * .then((environment) => environment.getEntryReferences('<entry_id>', '<max_depth>'))
      * .then((entry) => console.log(entry.includes))
+     * // Or
+     * .then((environment) => environment.getEntry('<entry_id>')).then((entry) => entry.references('<max_depth>'))
      * .catch(console.error)
      * ```
      */

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -771,7 +771,24 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
     },
 
     /**
-     * Todo: Explain this
+     * Get entry references
+     * @param entryId - Entry ID
+     * @param maxDepth - Level of the entry descendants from 1 up to 10 maximum
+     * @returns Promise of Entry references
+     * @example ```javascript
+     * const contentful = require('contentful-management');
+     *
+     * const client = contentful.createClient({
+     *  accessToken: '<contentful_management_api_key>
+     * })
+     *
+     * // Get entry references
+     * client.getSpace('<space_id>')
+     * .then((space) => space.getEnvironment('<environment_id>'))
+     * .then((environment) => environment.getEntryReferences('<entry_id>', '<max_depth>'))
+     * .then((entry) => console.log(entry.includes))
+     * .catch(console.error)
+     * ```
      */
     getEntryReferences(entryId: string, maxDepth: number) {
       const raw = this.toPlainObject() as EnvironmentProps

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -771,6 +771,23 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
     },
 
     /**
+     * Todo: Explain this
+     */
+    getEntryReferences(entryId: string, maxDepth: number) {
+      const raw = this.toPlainObject() as EnvironmentProps
+      return makeRequest({
+        entityType: 'Entry',
+        action: 'references',
+        params: {
+          spaceId: raw.sys.space.sys.id,
+          environmentId: raw.sys.id,
+          entryId: entryId,
+          maxDepth: maxDepth,
+        },
+      }).then((response) => wrapEntryCollection(makeRequest, response))
+    },
+
+    /**
      * Gets an Asset
      * Warning: if you are using the select operator, when saving, any field that was not selected will be removed
      * from your entry in the backend

--- a/lib/entities/entry.ts
+++ b/lib/entities/entry.ts
@@ -24,6 +24,12 @@ export type EntryProps<T = KeyValueMap> = {
 
 export type CreateEntryProps<TFields = KeyValueMap> = Omit<EntryProps<TFields>, 'sys'>
 
+export interface EntryReferenceProps<TObj> extends CollectionProp<TObj> {
+  includes?: {
+    [key: string]: TObj[]
+  }
+}
+
 type EntryApi = {
   /**
    * Sends an update to the server with any changes made to the object's properties
@@ -225,7 +231,10 @@ type EntryApi = {
    */
   isUpdated(): boolean
 
-  references(maxDepth: number): Promise<CollectionProp<EntryProps>>
+  /**
+   * Recursively collects references of an entry and their descendants
+   */
+  references(maxDepth: number): Promise<EntryReferenceProps<EntryProps>>
 }
 
 export interface Entry extends EntryProps, DefaultElements<EntryProps>, EntryApi {}

--- a/lib/entities/entry.ts
+++ b/lib/entities/entry.ts
@@ -12,6 +12,7 @@ import {
   MakeRequest,
   CollectionProp,
 } from '../common-types'
+import type { AssetProps } from '../entities/asset'
 import * as checks from '../plain/checks'
 import type { OpPatch } from 'json-patch'
 
@@ -24,9 +25,10 @@ export type EntryProps<T = KeyValueMap> = {
 
 export type CreateEntryProps<TFields = KeyValueMap> = Omit<EntryProps<TFields>, 'sys'>
 
-export interface EntryReferenceProps<TObj> extends CollectionProp<TObj> {
+export interface EntryReferenceProps extends CollectionProp<EntryProps> {
   includes?: {
-    [key: string]: TObj[]
+    Entry?: CollectionProp<EntryProps>
+    Asset?: CollectionProp<AssetProps>
   }
 }
 
@@ -234,7 +236,7 @@ type EntryApi = {
   /**
    * Recursively collects references of an entry and their descendants
    */
-  references(maxDepth: number): Promise<EntryReferenceProps<EntryProps>>
+  references(maxDepth: number): Promise<EntryReferenceProps>
 }
 
 export interface Entry extends EntryProps, DefaultElements<EntryProps>, EntryApi {}

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -271,7 +271,7 @@ export type PlainClientAPI = {
     ): Promise<EntryProps<T>>
     references(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string; maxDepth?: number }>
-    ): Promise<EntryReferenceProps<EntryProps>>
+    ): Promise<EntryReferenceProps>
   }
   asset: {
     getMany(

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -270,7 +270,7 @@ export type PlainClientAPI = {
       rawData: CreateEntryProps<T>
     ): Promise<EntryProps<T>>
     references(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string; maxDepth: number }>
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string; maxDepth?: number }>
     ): Promise<EntryReferenceProps<EntryProps>>
   }
   asset: {

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -40,7 +40,7 @@ import {
 } from '../entities/asset'
 import { ContentTypeProps } from '../entities/content-type'
 import { EditorInterfaceProps } from '../entities/editor-interface'
-import { CreateEntryProps, EntryProps } from '../entities/entry'
+import { CreateEntryProps, EntryProps, EntryReferenceProps } from '../entities/entry'
 import { CreateEnvironmentProps, EnvironmentProps } from '../entities/environment'
 import { CreateEnvironmentAliasProps, EnvironmentAliasProps } from '../entities/environment-alias'
 import { CreateLocaleProps, LocaleProps } from '../entities/locale'
@@ -271,7 +271,7 @@ export type PlainClientAPI = {
     ): Promise<EntryProps<T>>
     references(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string; maxDepth: number }>
-    ): Promise<CollectionProp<EntryProps>>
+    ): Promise<EntryReferenceProps<EntryProps>>
   }
   asset: {
     getMany(

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -269,6 +269,9 @@ export type PlainClientAPI = {
       >,
       rawData: CreateEntryProps<T>
     ): Promise<EntryProps<T>>
+    references(
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string; maxDepth: number }>
+    ): Promise<CollectionProp<EntryProps>>
   }
   asset: {
     getMany(

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -126,6 +126,7 @@ export const createPlainClient = (
       unarchive: wrap(wrapParams, 'Entry', 'unarchive'),
       create: wrap(wrapParams, 'Entry', 'create'),
       createWithId: wrap(wrapParams, 'Entry', 'createWithId'),
+      references: wrap(wrapParams, 'Entry', 'references'),
     },
     asset: {
       getMany: wrap(wrapParams, 'Asset', 'getMany'),

--- a/test/defaults.ts
+++ b/test/defaults.ts
@@ -5,5 +5,6 @@ export const TestDefaults = {
   environmentId: 'master',
   entry: {
     testEntryId: '5ETMRzkl9KM4omyMwKAOki',
+    testEntryReferenceId: '3ZgkmNQJxGjO9TUcnDgNQC',
   },
 }

--- a/test/integration/entry-references-integration.ts
+++ b/test/integration/entry-references-integration.ts
@@ -17,10 +17,13 @@ describe('Entry References', async function () {
     testEnvironment = await testSpace.getEnvironment('master')
   })
 
-  describe('Environment Scoped', () => {
+  describe.only('Environment Scoped', () => {
     let entryWithReferences
     before(async () => {
       entryWithReferences = await testEnvironment.getEntryReferences(ENTRY_WITH_REFERENCES_ID, 2)
+      console.dir(entryWithReferences, {
+        depth: 6,
+      })
     })
 
     test('Get the correct entry with references', () => {

--- a/test/integration/entry-references-integration.ts
+++ b/test/integration/entry-references-integration.ts
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from 'chai'
+import { merge } from 'lodash'
+import { before, describe, test } from 'mocha'
+import sinon from 'sinon'
+import { Environment } from '../../lib/entities/environment'
+import { Space } from '../../lib/entities/space'
+import { TestDefaults } from '../defaults'
+import { getDefaultSpace, getPlainClient } from '../helpers'
+import { makeLink, makeVersionedLink } from '../utils'
+
+describe('BulkActions Api', async function () {
+  let testSpace: Space
+  let testEnvironment: Environment
+
+  before(async () => {
+    testSpace = await getDefaultSpace()
+    testEnvironment = await testSpace.getEnvironment('master')
+  })
+
+  describe('Environment Scoped', () => {
+    test.only('getEntryReferences', async () => {
+      const entryReferences = await testEnvironment.getEntryReferences(
+        TestDefaults.entry.testEntryId,
+        2
+      )
+      console.dir(entryReferences, {
+        depth: 3,
+      })
+    })
+  })
+
+  // PlainAPI doesn't offer the wait for processing
+  describe('PlainClient', () => {
+    const defaultParams = {
+      environmentId: TestDefaults.environmentId,
+      spaceId: TestDefaults.spaceId,
+    }
+
+    test('entry.references', async () => {
+      const plainClient = getPlainClient(defaultParams)
+      const entry = await plainClient.entry.get({ entryId: TestDefaults.entry.testEntryId })
+
+      const entryReferences = await plainClient.entry.references({
+        entryId: entry.sys.id,
+        maxDepth: 5,
+      })
+      console.dir(entryReferences, {
+        depth: 3,
+      })
+    })
+  })
+})

--- a/test/integration/entry-references-integration.ts
+++ b/test/integration/entry-references-integration.ts
@@ -1,15 +1,14 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from 'chai'
-import { merge } from 'lodash'
 import { before, describe, test } from 'mocha'
-import sinon from 'sinon'
 import { Environment } from '../../lib/entities/environment'
 import { Space } from '../../lib/entities/space'
 import { TestDefaults } from '../defaults'
 import { getDefaultSpace, getPlainClient } from '../helpers'
-import { makeLink, makeVersionedLink } from '../utils'
 
-describe('BulkActions Api', async function () {
+const ENTRY_WITH_REFERENCES_ID = TestDefaults.entry.testEntryReferenceId
+const WRONG_ENTRY_ID = `123123XD`
+
+describe('Entry References', async function () {
   let testSpace: Space
   let testEnvironment: Environment
 
@@ -19,37 +18,67 @@ describe('BulkActions Api', async function () {
   })
 
   describe('Environment Scoped', () => {
-    test.only('getEntryReferences', async () => {
-      const entryReferences = await testEnvironment.getEntryReferences(
-        TestDefaults.entry.testEntryReferenceId,
-        2
-      )
-      console.dir(entryReferences, {
-        depth: 5,
-      })
+    let entryWithReferences
+    before(async () => {
+      entryWithReferences = await testEnvironment.getEntryReferences(ENTRY_WITH_REFERENCES_ID, 2)
+    })
+
+    test('Get the correct entry with references', () => {
+      expect(entryWithReferences.items[0].sys.id).to.eql(ENTRY_WITH_REFERENCES_ID)
+      expect(entryWithReferences.includes).not.to.be.empty
+      expect(entryWithReferences.includes.Entry.length).above(0)
+    })
+
+    test('Should return the correct cities', () => {
+      const cities = entryWithReferences.includes.Entry.map((entry) => entry.fields.name['en-US'])
+      expect(cities).to.have.members(['Berlin', 'London', 'San Francisco', 'Paris'])
+    })
+
+    test('Should not return any references', async () => {
+      const noEntryReferences = await testEnvironment.getEntryReferences(WRONG_ENTRY_ID, 2)
+      expect(noEntryReferences.items).to.be.empty
     })
   })
 
-  // PlainAPI doesn't offer the wait for processing
-  describe('PlainClient', () => {
+  describe('Plain Client', () => {
     const defaultParams = {
       environmentId: TestDefaults.environmentId,
       spaceId: TestDefaults.spaceId,
     }
+    let plainClient
+    let entry
+    let entryWithReferences
 
-    test('entry.references', async () => {
-      const plainClient = getPlainClient(defaultParams)
-      const entry = await plainClient.entry.get({
-        entryId: TestDefaults.entry.testEntryReferenceId,
+    before(async () => {
+      plainClient = getPlainClient(defaultParams)
+
+      entry = await plainClient.entry.get({
+        entryId: ENTRY_WITH_REFERENCES_ID,
       })
 
-      const entryReferences = await plainClient.entry.references({
+      entryWithReferences = await plainClient.entry.references({
         entryId: entry.sys.id,
         maxDepth: 5,
       })
-      console.dir(entryReferences, {
-        depth: 3,
+    })
+
+    test('Get the correct entry with references', () => {
+      expect(entryWithReferences.items[0].sys.id).to.eql(ENTRY_WITH_REFERENCES_ID)
+      expect(entryWithReferences.includes).not.to.be.empty
+      expect(entryWithReferences.includes.Entry.length).above(0)
+    })
+
+    test('Should return the correct cities', () => {
+      const cities = entryWithReferences.includes.Entry.map((entry) => entry.fields.name['en-US'])
+      expect(cities).to.have.members(['Berlin', 'London', 'San Francisco', 'Paris'])
+    })
+
+    test('Should not return any references', async () => {
+      const noEntryReferences = await await plainClient.entry.references({
+        entryId: WRONG_ENTRY_ID,
+        maxDepth: 2,
       })
+      expect(noEntryReferences.items).to.be.empty
     })
   })
 })

--- a/test/integration/entry-references-integration.ts
+++ b/test/integration/entry-references-integration.ts
@@ -21,11 +21,11 @@ describe('BulkActions Api', async function () {
   describe('Environment Scoped', () => {
     test.only('getEntryReferences', async () => {
       const entryReferences = await testEnvironment.getEntryReferences(
-        TestDefaults.entry.testEntryId,
+        TestDefaults.entry.testEntryReferenceId,
         2
       )
       console.dir(entryReferences, {
-        depth: 3,
+        depth: 5,
       })
     })
   })
@@ -39,7 +39,9 @@ describe('BulkActions Api', async function () {
 
     test('entry.references', async () => {
       const plainClient = getPlainClient(defaultParams)
-      const entry = await plainClient.entry.get({ entryId: TestDefaults.entry.testEntryId })
+      const entry = await plainClient.entry.get({
+        entryId: TestDefaults.entry.testEntryReferenceId,
+      })
 
       const entryReferences = await plainClient.entry.references({
         entryId: entry.sys.id,

--- a/test/unit/entities/entry-test.js
+++ b/test/unit/entities/entry-test.js
@@ -16,6 +16,7 @@ import {
   isUpdatedTest,
   isDraftTest,
   isArchivedTest,
+  entityReferenceCollectionTest,
 } from '../test-creators/instance-entity-methods'
 import { describe, test } from 'mocha'
 
@@ -168,5 +169,17 @@ describe('Entity Entry', () => {
       wrapperMethod: wrapEntry,
       actionMethod: 'getSnapshots',
     })
+  })
+
+  test('Entry references', async () => {
+    return entityReferenceCollectionTest(
+      (promise) => {
+        return {
+          makeRequest: setupMakeRequest(promise),
+          entityMock: cloneMock('entryReferencesCollection'),
+        }
+      },
+      { wrapperMethod: wrapEntryCollection }
+    )
   })
 })

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -513,7 +513,7 @@ const entryWithReferencesMock = {
   sys: {
     type: 'Array',
   },
-  items: [makeLink('Entry', 'entry-id')],
+  items: [entryMock],
 }
 
 const entryReferencesCollectionMock = {

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -509,6 +509,22 @@ export const scheduledActionCollectionMock = {
   items: [cloneDeep(scheduledActionMock)],
 }
 
+const entryWithReferencesMock = {
+  sys: {
+    type: 'Array',
+  },
+  items: [makeLink('Entry', 'entry-id')],
+}
+
+const entryReferencesCollectionMock = {
+  sys: {
+    type: 'Array',
+  },
+  limit: 1,
+  items: [cloneDeep(entryWithReferencesMock)],
+  includes: [makeLink('Entry', 'entry-1'), makeLink('Entry', 'entry-2')],
+}
+
 const mocks = {
   apiKey: apiKeyMock,
   appBundle: appBundleMock,
@@ -524,6 +540,8 @@ const mocks = {
   editorInterface: editorInterfaceMock,
   entry: entryMock,
   entryWithTags: entryMockWithTags,
+  entryWithReferences: entryWithReferencesMock,
+  entryReferencesCollection: entryReferencesCollectionMock,
   environmentAlias: environmentAliasMock,
   error: errorMock,
   extension: extensionMock,
@@ -710,6 +728,8 @@ export {
   contentTypeMock,
   editorInterfaceMock,
   entryMock,
+  entryWithReferencesMock,
+  entryReferencesCollectionMock,
   extensionMock,
   assetMock,
   assetWithFilesMock,

--- a/test/unit/test-creators/instance-entity-methods.js
+++ b/test/unit/test-creators/instance-entity-methods.js
@@ -140,3 +140,9 @@ export async function failingOmitAndDeleteFieldTest(setup, { wrapperMethod }) {
     expect(r, "throws an error when field doesn't exist").to.be.ok
   })
 }
+
+export async function entityReferenceCollectionTest(setup, { wrapperMethod }) {
+  const { makeRequest, entityMock } = setup()
+  const entity = wrapperMethod(makeRequest, entityMock)
+  expect(entity.includes).not.to.be.empty
+}


### PR DESCRIPTION
## Summary

Add `references` to entry api
Add `getReferences` to environment api

## Todo
- [x] Write `jsdoc` for the new methods
- [x] Write more tests

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
