### PR TITLE
chore: add timezone to schedule action props

### DIFF
--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -49,6 +49,12 @@ export type ScheduledActionProps = {
   environment?: { sys: MetaLinkProps }
   scheduledFor: {
     datetime: ISO8601Timestamp
+    /**
+     * A valid IANA timezone Olson identifier
+     *
+     * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+     * @example 'Asia/Kolkata'
+     */
     timezone?: string
   }
 }

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -49,6 +49,7 @@ export type ScheduledActionProps = {
   environment?: { sys: MetaLinkProps }
   scheduledFor: {
     datetime: ISO8601Timestamp
+    timezone?: string
   }
 }
 

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -548,6 +548,7 @@ export const scheduledActionMock = {
   environment: { sys: cloneDeep(linkMock) },
   scheduledFor: {
     datetime: 'scheduledFor',
+    timezone: 'timezone',
   },
 }
 

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -547,8 +547,8 @@ export const scheduledActionMock = {
   entity: { sys: cloneDeep(linkMock) },
   environment: { sys: cloneDeep(linkMock) },
   scheduledFor: {
-    datetime: 'scheduledFor',
-    timezone: 'timezone',
+    datetime: '2006-01-02T15:04:05-0700',
+    timezone: 'Asia/Kolkata',
   },
 }
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Add" timezone" to schedule action props i.e : 

scheduledFor: {
  datetime: datetime,
  timezone: timezone,
}

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
