### PR TITLE
fix(deps): downgrade type-fest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,8 @@ updates:
       - dependency-name: typedoc
         versions:
           - '>= 0'
+      - dependency-name: type-fest
+        versions:
+          - '>= 1'
     registries:
       - npm-registry-registry-npmjs-org

--- a/package-lock.json
+++ b/package-lock.json
@@ -19776,9 +19776,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19776,9 +19776,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.1.3.tgz",
-      "integrity": "sha512-CsiQeFMR1jZEq8R+H59qe+bBevnjoV5N2WZTTdlyqxeoODQOOepN2+msQOywcieDq5sBjabKzTn3U+sfHZlMdw=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "contentful-sdk-core": "^6.8.0",
     "fast-copy": "^2.1.0",
     "lodash.isplainobject": "^4.0.6",
-    "type-fest": "^0.8.1"
+    "type-fest": "^0.20.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.7",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "contentful-sdk-core": "^6.8.0",
     "fast-copy": "^2.1.0",
     "lodash.isplainobject": "^4.0.6",
-    "type-fest": "1.1.3"
+    "type-fest": "^0.8.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.7",


### PR DESCRIPTION
We version conflicts with `type-fest` when used in other projects. With this changes, we downgrade the version of `type-fest` to unblock users. 

We will investigate further how and when we can update again.  