### PR TITLE
refactor(entry-references): use named args instead of positional

### DIFF
--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -773,7 +773,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
     /**
      * Get entry references
      * @param entryId - Entry ID
-     * @param maxDepth - Level of the entry descendants from 1 up to 10 maximum
+     * @param {Object} options.maxDepth - Level of the entry descendants from 1 up to 10 maximum
      * @returns Promise of Entry references
      * @example ```javascript
      * const contentful = require('contentful-management');
@@ -785,14 +785,14 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * // Get entry references
      * client.getSpace('<space_id>')
      * .then((space) => space.getEnvironment('<environment_id>'))
-     * .then((environment) => environment.getEntryReferences('<entry_id>', '<max_depth>'))
+     * .then((environment) => environment.getEntryReferences('<entry_id>', {maxDepth: number}))
      * .then((entry) => console.log(entry.includes))
      * // Or
-     * .then((environment) => environment.getEntry('<entry_id>')).then((entry) => entry.references('<max_depth>'))
+     * .then((environment) => environment.getEntry('<entry_id>')).then((entry) => entry.references({maxDepth: number}))
      * .catch(console.error)
      * ```
      */
-    getEntryReferences(entryId: string, maxDepth: number) {
+    getEntryReferences(entryId: string, options: { maxDepth: number }) {
       const raw = this.toPlainObject() as EnvironmentProps
       return makeRequest({
         entityType: 'Entry',
@@ -801,7 +801,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
           spaceId: raw.sys.space.sys.id,
           environmentId: raw.sys.id,
           entryId: entryId,
-          maxDepth: maxDepth,
+          maxDepth: options.maxDepth,
         },
       }).then((response) => wrapEntryCollection(makeRequest, response))
     },

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -1,15 +1,15 @@
 import { createRequestConfig } from 'contentful-sdk-core'
-import { BasicQueryOptions, GetTagParams, MakeRequest } from './common-types'
+import { BasicQueryOptions, MakeRequest } from './common-types'
 import entities from './entities'
 import type { QueryOptions } from './common-types'
-import type { EntryProps, CreateEntryProps } from './entities/entry'
+import type { EntryProps, CreateEntryProps, EntryReferenceOptionsProps } from './entities/entry'
 import type { AssetFileProp, AssetProps, CreateAssetProps } from './entities/asset'
 import type { CreateAssetKeyProps } from './entities/asset-key'
 import type { CreateContentTypeProps, ContentTypeProps } from './entities/content-type'
 import type { CreateLocaleProps } from './entities/locale'
 import type { CreateExtensionProps } from './entities/extension'
 import type { CreateAppInstallationProps } from './entities/app-installation'
-import { CreateTagProps, TagVisibility, wrapTag, wrapTagCollection } from './entities/tag'
+import { TagVisibility, wrapTag, wrapTagCollection } from './entities/tag'
 import { Stream } from 'stream'
 import { EnvironmentProps } from './entities/environment'
 import {
@@ -792,7 +792,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    getEntryReferences(entryId: string, options: { maxDepth: number }) {
+    getEntryReferences(entryId: string, options?: EntryReferenceOptionsProps) {
       const raw = this.toPlainObject() as EnvironmentProps
       return makeRequest({
         entityType: 'Entry',
@@ -801,7 +801,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
           spaceId: raw.sys.space.sys.id,
           environmentId: raw.sys.id,
           entryId: entryId,
-          maxDepth: options.maxDepth,
+          maxDepth: options?.maxDepth,
         },
       }).then((response) => wrapEntryCollection(makeRequest, response))
     },

--- a/lib/entities/entry.ts
+++ b/lib/entities/entry.ts
@@ -32,6 +32,10 @@ export interface EntryReferenceProps extends CollectionProp<EntryProps> {
   }
 }
 
+export type EntryReferenceOptionsProps = {
+  maxDepth?: number
+}
+
 type EntryApi = {
   /**
    * Sends an update to the server with any changes made to the object's properties
@@ -236,7 +240,7 @@ type EntryApi = {
   /**
    * Recursively collects references of an entry and their descendants
    */
-  references({ maxDepth }: { maxDepth: number }): Promise<EntryReferenceProps>
+  references(options?: EntryReferenceOptionsProps): Promise<EntryReferenceProps>
 }
 
 export interface Entry extends EntryProps, DefaultElements<EntryProps>, EntryApi {}
@@ -368,7 +372,7 @@ function createEntryApi(makeRequest: MakeRequest): EntryApi {
       return checks.isArchived(raw)
     },
 
-    references: function references(options?: { maxDepth?: number }) {
+    references: function references(options?: EntryReferenceOptionsProps) {
       const raw = this.toPlainObject() as EntryProps
       return makeRequest({
         entityType: 'Entry',

--- a/lib/entities/entry.ts
+++ b/lib/entities/entry.ts
@@ -236,7 +236,7 @@ type EntryApi = {
   /**
    * Recursively collects references of an entry and their descendants
    */
-  references(maxDepth: number): Promise<EntryReferenceProps>
+  references({ maxDepth }: { maxDepth: number }): Promise<EntryReferenceProps>
 }
 
 export interface Entry extends EntryProps, DefaultElements<EntryProps>, EntryApi {}
@@ -368,7 +368,7 @@ function createEntryApi(makeRequest: MakeRequest): EntryApi {
       return checks.isArchived(raw)
     },
 
-    references: function references(maxDepth: number) {
+    references: function references(options?: { maxDepth?: number }) {
       const raw = this.toPlainObject() as EntryProps
       return makeRequest({
         entityType: 'Entry',
@@ -377,7 +377,7 @@ function createEntryApi(makeRequest: MakeRequest): EntryApi {
           spaceId: raw.sys.space.sys.id,
           environmentId: raw.sys.environment.sys.id,
           entryId: raw.sys.id,
-          maxDepth: maxDepth,
+          maxDepth: options?.maxDepth,
         },
       }).then((response) => wrapEntryCollection(makeRequest, response))
     },

--- a/test/integration/entry-references-integration.ts
+++ b/test/integration/entry-references-integration.ts
@@ -17,12 +17,11 @@ describe('Entry References', async function () {
     testEnvironment = await testSpace.getEnvironment('master')
   })
 
-  describe.only('Environment Scoped', () => {
+  describe('Environment Scoped', () => {
     let entryWithReferences
     before(async () => {
-      entryWithReferences = await testEnvironment.getEntryReferences(ENTRY_WITH_REFERENCES_ID, 2)
-      console.dir(entryWithReferences, {
-        depth: 6,
+      entryWithReferences = await testEnvironment.getEntryReferences(ENTRY_WITH_REFERENCES_ID, {
+        maxDepth: 2,
       })
     })
 
@@ -38,7 +37,9 @@ describe('Entry References', async function () {
     })
 
     test('Should not return any references', async () => {
-      const noEntryReferences = await testEnvironment.getEntryReferences(WRONG_ENTRY_ID, 2)
+      const noEntryReferences = await testEnvironment.getEntryReferences(WRONG_ENTRY_ID, {
+        maxDepth: 2,
+      })
       expect(noEntryReferences.items).to.be.empty
     })
   })


### PR DESCRIPTION
## Summary

Refactor `getEntryReferences` and `entry.references` to use named args instead of positional

## Checklist 

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation
