### PR TITLE
fix: failing big files upload

### DIFF
--- a/lib/adapters/REST/endpoints/upload.ts
+++ b/lib/adapters/REST/endpoints/upload.ts
@@ -20,6 +20,9 @@ export const create: RestEndpoint<'Upload', 'create'> = (
     headers: {
       'Content-Type': 'application/octet-stream',
     },
+    //TODO: remove the line below when CreateHttpClientParams
+    //from sdk-core supports maxContentLength
+    maxBodyLength: http.defaults.maxContentLength,
   })
 }
 


### PR DESCRIPTION
## Summary
The client parameters don't handle axios's `maxBodyLength` so it's always -1. This makes big file uploads failing.
As a temporary solution while the `maxBodyLength` is handled in `contentful-sdk-core` we can set the value equal to `maxContentLength` which already is

## Motivation and Context

Costumer reports failing upload with big files
