### PR TITLE
feat: enable teams to be assigned to tasks [HOMER-69]

### DIFF
--- a/lib/entities/task.ts
+++ b/lib/entities/task.ts
@@ -27,7 +27,7 @@ export type TaskSysProps = Pick<
 export type TaskProps = {
   sys: TaskSysProps
   body: string
-  assignedTo: Link<'User'>
+  assignedTo: Link<'User' | 'Team'>
   status: TaskStatus
   dueDate?: string
 }


### PR DESCRIPTION
## Summary

Assign tasks to teams via CMA.

## Description

Enhance the `assignedTo` type to also include links to teams. Since everything is passed through, there are no other code changes required.

## Motivation and Context

This is part of Team Homer's first project.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] [Changes are reflected in the documentation](https://github.com/contentful/doc-app/pull/2020)
