### PR TITLE
chore: add lastAction to release sys types

### DIFF
--- a/lib/entities/release.ts
+++ b/lib/entities/release.ts
@@ -45,6 +45,7 @@ export type ReleaseSysProps = {
   updatedBy: Link<'User'>
   createdAt: ISO8601Timestamp
   updatedAt: ISO8601Timestamp
+  lastAction?: Link<'ReleaseAction'>
 }
 
 /** The object returned by the Releases API */


### PR DESCRIPTION
Adds `lastAction: Link<'ReleaseAction'>` to `sys` typing of `Release` entity

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
