### PR TITLE
fix(release): jsDoc examples and typing

### DIFF
--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -1643,7 +1643,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *   entities: {
      *     sys: { type: 'Array' },
      *     items: [
-     *      { linkType: 'Entry', type: 'Link', id: '<entry_id>' }
+     *      { sys: { linkType: 'Entry', type: 'Link', id: '<entry_id>' } }
      *     ]
      *   }
      * }
@@ -1675,8 +1675,8 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * @param options.releaseId the ID of the release
      * @param options.payload the payload to be updated in the Release
      * @param options.version Release sys.version that to be updated
-     *
      * @returns Promise containing a wrapped Release, that has helper methods within.
+     *
      * @example ```javascript
      * const contentful = require('contentful-management')
      *
@@ -1690,7 +1690,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *   entities: {
      *     sys: { type: 'Array' },
      *     items: [
-     *      { linkType: 'Entry', type: 'Link', id: '<entry_id>' }
+     *        { sys: { linkType: 'Entry', type: 'Link', id: '<entry_id>' } }
      *     ]
      *   }
      * }
@@ -1762,8 +1762,8 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * Publishes all Entities contained in a Release.
      * @param options.releaseId the ID of the release
      * @param options.version the version of the release that is to be published
-     *
      * @returns Promise containing a wrapped Release, that has helper methods within.
+     *
      * @example ```javascript
      * const contentful = require('contentful-management')
      *
@@ -1773,7 +1773,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *
      * client.getSpace('<space_id>')
      * .then((space) => space.getEnvironment('<environment-id>'))
-     * .then((environment) => environment.publishRelease({ releaseId: '<release_id>', version: 1 })
+     * .then((environment) => environment.publishRelease({ releaseId: '<release_id>', version: 1 }))
      * .catch(console.error)
      * ```
      */
@@ -1796,8 +1796,8 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * Unpublishes all Entities contained in a Release.
      * @param options.releaseId the ID of the release
      * @param options.version the version of the release that is to be published
-     *
      * @returns Promise containing a wrapped Release, that has helper methods within.
+     *
      * @example ```javascript
      * const contentful = require('contentful-management')
      *
@@ -1807,7 +1807,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *
      * client.getSpace('<space_id>')
      * .then((space) => space.getEnvironment('<environment-id>'))
-     * .then((environment) => environment.unpublishRelease({ releaseId: '<release_id>', version: 1 })
+     * .then((environment) => environment.unpublishRelease({ releaseId: '<release_id>', version: 1 }))
      * .catch(console.error)
      * ```
      */
@@ -1832,6 +1832,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * @param options.payload (optional) the type of action to be validated against
      *
      * @returns Promise containing a wrapped Release, that has helper methods within.
+     *
      * @example ```javascript
      * const contentful = require('contentful-management')
      *
@@ -1841,7 +1842,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *
      * client.getSpace('<space_id>')
      * .then((space) => space.getEnvironment('<environment-id>'))
-     * .then((environment) => environment.validateRelease({ releaseId: '<release_id>', payload: { action: 'unpublish' } })
+     * .then((environment) => environment.validateRelease({ releaseId: '<release_id>', payload: { action: 'unpublish' } }))
      * .catch(console.error)
      * ```
      */
@@ -1905,6 +1906,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * @param {string} params.releaseId ID of the Release to fetch the actions from
      * @param {ReleaseQueryOptions} params.query filtering options for the collection result
      * @returns Promise containing a wrapped ReleaseAction Collection
+     *
      * @example ```javascript
      * const contentful = require('contentful-management')
      *

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -1608,7 +1608,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *
      * client.getSpace('<space_id>')
      * .then((space) => space.getEnvironment('<environment-id>'))
-     * .then((environment) => environment.getReleases({ 'entities.sys.id': '<asset_id>,<entry_id>' }))
+     * .then((environment) => environment.getReleases({ 'entities.sys.id[in]': '<asset_id>,<entry_id>' }))
      * .then((releases) => console.log(releases))
      * .catch(console.error)
      * ```
@@ -1916,7 +1916,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *
      * client.getSpace('<space_id>')
      * .then((space) => space.getEnvironment('<environment-id>'))
-     * .then((environment) => environment.getReleaseActions({ releaseId: '<release_id>', query: { 'sys.id': '<id_1>,<id_2>' } }))
+     * .then((environment) => environment.getReleaseActions({ releaseId: '<release_id>', query: { 'sys.id[in]': '<id_1>,<id_2>' } }))
      * .then((releaseActions) => console.log(releaseActions))
      * .catch(console.error)
      * ```

--- a/lib/entities/release.ts
+++ b/lib/entities/release.ts
@@ -69,6 +69,8 @@ export interface ReleaseValidateOptions {
 }
 
 export interface ReleaseApiMethods {
+  /** Updates a Release and returns the updated Release object */
+  update(payload: ReleasePayload): Promise<Release>
   /** Deletes a Release and all ReleaseActions linked to it (non-reversible) */
   delete(): Promise<void>
   /** Publishes a Release and waits until the asynchronous action is completed */
@@ -98,6 +100,16 @@ function createReleaseApi(makeRequest: MakeRequest) {
   }
 
   return {
+    async update(payload: ReleasePayload) {
+      const params = getParams(this)
+
+      return makeRequest({
+        entityType: 'Release',
+        action: 'update',
+        params,
+        payload,
+      }).then((release) => wrapRelease(makeRequest, release))
+    },
     async delete() {
       const params = getParams(this)
 

--- a/lib/entities/release.ts
+++ b/lib/entities/release.ts
@@ -23,9 +23,9 @@ export interface ReleaseQueryOptions {
   /** Find releases filtered by the Entity type (Asset, Entry) */
   'entities.sys.linkType'?: string
   /** Find releases containing the specified, comma-separated entities. Requires `entities.sys.linkType` */
-  'entities.sys.id'?: string
+  'entities.sys.id[in]'?: string
   /** Find releases by using a comma-separated list of Ids */
-  'sys.id'?: string
+  'sys.id[in]'?: string
   /** If present, will return results based on a pagination cursor */
   pageNext?: string
   /**

--- a/test/unit/entities/release-test.ts
+++ b/test/unit/entities/release-test.ts
@@ -7,6 +7,7 @@ import {
   entityWrappedTest,
   entityCollectionWrappedTest,
   entityDeleteTest,
+  entityUpdateTest,
 } from '../test-creators/instance-entity-methods'
 
 function setup(promise) {
@@ -24,6 +25,12 @@ describe('Entity Release', () => {
   it('Release collection is wrapped', async () => {
     return entityCollectionWrappedTest(setup, {
       wrapperMethod: wrapReleaseCollection,
+    })
+  })
+
+  it('Release update', async () => {
+    return entityUpdateTest(setup, {
+      wrapperMethod: wrapRelease,
     })
   })
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->
- This PR fixes the JSDoc example for Releases (incorrect shape for Link object)
- Fixes the typing for query methods

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->



## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [x] The new method is added to the documentation
