### PR TITLE
feat: export RestAdapter

### DIFF
--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -19,6 +19,7 @@ export { asIterator } from './plain/as-iterator'
 export { isDraft, isPublished, isUpdated } from './plain/checks'
 export type { PlainClientAPI } from './plain/common-types'
 export { createClient }
+export { RestAdapter } from './adapters/REST/rest-adapter'
 export { editorInterfaceDefaults }
 export type PlainClientDefaultParams = DefaultParams
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

This PR exports RestAdapter so it can be initialized outside of cma.js and passed into `createClient`

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation
