### PR TITLE
Feat: update scheduled actions [SPA-284]

### DIFF
--- a/lib/adapters/REST/endpoints/scheduled-action.ts
+++ b/lib/adapters/REST/endpoints/scheduled-action.ts
@@ -41,3 +41,23 @@ export const del: RestEndpoint<'ScheduledAction', 'delete'> = (
     },
   })
 }
+
+export const update: RestEndpoint<'ScheduledAction', 'update'> = (
+  http: AxiosInstance,
+  params: GetSpaceParams & { scheduledActionId: string; version: number },
+  data: Omit<ScheduledActionProps, 'sys'>
+) => {
+  return raw.put(
+    http,
+    `/spaces/${params.spaceId}/scheduled_actions/${params.scheduledActionId}`,
+    data,
+    {
+      params: {
+        'environment.sys.id': data.environment?.sys.id,
+      },
+      headers: {
+        'X-Contentful-Version': params.version,
+      },
+    }
+  )
+}

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -381,6 +381,7 @@ type MRInternal<UA extends boolean> = {
 
   (opts: MROpts<'ScheduledAction', 'getMany', UA>): MRReturn<'ScheduledAction', 'getMany'>
   (opts: MROpts<'ScheduledAction', 'create', UA>): MRReturn<'ScheduledAction', 'create'>
+  (opts: MROpts<'ScheduledAction', 'update', UA>): MRReturn<'ScheduledAction', 'update'>
   (opts: MROpts<'ScheduledAction', 'delete', UA>): MRReturn<'ScheduledAction', 'delete'>
 
   (opts: MROpts<'Snapshot', 'getManyForEntry', UA>): MRReturn<'Snapshot', 'getManyForEntry'>
@@ -969,6 +970,11 @@ export type MRActions = {
     getMany: { params: GetSpaceParams & QueryParams; return: CollectionProp<ScheduledActionProps> }
     create: {
       params: GetSpaceParams
+      payload: Omit<ScheduledActionProps, 'sys'>
+      return: ScheduledActionProps
+    }
+    update: {
+      params: GetSpaceParams & { scheduledActionId: string; version: number }
       payload: Omit<ScheduledActionProps, 'sys'>
       return: ScheduledActionProps
     }

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -1105,6 +1105,22 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * Query for scheduled actions in space.
      * @param query - Object with search parameters. The enviroment id field is mandatory. Check the <a href="https://www.contentful.com/developers/docs/references/content-management-api/#/reference/scheduled-actions/scheduled-actions-collection">REST API reference</a> for more details.
      * @return Promise for the scheduled actions query
+     *
+     * @example ```javascript
+     *  const contentful = require('contentful-management');
+     *
+     *  const client = contentful.createClient({
+     *    accessToken: '<content_management_api_key>'
+     *  })
+     *
+     *  client.getSpace('<space_id>')
+     *    .then((space) => space.getScheduledActions({
+     *      'environment.sys.id': '<environment_id>',
+     *      'sys.status': 'scheduled'
+     *    }))
+     *    .then((scheduledActionCollection) => console.log(scheduledActionCollection.items))
+     *    .catch(console.error)
+     * ```
      */
     getScheduledActions(query: ScheduledActionQueryOptions) {
       const raw = this.toPlainObject() as SpaceProps
@@ -1118,6 +1134,36 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * Creates a scheduled action
      * @param data - Object representation of the scheduled action to be created
      * @return Promise for the newly created scheduled actions
+     * @example ```javascript
+     *  const contentful = require('contentful-management');
+     *
+     *  const client = contentful.createClient({
+     *    accessToken: '<content_management_api_key>'
+     *  })
+     *
+     *  client.getSpace('<space_id>')
+     *    .then((space) => space.createScheduledAction({
+     *      entity: {
+     *        sys: {
+     *          type: 'Link',
+     *          linkType: 'Entry',
+     *          id: '<entry_id>'
+     *        }
+     *      },
+     *      environment: {
+     *        type: 'Link',
+     *        linkType: 'Environment',
+     *        id: '<environment_id>'
+     *      },
+     *      action: 'publish',
+     *      scheduledFor: {
+     *        dateTime: <ISO_date_string>,
+     *        timezone: 'Europe/Berlin'
+     *      }
+     *    }))
+     *    .then((scheduledAction) => console.log(scheduledAction))
+     *    .catch(console.error)
+     * ```
      */
     createScheduledAction(data: Omit<ScheduledActionProps, 'sys'>) {
       const raw = this.toPlainObject() as SpaceProps
@@ -1135,6 +1181,47 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * @param options.version the sys.version of the scheduled action to be updated
      * @param payload the scheduled actions object with updates, omitting sys object
      * @returns Promise containing a wrapped scheduled action with helper methods
+     * @example ```javascript
+     *  const contentful = require('contentful-management');
+     *
+     *  const client = contentful.createClient({
+     *    accessToken: '<content_management_api_key>'
+     *  })
+     *
+     *  client.getSpace('<space_id>')
+     *    .then((space) => {
+     *      return space.createScheduledAction({
+     *        entity: {
+     *          sys: {
+     *            type: 'Link',
+     *            linkType: 'Entry',
+     *            id: '<entry_id>'
+     *          }
+     *        },
+     *        environment: {
+     *          type: 'Link',
+     *          linkType: 'Environment',
+     *          id: '<environment_id>'
+     *        },
+     *        action: 'publish',
+     *        scheduledFor: {
+     *          dateTime: <ISO_date_string>,
+     *          timezone: 'Europe/Berlin'
+     *        }
+     *      })
+     *      .then((scheduledAction) => {
+     *        const { _sys, ...payload } = scheduledAction;
+     *        return space.updateScheduledAction({
+     *          ...payload,
+     *          scheduledFor: {
+     *            ...payload.scheduledFor,
+     *            timezone: 'Europe/Paris'
+     *          }
+     *        })
+     *      })
+     *    .then((scheduledAction) => console.log(scheduledAction))
+     *    .catch(console.error);
+     * ```
      */
     updateScheduledAction({
       scheduledActionId,

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -4,6 +4,7 @@
  */
 
 import { createRequestConfig } from 'contentful-sdk-core'
+import { rawListeners } from 'node:process'
 import { MakeRequest, PaginationQueryOptions, QueryOptions } from './common-types'
 import entities from './entities'
 import { CreateApiKeyProps } from './entities/api-key'
@@ -1126,6 +1127,35 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
         action: 'create',
         params: { spaceId: raw.sys.id },
         payload: data,
+      }).then((response) => wrapScheduledAction(makeRequest, response))
+    },
+    /**
+     * Update a scheduled action
+     * @param {object} options
+     * @param options.scheduledActionId the id of the scheduled action to update
+     * @param options.version the sys.version of the scheduled action to be updated
+     * @param payload the scheduled actions object with updates, omitting sys object
+     * @returns Promise containing a wrapped scheduled action with helper methods
+     */
+    updateScheduledAction({
+      scheduledActionId,
+      payload,
+      version,
+    }: {
+      scheduledActionId: string
+      payload: Omit<ScheduledActionProps, 'sys'>
+      version: number
+    }) {
+      const spaceProps = this.toPlainObject() as SpaceProps
+      return makeRequest({
+        entityType: 'ScheduledAction',
+        action: 'update',
+        params: {
+          spaceId: spaceProps.sys.id,
+          version,
+          scheduledActionId,
+        },
+        payload,
       }).then((response) => wrapScheduledAction(makeRequest, response))
     },
   }

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -4,7 +4,6 @@
  */
 
 import { createRequestConfig } from 'contentful-sdk-core'
-import { rawListeners } from 'node:process'
 import { MakeRequest, PaginationQueryOptions, QueryOptions } from './common-types'
 import entities from './entities'
 import { CreateApiKeyProps } from './entities/api-key'

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -101,6 +101,42 @@ export default function getInstanceMethods(makeRequest: MakeRequest): ScheduledA
   }
 
   return {
+    /**
+     * Delete current scheduled action.
+     *
+     * @example ```javascript
+     *  const contentful = require('contentful-management');
+     *
+     *  const client = contentful.createClient({
+     *    accessToken: '<content_management_api_key>'
+     *  })
+     *
+     *  client.getSpace('<space_id>')
+     *    .then((space) => {
+     *      return space.createScheduledAction({
+     *        entity: {
+     *          sys: {
+     *            type: 'Link',
+     *            linkType: 'Entry',
+     *            id: '<entry_id>'
+     *          }
+     *        },
+     *        environment: {
+     *          type: 'Link',
+     *          linkType: 'Environment',
+     *          id: '<environment_id>'
+     *        },
+     *        action: 'publish',
+     *        scheduledFor: {
+     *          dateTime: <ISO_date_string>,
+     *          timezone: 'Europe/Berlin'
+     *        }
+     *      })
+     *    .then((scheduledAction) => scheduledAction.delete())
+     *    .then((deletedScheduledAction) => console.log(deletedScheduledAction))
+     *    .catch(console.error);
+     * ```
+     */
     async delete(): Promise<ScheduledAction> {
       const params = getParams(this)
 
@@ -110,6 +146,46 @@ export default function getInstanceMethods(makeRequest: MakeRequest): ScheduledA
         params,
       }).then((data) => wrapScheduledAction(makeRequest, data))
     },
