### PR TITLE
fix: add new content model to tests

### DIFF
--- a/test/integration/entry-integration.js
+++ b/test/integration/entry-integration.js
@@ -275,6 +275,7 @@ describe('Entry Api', () => {
               'dog',
               'human',
               'kangaroo',
+              'testEntryReferences',
             ],
             'orders'
           )


### PR DESCRIPTION
## Summary

We added a new content model to test entry with multiple [references](https://github.com/contentful/contentful-management.js/pull/829), this causes tests to fail in other PRs

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes