### PR TITLE
fix(type-fest): update type-fest to include simplify.d.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19776,9 +19776,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.0.2.tgz",
-      "integrity": "sha512-a720oz3Kjbp3ll0zkeN9qjRhO7I34MKMhPGQiQJAmaZQZQ1lo+NWThK322f7sXV+kTg9B1Ybt16KgBXWgteT8w=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.1.3.tgz",
+      "integrity": "sha512-CsiQeFMR1jZEq8R+H59qe+bBevnjoV5N2WZTTdlyqxeoODQOOepN2+msQOywcieDq5sBjabKzTn3U+sfHZlMdw=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "contentful-sdk-core": "^6.8.0",
     "fast-copy": "^2.1.0",
     "lodash.isplainobject": "^4.0.6",
-    "type-fest": "1.0.2"
+    "type-fest": "1.1.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.7",


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

- Fixes #848 

## Description

<!-- Describe your changes in detail -->

- Update `type-fest` to 1.1.3 - the previous version didn't include the `simplify.d.ts` file.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [N/A] Changes are reflected in the documentation

When adding a new method:

- [N/A] The new method is exported through the default and plain CMA client
- [N/A] All new public types are exported from `./lib/export-types.ts`
- [N/A] Added a unit test for the new method
- [N/A] Added an integration test for the new method
- [N/A] The new method is added to the documentation
