### PR TITLE
fix: use correct name for new method [HOMER-75]

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -326,39 +326,6 @@ export default function createClientApi(makeRequest: MakeRequest) {
     },
 
     /**
-     * Get a filtered set of teams that have access to a space
-     *
-     * @param spaceId - Id of a space
-     * @param query - Query parameters
-     * @return Promise of a collection of teams
-     * ```javascript
-     * const contentful = require('contentful-management')
-     *
-     * const client = contentful.createClient({
-     *   accessToken: '<content_management_api_key>'
-     * })
-     *
-     * client.getSpaceTeams('<spaceId>', {
-     *    skip: 0,
-     *    limit: 10,
-     *    }
-     * })
-     * .then(result => console.log(result.items))
-     * .catch(console.error)
-     * ```
-     */
-    getSpaceTeams: function getSpaceTeams(spaceId: string, query: UsageQuery = {}) {
-      return makeRequest({
-        entityType: 'Team',
-        action: 'getManyForSpace',
-        params: {
-          spaceId,
-          query,
-        },
-      }).then((data) => wrapTeamCollection(makeRequest, data))
-    },
-
-    /**
      * Make a custom request to the Contentful management API's /spaces endpoint
      * @param opts - axios request options (https://github.com/mzabriskie/axios)
      * @return Promise for the response data

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -557,15 +557,14 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    getTeams() {
+    getTeams(query: QueryOptions = { limit: 100 }) {
       const raw = this.toPlainObject() as SpaceProps
       return makeRequest({
         entityType: 'Team',
         action: 'getManyForSpace',
         params: {
           spaceId: raw.sys.id,
-          // The largest organization includes 29 teams, so the limit is sufficient and no pagination is required
-          query: createRequestConfig({ query: { limit: 100 } }).params,
+          query: createRequestConfig({ query }).params,
         },
       }).then((data) => wrapTeamCollection(makeRequest, data))
     },

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -552,19 +552,20 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * const contentful = require('contentful-management')
      *
      * client.getSpace('<space_id>')
-     * .then((space) => space.getSpaceTeams({'limit': 100}))
-     * .then((spaceTeamCollection) => console.log(spaceTeamCollection))
+     * .then((space) => space.getTeams())
+     * .then((teamsCollection) => console.log(teamsCollection))
      * .catch(console.error)
      * ```
      */
-    getSpaceTeams(query: QueryOptions = {}) {
+    getTeams() {
       const raw = this.toPlainObject() as SpaceProps
       return makeRequest({
         entityType: 'Team',
         action: 'getManyForSpace',
         params: {
           spaceId: raw.sys.id,
-          query: createRequestConfig({ query }).params,
+          // The largest organization includes 29 teams, so the limit is sufficient and no pagination is required
+          query: createRequestConfig({ query: { limit: 100 } }).params,
         },
       }).then((data) => wrapTeamCollection(makeRequest, data))
     },

--- a/test/integration/space-team-integration.js
+++ b/test/integration/space-team-integration.js
@@ -9,8 +9,8 @@ describe('SpaceTeam Api', () => {
     space = await getV2Space()
   })
 
-  test.only('Gets spaceTeams', async () => {
-    return space.getSpaceTeams().then((response) => {
+  test.only('Gets teams for space', async () => {
+    return space.getTeams().then((response) => {
       console.log(response.items)
       expect(response.sys, 'sys').ok
       expect(response.sys.type, 'Array').ok

--- a/test/unit/create-space-api-test.js
+++ b/test/unit/create-space-api-test.js
@@ -161,17 +161,17 @@ describe('A createSpaceApi', () => {
     })
   })
 
-  test('API call getSpaceTeams', async () => {
+  test('API call getTeams', async () => {
     return makeGetCollectionTest(setup, {
       entityType: 'team',
       mockToReturn: teamMock,
-      methodToTest: 'getSpaceTeams',
+      methodToTest: 'getTeams',
     })
   })
 
-  test('API call getSpaceTeams fails', async () => {
+  test('API call getTeams fails', async () => {
     return makeEntityMethodFailingTest(setup, {
-      methodToTest: 'getSpaceTeams',
+      methodToTest: 'getTeams',
     })
   })
 


### PR DESCRIPTION
## Summary

It's `SpaceApi.getTeams`, not `SpaceApi.getSpaceTeams`.

## Description

[Related open App-SDK PR](https://github.com/contentful/ui-extensions-sdk/pull/797/files)
[Previous PR](https://github.com/contentful/contentful-management.js/pull/873)

## Motivation and Context


## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
