### PR TITLE
feat: get pending tasks [HOMER-124]

### DIFF
--- a/lib/adapters/REST/endpoints/task.ts
+++ b/lib/adapters/REST/endpoints/task.ts
@@ -1,6 +1,11 @@
 import { AxiosInstance } from 'axios'
 import copy from 'fast-copy'
-import { CollectionProp, GetEntryParams, GetTaskParams } from '../../../common-types'
+import {
+  CollectionProp,
+  GetEntryParams,
+  GetSpaceParams,
+  GetTaskParams,
+} from '../../../common-types'
 import {
   CreateTaskParams,
   CreateTaskProps,
@@ -10,6 +15,7 @@ import {
 } from '../../../entities/task'
 import { RestEndpoint } from '../types'
 import * as raw from './raw'
+import { normalizeSelect } from './utils'
 
 const getBaseUrl = (params: GetEntryParams) =>
   `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}/tasks`
@@ -22,6 +28,17 @@ export const getAll: RestEndpoint<'Task', 'getAll'> = (
   http: AxiosInstance,
   params: GetEntryParams
 ) => raw.get<CollectionProp<TaskProps>>(http, getBaseUrl(params))
+
+export const getAllForSpaceAndUser: RestEndpoint<'Task', 'getAllForSpaceAndUser'> = (
+  http: AxiosInstance,
+  params: GetSpaceParams & { userId: string; includeTeams: boolean }
+) =>
+  raw.get<CollectionProp<TaskProps>>(http, `/spaces/${params.spaceId}/tasks`, {
+    params: normalizeSelect({
+      'assignedTo.sys.id': params.userId,
+      includeTeams: params.includeTeams,
+    }),
+  })
 
 export const create: RestEndpoint<'Task', 'create'> = (
   http: AxiosInstance,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -423,6 +423,7 @@ type MRInternal<UA extends boolean> = {
 
   (opts: MROpts<'Task', 'get', UA>): MRReturn<'Task', 'get'>
   (opts: MROpts<'Task', 'getAll', UA>): MRReturn<'Task', 'getAll'>
+  (opts: MROpts<'Task', 'getAllForSpaceAndUser', UA>): MRReturn<'Task', 'getAllForSpaceAndUser'>
   (opts: MROpts<'Task', 'create', UA>): MRReturn<'Task', 'create'>
   (opts: MROpts<'Task', 'update', UA>): MRReturn<'Task', 'update'>
   (opts: MROpts<'Task', 'delete', UA>): MRReturn<'Task', 'delete'>
@@ -1059,6 +1060,10 @@ export type MRActions = {
   Task: {
     get: { params: GetTaskParams; return: TaskProps }
     getAll: { params: GetEntryParams; return: CollectionProp<TaskProps> }
+    getAllForSpaceAndUser: {
+      params: GetSpaceParams & { userId: string; includeTeams: boolean }
+      return: CollectionProp<TaskProps>
+    }
     create: { params: CreateTaskParams; payload: CreateTaskProps; return: TaskProps }
     update: {
       params: UpdateTaskParams

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -36,6 +36,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
     wrapTeamSpaceMembershipCollection,
   } = entities.teamSpaceMembership
   const { wrapTeamCollection } = entities.team
+  const { wrapTaskCollection } = entities.task
   const { wrapApiKey, wrapApiKeyCollection } = entities.apiKey
   const { wrapEnvironmentAlias, wrapEnvironmentAliasCollection } = entities.environmentAlias
   const { wrapPreviewApiKey, wrapPreviewApiKeyCollection } = entities.previewApiKey
@@ -831,6 +832,32 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
         },
         payload: data,
       }).then((response) => wrapTeamSpaceMembership(makeRequest, response))
+    },
+    /**
+     * Gets a collection of all pending tasks in a space for a user.
+     * @param userId - User ID
+     * @param  includeTeams - Consider tasks assigned to teams to which the user belongs
+     * @return Promise a collection of pending Tasks of a user in a space
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * client.getSpace('<space_id>')
+     * .then((space) => space.getPendingTasks('<user_id>', true))
+     * .then((data) => console.log(data))
+     * .catch(console.error)
+     * ```
+     */
+    getPendingTasks(userId: string, includeTeams = false) {
+      const raw = this.toPlainObject() as SpaceProps
+      return makeRequest({
+        entityType: 'Task',
+        action: 'getAllForSpaceAndUser',
+        params: {
+          spaceId: raw.sys.id,
+          userId,
+          includeTeams,
+        },
+      }).then((data) => wrapTaskCollection(makeRequest, data))
     },
     /**
      * Gets a Api Key

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -669,6 +669,9 @@ export type PlainClientAPI = {
   task: {
     get(params: OptionalDefaults<GetTaskParams>): Promise<TaskProps>
     getAll(params: OptionalDefaults<GetEntryParams>): Promise<CollectionProp<TaskProps>>
+    getAllForSpaceAndUser(
+      params: OptionalDefaults<GetSpaceParams & { userId: string; includeTeams: boolean }>
+    ): Promise<CollectionProp<TaskProps>>
     create(
       params: OptionalDefaults<CreateTaskParams>,
       rawData: CreateTaskProps,

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -117,6 +117,7 @@ export const createPlainClient = (
     task: {
       get: wrap(wrapParams, 'Task', 'get'),
       getAll: wrap(wrapParams, 'Task', 'getAll'),
+      getAllForSpaceAndUser: wrap(wrapParams, 'Task', 'getAllForSpaceAndUser'),
       create: wrap(wrapParams, 'Task', 'create'),
       update: wrap(wrapParams, 'Task', 'update'),
       delete: wrap(wrapParams, 'Task', 'delete'),

--- a/test/unit/create-space-api-test.js
+++ b/test/unit/create-space-api-test.js
@@ -15,6 +15,7 @@ import {
   spaceMemberMock,
   spaceMembershipMock,
   spaceMock,
+  taskMock,
   teamMock,
   teamSpaceMembershipMock,
   userMock,
@@ -360,6 +361,20 @@ describe('A createSpaceApi', () => {
   test('API call createRoleWithId fails', async () => {
     return makeEntityMethodFailingTest(setup, {
       methodToTest: 'createRoleWithId',
+    })
+  })
+
+  test('API call getPendingTasks', async () => {
+    return makeGetCollectionTest(setup, {
+      entityType: 'task',
+      mockToReturn: taskMock,
+      methodToTest: 'getPendingTasks',
+    })
+  })
+
+  test('API call getPendingTasks fails', async () => {
+    return makeEntityMethodFailingTest(setup, {
+      methodToTest: 'getPendingTasks',
     })
   })
 


### PR DESCRIPTION
## Summary

Allow fetching all pending tasks of a user in a space, incl. the option to consider the team memberships of the user.

## Description

Add two new methods to plain and default client:
`cma.space.getPendingTasks(userId, includeTeams)`
`plainCma.task.getAllForSpaceAndUser({ spaceId, userId, includeTeams })`

## Motivation and Context

We will create a new pending tasks page which also considers the tasks assigned to teams.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation: [Branch](https://github.com/contentful/doc-app/tree/feat/HOMER-124-pending-tasks), [Deploy](https://ctf-doc-app-branch-feat-homer-124-pending-tasks.netlify.app/developers/docs/references/content-management-api/#/reference/entry-tasks/tasks-in-a-space-collection)

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- The new method is added to the documentation
