### PR TITLE
fix: entry references conventional commit release

### DIFF
--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -787,7 +787,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((space) => space.getEnvironment('<environment_id>'))
      * .then((environment) => environment.getEntryReferences('<entry_id>', {maxDepth: number}))
      * .then((entry) => console.log(entry.includes))
-     * // Or
+     * // or
      * .then((environment) => environment.getEntry('<entry_id>')).then((entry) => entry.references({maxDepth: number}))
      * .catch(console.error)
      * ```


### PR DESCRIPTION
## Summary

Last commit wasn't release due to `refactor` keyword in commit message

https://app.circleci.com/pipelines/github/contentful/contentful-management.js/2686/workflows/93f05bb5-55af-4fac-a4f5-8e22079493aa/jobs/7616