+    /**
+     * Update current scheduled actions. All changes made to current instance will be saved in the database,
+     * provided the request succeeds.
+     *
+     * @example ```javascript
+     *  const contentful = require('contentful-management');
+     *
+     *  const client = contentful.createClient({
+     *    accessToken: '<content_management_api_key>'
+     *  })
+     *
+     *  client.getSpace('<space_id>')
+     *    .then((space) => {
+     *      return space.createScheduledAction({
+     *        entity: {
+     *          sys: {
+     *            type: 'Link',
+     *            linkType: 'Entry',
+     *            id: '<entry_id>'
+     *          }
+     *        },
+     *        environment: {
+     *          type: 'Link',
+     *          linkType: 'Environment',
+     *          id: '<environment_id>'
+     *        },
+     *        action: 'publish',
+     *        scheduledFor: {
+     *          dateTime: <ISO_date_string>,
+     *          timezone: 'Europe/Berlin'
+     *        }
+     *      })
+     *    .then((scheduledAction) => {
+     *      scheduledAction.scheduledFor.timezone = 'Europe/Paris';
+     *      return scheduledAction.update();
+     *    })
+     *    .then((scheduledAction) => console.log(scheduledAction))
+     *    .catch(console.error);
+     * ```
+     */
     async update(): Promise<ScheduledAction> {
       const params = getParams(this)
 

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -81,6 +81,7 @@ export interface ScheduledActionQueryOptions extends BasicCursorPaginationOption
 
 type ScheduledActionApi = {
   delete(): Promise<ScheduledAction>
+  update(): Promise<ScheduledAction>
 }
 
 export interface ScheduledAction
@@ -105,9 +106,28 @@ export function createDeleteScheduledAction(
   }
 }
 
