### PR TITLE
fix: require env id as an argument to scheduled actions delete function

### DIFF
--- a/lib/adapters/REST/endpoints/scheduled-action.ts
+++ b/lib/adapters/REST/endpoints/scheduled-action.ts
@@ -1,5 +1,10 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import { CollectionProp, GetSpaceParams, QueryParams } from '../../../common-types'
+import {
+  CollectionProp,
+  GetSpaceEnvironmentParams,
+  GetSpaceParams,
+  QueryParams,
+} from '../../../common-types'
 import { ScheduledActionProps } from '../../../entities/scheduled-action'
 import { RestEndpoint } from '../types'
 import * as raw from './raw'
@@ -28,7 +33,11 @@ export const create: RestEndpoint<'ScheduledAction', 'create'> = (
 
 export const del: RestEndpoint<'ScheduledAction', 'delete'> = (
   http: AxiosInstance,
-  params: GetSpaceParams & { scheduledActionId: string }
+  params: GetSpaceEnvironmentParams & { scheduledActionId: string }
 ) => {
-  return raw.del(http, `/spaces/${params.spaceId}/scheduled_actions/${params.scheduledActionId}`)
+  return raw.del(http, `/spaces/${params.spaceId}/scheduled_actions/${params.scheduledActionId}`, {
+    params: {
+      'environment.sys.id': params.environmentId,
+    },
+  })
 }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -971,7 +971,7 @@ export type MRActions = {
       payload: Omit<ScheduledActionProps, 'sys'>
       return: ScheduledActionProps
     }
-    delete: { params: GetSpaceParams & { scheduledActionId: string }; return: any }
+    delete: { params: GetSpaceEnvironmentParams & { scheduledActionId: string }; return: any }
   }
   Snapshot: {
     getManyForEntry: {

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -94,6 +94,7 @@ export function createDeleteScheduledAction(
       params: {
         spaceId: data.sys.space.sys.id,
         scheduledActionId: data.sys.id,
+        environmentId: data.environment?.sys.id as string,
       },
     }).then((data) => wrapScheduledAction(makeRequest, data))
   }

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -466,7 +466,7 @@ export type PlainClientAPI = {
       data: Omit<ScheduledActionProps, 'sys'>
     ): Promise<ScheduledActionProps>
     delete(
-      params: OptionalDefaults<GetSpaceParams & { scheduledActionId: string }>
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { scheduledActionId: string }>
     ): Promise<ScheduledActionProps>
   }
   previewApiKey: {


### PR DESCRIPTION

<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary
Deleting a scheduled action is impossible as it throws an error "Missing environment id". This PR fixes it
<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
