### PR TITLE
feat: add due date as a task field type [HOMER-78]

### DIFF
--- a/lib/entities/task.ts
+++ b/lib/entities/task.ts
@@ -29,6 +29,7 @@ export type TaskProps = {
   body: string
   assignedTo: Link<'User'>
   status: TaskStatus
+  dueDate?: string
 }
 
 export type CreateTaskProps = Omit<TaskProps, 'sys'>


### PR DESCRIPTION
## Summary

Add a new dueDate field to the Task property.


## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