+export function createUpdateScheduledAction(
+  makeRequest: MakeRequest
+): () => Promise<ScheduledAction> {
+  return function (): Promise<ScheduledAction> {
+    const { sys, ...payload } = this.toPlainObject() as ScheduledActionProps
+    return makeRequest({
+      entityType: 'ScheduledAction',
+      action: 'update',
+      params: {
+        spaceId: sys.space.sys.id,
+        scheduledActionId: sys.id,
+        version: sys.version,
+      },
+      payload,
+    }).then((data) => wrapScheduledAction(makeRequest, data))
+  }
+}
+
 export default function createScheduledActionApi(makeRequest: MakeRequest): ScheduledActionApi {
   return {
     delete: createDeleteScheduledAction(makeRequest),
+    update: createUpdateScheduledAction(makeRequest),
   }
 }
 

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -468,6 +468,10 @@ export type PlainClientAPI = {
     delete(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { scheduledActionId: string }>
     ): Promise<ScheduledActionProps>
+    update(
+      params: OptionalDefaults<GetSpaceParams & { scheduledActionId: string; version: number }>,
+      data: Omit<ScheduledActionProps, 'sys'>
+    ): Promise<ScheduledActionProps>
   }
   previewApiKey: {
     get(

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -232,6 +232,7 @@ export const createPlainClient = (
       getMany: wrap(wrapParams, 'ScheduledAction', 'getMany'),
       create: wrap(wrapParams, 'ScheduledAction', 'create'),
       delete: wrap(wrapParams, 'ScheduledAction', 'delete'),
+      update: wrap(wrapParams, 'ScheduledAction', 'update'),
     },
     previewApiKey: {
       get: wrap(wrapParams, 'PreviewApiKey', 'get'),

--- a/test/defaults.ts
+++ b/test/defaults.ts
@@ -12,7 +12,4 @@ export const TestDefaults = {
     /** Used in BulkAction specs */
     testEntryBulkActionId: '375PMdQrwWOsifPJYP5Bb9',
   },
-  asset: {
-    testAssetId: '67c9d14ab3ed26b61bbbba',
-  },
 }

--- a/test/defaults.ts
+++ b/test/defaults.ts
@@ -12,4 +12,7 @@ export const TestDefaults = {
     /** Used in BulkAction specs */
     testEntryBulkActionId: '375PMdQrwWOsifPJYP5Bb9',
   },
+  asset: {
+    testAssetId: '67c9d14ab3ed26b61bbbba',
+  },
 }

--- a/test/integration/scheduled-action-integration.ts
+++ b/test/integration/scheduled-action-integration.ts
@@ -1,0 +1,267 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from 'chai'
+import { before, describe, test } from 'mocha'
+import { Space } from '../../lib/entities/space'
+import { TestDefaults } from '../defaults'
+import { getDefaultSpace, getPlainClient } from '../helpers'
+import { makeLink } from '../utils'
+
+describe('Scheduled actions api', async function () {
+  let testSpace: Space
+
+  before(async () => {
+    testSpace = await getDefaultSpace()
+  })
+
+  describe('Read', () => {
+    test('Get Scheduled action', async () => {
+      const createdAction = await testSpace.createScheduledAction({
+        entity: makeLink('Entry', TestDefaults.entry.testEntryId),
+        action: 'publish',
+        scheduledFor: {
+          datetime: new Date().toISOString(),
+        },
+      })
+
+      const fetchedActions = await testSpace.getScheduledActions({
+        'environment.sys.id': createdAction.environment.sys.id,
+        'sys.id[in]': createdAction.sys.id,
+      })
+
+      expect(fetchedActions.total).to.eql(1)
+      const fetchedAction = fetchedActions.items[0]
+      expect(fetchedAction.sys.id).to.eql(createdAction.sys.id)
+      expect(fetchedAction.action).to.eql(createdAction.action)
+      expect(fetchedAction.entity).to.eql(createdAction.entity)
+
+      // cleanup
+      await fetchedAction.delete()
+    })
+
+    test('Get Scheduled Actions', async () => {
+      // Creates 2 scheduled actions
+      const [action1, action2] = await Promise.all([
+        testSpace.createScheduledAction({
+          entity: makeLink('Entry', TestDefaults.entry.testEntryId),
+          action: 'publish',
+          scheduledFor: {
+            datetime: new Date().toISOString(),
+          },
+        }),
+        testSpace.createScheduledAction({
+          entity: makeLink('Asset', TestDefaults.asset.testAssetId),
+          action: 'unpublish',
+          scheduledFor: {
+            datetime: new Date().toISOString(),
+          },
+        }),
+      ])
+
+      const queryLimit = 1
+      const queryResult = await testSpace.getScheduledActions({
+        'environment.sys.id': TestDefaults.environmentId,
+        limit: queryLimit,
+      })
+
+      // Returns the filtered results based on the limit
+      expect(queryResult.items.length).to.eql(queryLimit)
+      expect(queryResult).to.have.property('pages')
+
+      // cleanup
+      await Promise.all([action1.delete(), action2.delete()])
+    })
+  })
+
+  describe('Write', () => {
+    test('create Scheduled Action', async () => {
+      const datetime = new Date().toISOString()
+
+      const scheduledAction = await testSpace.createScheduledAction({
+        entity: makeLink('Entry', TestDefaults.entry.testEntryId),
+        action: 'publish',
+        scheduledFor: {
+          datetime,
+        },
+      })
+
+      expect(scheduledAction.entity).to.equal(makeLink('Entry', TestDefaults.entry.testEntryId))
+      expect(scheduledAction.action).to.eql('publish')
+      expect(scheduledAction.scheduledFor).to.eql({
+        datetime,
+      })
+
+      // cleanup
+      await scheduledAction.delete()
+    })
+
+    test('create scheduled action for an asset', async () => {
+      const datetime = new Date().toISOString()
+
+      const scheduledAction = await testSpace.createScheduledAction({
+        entity: makeLink('Asset', TestDefaults.asset.testAssetId),
+        action: 'unpublish',
+        scheduledFor: {
+          datetime,
+        },
+      })
+
+      expect(scheduledAction.entity).to.eql(makeLink('Asset', TestDefaults.asset.testAssetId))
+      expect(scheduledAction.action).to.eql('unpublish')
+      expect(scheduledAction.scheduledFor).to.equal({
+        datetime,
+      })
+
+      // cleanup
+      await scheduledAction.delete()
+    })
+
+    test('create invalid scheduled action', async () => {
+      try {
+        const datetime = new Date().toISOString()
+
+        await testSpace.createScheduledAction({
+          entity: makeLink('Asset', 'invalid-id'),
+          action: 'unpublish',
+          scheduledFor: {
+            datetime,
+          },
+        })
+      } catch (error) {
+        const parsed = JSON.parse(error.message)
+        expect(parsed.status).to.eql(422)
+        expect(parsed.message).to.eql('Validation error')
+        expect(parsed.details).to.eql({
+          errors: [
+            {
+              error: {
+                details: {
+                  sys: {
+                    id: 'non-existent-asset',
+                    type: 'Asset',
+                  },
+                },
+                message: 'The resource could not be found.',
+                sys: {
+                  id: 'NotFound',
+                  type: 'Error',
+                },
+              },
+            },
+          ],
+        })
+      }
+    })
+
+    test('update scheduled actions', async () => {
+      const datetime = new Date().toISOString()
+      const updatedSchedule = new Date(Date.now() + 10000).toISOString()
+
+      const scheduledAction = await testSpace.createScheduledAction({
+        entity: makeLink('Asset', TestDefaults.asset.testAssetId),
+        action: 'unpublish',
+        scheduledFor: {
+          datetime,
+        },
+      })
+
+      expect(scheduledAction.entity).to.eql(makeLink('Asset', TestDefaults.asset.testAssetId))
+      expect(scheduledAction.scheduledFor).to.eql({
+        datetime,
+      })
+
+      const { sys, ...payload } = scheduledAction
+
+      await testSpace.updateScheduledAction({
+        scheduledActionId: sys.id,
+        version: sys.version,
+        payload: {
+          entity: makeLink('Entry', TestDefaults.entry.testEntryId),
+          action: 'publish',
+          scheduledFor: {
+            datetime: updatedSchedule,
+          },
+        },
+      })
+
+      const actions = await testSpace.getScheduledActions({
+        'environment.sys.id': payload.environment.sys.id,
+      })
+      const updatedAction = actions.items[0]
+
+      expect(updatedAction.entity).to.eql([makeLink('Entry', TestDefaults.entry.testEntryId)])
+      expect(updatedAction.action).to.eql('publish')
+      expect(updatedAction.scheduledFor).to.eql({
+        datetime: updatedSchedule,
+      })
+
+      // cleanup
+      await updatedAction.delete()
+    })
+
+    test('delete scheduled action', async () => {
+      const datetime = new Date().toISOString()
+
+      const scheduledAction = await testSpace.createScheduledAction({
+        entity: makeLink('Asset', TestDefaults.asset.testAssetId),
+        action: 'unpublish',
+        scheduledFor: {
+          datetime,
+        },
+      })
+
+      // Deletes a Release and all its Release Actions
+      await scheduledAction.delete()
+
+      const response = await testSpace.getScheduledActions({
+        'environment.sys.id': scheduledAction.environment.sys.id,
+      })
+      expect(response.total).to.equal(0)
+    })
+  })
+
+  describe('PlainClient', () => {
+    const defaultParams = {
+      environmentId: TestDefaults.environmentId,
+      spaceId: TestDefaults.spaceId,
+    }
+
+    test('lifecycle', async () => {
+      const plainClient = getPlainClient(defaultParams)
+      const entry = await plainClient.entry.get({
+        entryId: TestDefaults.entry.testEntryReferenceId,
+      })
+
+      const action = await plainClient.scheduledActions.create(
+        {},
+        {
+          entity: makeLink('Entry', entry.sys.id),
+          action: 'publish',
+          scheduledFor: {
+            datetime: new Date().toISOString(),
+          },
+        }
+      )
+
+      const scheduledActions = await plainClient.scheduledActions.getMany({})
+      expect(scheduledActions.items.length).to.equal(1)
+      expect(scheduledActions.items[0].sys.id).to.equal(action.sys.id)
+
+      const { sys, ...payload } = action
+      const updatedAction = await plainClient.scheduledActions.update(
+        { scheduledActionId: sys.id, version: sys.version },
+        {
+          ...payload,
+          action: 'unpublish',
+        }
+      )
+
+      expect(updatedAction.action).to.equal('unpublish')
+
+      // cleanup
+      await plainClient.scheduledActions.delete({
+        scheduledActionId: action.sys.id,
+        environmentId: action.environment.sys.id,
+      })
+    })
+  })
+})

--- a/test/integration/scheduled-action-integration.ts
+++ b/test/integration/scheduled-action-integration.ts
@@ -8,6 +8,7 @@ import { makeLink } from '../utils'
 
 describe('Scheduled actions api', async function () {
   let testSpace: Space
+  const datetime = new Date(Date.now() + 3600 * 24).toISOString()
 
   before(async () => {
     testSpace = await getDefaultSpace()
@@ -19,7 +20,7 @@ describe('Scheduled actions api', async function () {
         entity: makeLink('Entry', TestDefaults.entry.testEntryId),
         action: 'publish',
         scheduledFor: {
-          datetime: new Date().toISOString(),
+          datetime,
         },
       })
 
@@ -45,14 +46,14 @@ describe('Scheduled actions api', async function () {
           entity: makeLink('Entry', TestDefaults.entry.testEntryId),
           action: 'publish',
           scheduledFor: {
-            datetime: new Date().toISOString(),
+            datetime,
           },
         }),
         testSpace.createScheduledAction({
           entity: makeLink('Asset', TestDefaults.asset.testAssetId),
           action: 'unpublish',
           scheduledFor: {
-            datetime: new Date().toISOString(),
+            datetime,
           },
         }),
       ])
@@ -74,8 +75,6 @@ describe('Scheduled actions api', async function () {
 
   describe('Write', () => {
     test('create Scheduled Action', async () => {
-      const datetime = new Date().toISOString()
-
       const scheduledAction = await testSpace.createScheduledAction({
         entity: makeLink('Entry', TestDefaults.entry.testEntryId),
         action: 'publish',
@@ -95,8 +94,6 @@ describe('Scheduled actions api', async function () {
     })
 
     test('create scheduled action for an asset', async () => {
-      const datetime = new Date().toISOString()
-
       const scheduledAction = await testSpace.createScheduledAction({
         entity: makeLink('Asset', TestDefaults.asset.testAssetId),
         action: 'unpublish',
@@ -117,8 +114,6 @@ describe('Scheduled actions api', async function () {
 
     test('create invalid scheduled action', async () => {
       try {
-        const datetime = new Date().toISOString()
-
         await testSpace.createScheduledAction({
           entity: makeLink('Asset', 'invalid-id'),
           action: 'unpublish',
@@ -153,8 +148,7 @@ describe('Scheduled actions api', async function () {
     })
 
     test('update scheduled actions', async () => {
-      const datetime = new Date().toISOString()
-      const updatedSchedule = new Date(Date.now() + 10000).toISOString()
+      const updatedSchedule = new Date(new Date(datetime).getTime() + 3600).toISOString()
 
       const scheduledAction = await testSpace.createScheduledAction({
         entity: makeLink('Asset', TestDefaults.asset.testAssetId),
@@ -199,8 +193,6 @@ describe('Scheduled actions api', async function () {
     })
 
     test('delete scheduled action', async () => {
-      const datetime = new Date().toISOString()
-
       const scheduledAction = await testSpace.createScheduledAction({
         entity: makeLink('Asset', TestDefaults.asset.testAssetId),
         action: 'unpublish',
@@ -237,7 +229,7 @@ describe('Scheduled actions api', async function () {
           entity: makeLink('Entry', entry.sys.id),
           action: 'publish',
           scheduledFor: {
-            datetime: new Date().toISOString(),
+            datetime,
           },
         }
       )

--- a/test/integration/scheduled-action-integration.ts
+++ b/test/integration/scheduled-action-integration.ts
@@ -1,23 +1,53 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from 'chai'
 import { before, describe, test } from 'mocha'
+import { Asset } from '../../lib/entities/asset'
+import { Environment } from '../../lib/entities/environment'
 import { Space } from '../../lib/entities/space'
 import { TestDefaults } from '../defaults'
 import { getDefaultSpace, getPlainClient } from '../helpers'
 import { makeLink } from '../utils'
 
+const ONE_DAY_MS = 3600 * 1000 * 24
+
+const cleanup = async (testSpace: Space, environmentId: string) => {
+  const scheduledActions = await testSpace.getScheduledActions({
+    'environment.sys.id': environmentId,
+    'sys.status': 'scheduled',
+  })
+
+  await Promise.all(scheduledActions.items.map((action) => action.delete()))
+}
+
 describe('Scheduled actions api', async function () {
   let testSpace: Space
-  const datetime = new Date(Date.now() + 3600 * 24).toISOString()
+  let asset: Asset
+  let environment: Environment
+  const datetime = new Date(Date.now() + ONE_DAY_MS).toISOString()
 
   before(async () => {
     testSpace = await getDefaultSpace()
+    environment = await testSpace.getEnvironment('master')
+    asset = await environment.createAsset({
+      fields: {
+        title: {
+          'en-US': 'Test Asset',
+        },
+        file: {},
+      },
+    })
+    await cleanup(testSpace, environment.sys.id)
+  })
+
+  afterEach(async () => {
+    await cleanup(testSpace, environment.sys.id)
   })
 
   describe('Read', () => {
     test('Get Scheduled action', async () => {
       const createdAction = await testSpace.createScheduledAction({
         entity: makeLink('Entry', TestDefaults.entry.testEntryId),
+        environment: makeLink('Environment', environment.sys.id),
         action: 'publish',
         scheduledFor: {
           datetime,
@@ -25,11 +55,12 @@ describe('Scheduled actions api', async function () {
       })
 
       const fetchedActions = await testSpace.getScheduledActions({
-        'environment.sys.id': createdAction.environment.sys.id,
+        'environment.sys.id': environment.sys.id,
+        'sys.status': 'scheduled',
         'sys.id[in]': createdAction.sys.id,
       })
 
-      expect(fetchedActions.total).to.eql(1)
+      expect(fetchedActions.items.length).to.eql(1)
       const fetchedAction = fetchedActions.items[0]
       expect(fetchedAction.sys.id).to.eql(createdAction.sys.id)
       expect(fetchedAction.action).to.eql(createdAction.action)
@@ -45,13 +76,21 @@ describe('Scheduled actions api', async function () {
         testSpace.createScheduledAction({
           entity: makeLink('Entry', TestDefaults.entry.testEntryId),
           action: 'publish',
+          environment: makeLink('Environment', environment.sys.id),
           scheduledFor: {
             datetime,
           },
         }),
         testSpace.createScheduledAction({
-          entity: makeLink('Asset', TestDefaults.asset.testAssetId),
+          entity: makeLink('Asset', asset.sys.id),
           action: 'unpublish',
+          environment: {
+            sys: {
+              type: 'Link',
+              linkType: 'Environment',
+              id: environment.sys.id,
+            },
+          },
           scheduledFor: {
             datetime,
           },
@@ -61,6 +100,7 @@ describe('Scheduled actions api', async function () {
       const queryLimit = 1
       const queryResult = await testSpace.getScheduledActions({
         'environment.sys.id': TestDefaults.environmentId,
+        'sys.status': 'scheduled',
         limit: queryLimit,
       })
 
@@ -77,15 +117,18 @@ describe('Scheduled actions api', async function () {
     test('create Scheduled Action', async () => {
       const scheduledAction = await testSpace.createScheduledAction({
         entity: makeLink('Entry', TestDefaults.entry.testEntryId),
+        environment: makeLink('Environment', environment.sys.id),
         action: 'publish',
         scheduledFor: {
           datetime,
         },
       })
 
-      expect(scheduledAction.entity).to.equal(makeLink('Entry', TestDefaults.entry.testEntryId))
+      expect(scheduledAction.entity).to.deep.equal(
+        makeLink('Entry', TestDefaults.entry.testEntryId)
+      )
       expect(scheduledAction.action).to.eql('publish')
-      expect(scheduledAction.scheduledFor).to.eql({
+      expect(scheduledAction.scheduledFor).to.deep.equal({
         datetime,
       })
 
@@ -95,16 +138,17 @@ describe('Scheduled actions api', async function () {
 
     test('create scheduled action for an asset', async () => {
       const scheduledAction = await testSpace.createScheduledAction({
-        entity: makeLink('Asset', TestDefaults.asset.testAssetId),
+        entity: makeLink('Asset', asset.sys.id),
+        environment: makeLink('Environment', environment.sys.id),
         action: 'unpublish',
         scheduledFor: {
           datetime,
         },
       })
 
-      expect(scheduledAction.entity).to.eql(makeLink('Asset', TestDefaults.asset.testAssetId))
+      expect(scheduledAction.entity).to.deep.equal(makeLink('Asset', asset.sys.id))
       expect(scheduledAction.action).to.eql('unpublish')
-      expect(scheduledAction.scheduledFor).to.equal({
+      expect(scheduledAction.scheduledFor).to.deep.equal({
         datetime,
       })
 
@@ -116,6 +160,7 @@ describe('Scheduled actions api', async function () {
       try {
         await testSpace.createScheduledAction({
           entity: makeLink('Asset', 'invalid-id'),
+          environment: makeLink('Environment', environment.sys.id),
           action: 'unpublish',
           scheduledFor: {
             datetime,
@@ -123,43 +168,26 @@ describe('Scheduled actions api', async function () {
         })
       } catch (error) {
         const parsed = JSON.parse(error.message)
-        expect(parsed.status).to.eql(422)
-        expect(parsed.message).to.eql('Validation error')
-        expect(parsed.details).to.eql({
-          errors: [
-            {
-              error: {
-                details: {
-                  sys: {
-                    id: 'non-existent-asset',
-                    type: 'Asset',
-                  },
-                },
-                message: 'The resource could not be found.',
-                sys: {
-                  id: 'NotFound',
-                  type: 'Error',
-                },
-              },
-            },
-          ],
-        })
+        expect(parsed.status).to.eql(400)
+        expect(parsed.statusText).to.eql('Bad Request')
+        expect(parsed.message).to.eql('The resource could not be found.')
       }
     })
 
     test('update scheduled actions', async () => {
-      const updatedSchedule = new Date(new Date(datetime).getTime() + 3600).toISOString()
+      const updatedSchedule = new Date(new Date(datetime).getTime() + ONE_DAY_MS).toISOString()
 
       const scheduledAction = await testSpace.createScheduledAction({
-        entity: makeLink('Asset', TestDefaults.asset.testAssetId),
+        entity: makeLink('Asset', asset.sys.id),
+        environment: makeLink('Environment', environment.sys.id),
         action: 'unpublish',
         scheduledFor: {
           datetime,
         },
       })
 
-      expect(scheduledAction.entity).to.eql(makeLink('Asset', TestDefaults.asset.testAssetId))
-      expect(scheduledAction.scheduledFor).to.eql({
+      expect(scheduledAction.entity).to.eql(makeLink('Asset', asset.sys.id))
+      expect(scheduledAction.scheduledFor).to.deep.equal({
         datetime,
       })
 
@@ -169,32 +197,81 @@ describe('Scheduled actions api', async function () {
         scheduledActionId: sys.id,
         version: sys.version,
         payload: {
-          entity: makeLink('Entry', TestDefaults.entry.testEntryId),
-          action: 'publish',
+          ...payload,
           scheduledFor: {
             datetime: updatedSchedule,
+            timezone: 'Europe/Kiev',
           },
         },
       })
 
       const actions = await testSpace.getScheduledActions({
         'environment.sys.id': payload.environment.sys.id,
+        'sys.status': 'scheduled',
+        'sys.id[in]': scheduledAction.sys.id,
       })
       const updatedAction = actions.items[0]
 
-      expect(updatedAction.entity).to.eql([makeLink('Entry', TestDefaults.entry.testEntryId)])
-      expect(updatedAction.action).to.eql('publish')
-      expect(updatedAction.scheduledFor).to.eql({
+      expect(updatedAction.entity).to.deep.equal(makeLink('Asset', asset.sys.id))
+      expect(updatedAction.action).to.eql('unpublish')
+      expect(updatedAction.scheduledFor).to.deep.equal({
         datetime: updatedSchedule,
+        timezone: 'Europe/Kiev',
       })
 
       // cleanup
       await updatedAction.delete()
     })
 
+    test('fails to update unsupported property of scheduled actions', async () => {
+      const updatedSchedule = new Date(new Date(datetime).getTime() + ONE_DAY_MS).toISOString()
+
+      const scheduledAction = await testSpace.createScheduledAction({
+        entity: makeLink('Asset', asset.sys.id),
+        environment: makeLink('Environment', environment.sys.id),
+        action: 'unpublish',
+        scheduledFor: {
+          datetime,
+        },
+      })
+
+      expect(scheduledAction.entity).to.eql(makeLink('Asset', asset.sys.id))
+      expect(scheduledAction.scheduledFor).to.deep.equal({
+        datetime,
+      })
+
+      const { sys, ...payload } = scheduledAction
+
+      try {
+        await testSpace.updateScheduledAction({
+          scheduledActionId: sys.id,
+          version: sys.version,
+          payload: {
+            entity: makeLink('Entry', TestDefaults.entry.testEntryId),
+            environment: makeLink('Environment', environment.sys.id),
+            action: 'publish',
+            scheduledFor: {
+              datetime: updatedSchedule,
+            },
+          },
+        })
+      } catch (error) {
+        const parsedError = JSON.parse(error.message)
+        expect(parsedError.status).to.eql(400)
+        expect(parsedError.statusText).to.eql('Bad Request'),
+          expect(parsedError.message).to.eql(
+            'Can only update scheduleFor.datetime and scheduleFor.timezone properties'
+          )
+      }
+
+      // cleanup
+      await scheduledAction.delete()
+    })
+
     test('delete scheduled action', async () => {
       const scheduledAction = await testSpace.createScheduledAction({
-        entity: makeLink('Asset', TestDefaults.asset.testAssetId),
+        entity: makeLink('Asset', asset.sys.id),
+        environment: makeLink('Environment', environment.sys.id),
         action: 'unpublish',
         scheduledFor: {
           datetime,
@@ -206,8 +283,9 @@ describe('Scheduled actions api', async function () {
 
       const response = await testSpace.getScheduledActions({
         'environment.sys.id': scheduledAction.environment.sys.id,
+        'sys.status': 'scheduled',
       })
-      expect(response.total).to.equal(0)
+      expect(response.items.length).to.equal(0)
     })
   })
 
@@ -228,13 +306,19 @@ describe('Scheduled actions api', async function () {
         {
           entity: makeLink('Entry', entry.sys.id),
           action: 'publish',
+          environment: makeLink('Environment', environment.sys.id),
           scheduledFor: {
             datetime,
           },
         }
       )
 
-      const scheduledActions = await plainClient.scheduledActions.getMany({})
+      const scheduledActions = await plainClient.scheduledActions.getMany({
+        query: {
+          'environment.sys.id': environment.sys.id,
+          'sys.status': 'scheduled',
+        },
+      })
       expect(scheduledActions.items.length).to.equal(1)
       expect(scheduledActions.items[0].sys.id).to.equal(action.sys.id)
 
@@ -243,11 +327,14 @@ describe('Scheduled actions api', async function () {
         { scheduledActionId: sys.id, version: sys.version },
         {
           ...payload,
-          action: 'unpublish',
+          scheduledFor: {
+            ...payload.scheduledFor,
+            timezone: 'Europe/Berlin',
+          },
         }
       )
 
-      expect(updatedAction.action).to.equal('unpublish')
+      expect(updatedAction.scheduledFor.timezone).to.equal('Europe/Berlin')
 
       // cleanup
       await plainClient.scheduledActions.delete({

--- a/test/integration/scheduled-action-integration.ts
+++ b/test/integration/scheduled-action-integration.ts
@@ -321,7 +321,6 @@ describe('Scheduled actions api', async function () {
         },
       })
 
-      // Deletes a Release and all its Release Actions
       await scheduledAction.delete()
 
       const response = await testSpace.getScheduledActions({

--- a/test/unit/create-space-api-test.js
+++ b/test/unit/create-space-api-test.js
@@ -474,4 +474,18 @@ describe('A createSpaceApi', () => {
       methodToTest: 'createScheduledAction',
     })
   })
+
+  test('API call updateScheduledAction', async () => {
+    return makeGetEntityTest(setup, {
+      entityType: 'scheduledAction',
+      mockToReturn: scheduledActionMock,
+      methodToTest: 'updateScheduledAction',
+    })
+  })
+
+  test('API call updateScheduledAction fails', async () => {
+    return makeEntityMethodFailingTest(setup, {
+      methodToTest: 'updateScheduledAction',
+    })
+  })
 })

--- a/test/unit/entities/scheduled-action-test.js
+++ b/test/unit/entities/scheduled-action-test.js
@@ -9,6 +9,7 @@ import {
 import {
   entityCollectionWrappedTest,
   entityDeleteTest,
+  entityUpdateTest,
   entityWrappedTest,
   failingActionTest,
 } from '../test-creators/instance-entity-methods'
@@ -43,6 +44,19 @@ describe('Entity ScheduledAction', () => {
     return failingActionTest(setup, {
       wrapperMethod: wrapScheduledAction,
       actionMethod: 'delete',
+    })
+  })
+
+  test('Scheduled action update', async () => {
+    return entityUpdateTest(setup, {
+      wrapperMethod: wrapScheduledAction,
+    })
+  })
+
+  test('Scheduled action update fails', async () => {
+    return failingActionTest(setup, {
+      wrapperMethod: wrapScheduledAction,
+      actionMethod: 'update',
     })
   })
 })

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -562,6 +562,7 @@ export const scheduledActionMock = {
     space: {
       sys: cloneDeep(linkMock),
     },
+    version: 1,
     createdAt: 'createdAt',
     createdBy: 'createdBy',
     type: 'ScheduledAction',


### PR DESCRIPTION
## Summary

Adds support for 
```js
plainClient.scheduledActions.update();
spaceClient.updateScheduledAction();
scheduledAction.update();
```

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [x] Added an integration test for the new method
- [ ] The new method is added to the documentation
