### PR TITLE
feat: initialValue property in content type field

### DIFF
--- a/lib/entities/content-type-fields.ts
+++ b/lib/entities/content-type-fields.ts
@@ -1,3 +1,5 @@
+import { KeyValueMap } from '../common-types'
+
 interface NumRange {
   min?: number
   max?: number
@@ -38,7 +40,7 @@ interface Item {
   validations?: ContentTypeFieldValidation[]
 }
 
-export interface ContentFields extends Item {
+export interface ContentFields<T = KeyValueMap> extends Item {
   id: string
   name: string
   required: boolean
@@ -48,4 +50,5 @@ export interface ContentFields extends Item {
   deleted?: boolean
   items?: Item
   apiName?: string
+  initialValue?: T
 }


### PR DESCRIPTION
[DANTE-46]

## Summary
Amends declaration of the content type field type to support the `initialValue` property

## Description

The property declaration follows the `fields` property in `EntryProps` type, i.e. `<T = KeyValueMap>`

[DANTE-46]: https://contentful.atlassian.net/browse/DANTE-46