### PR TITLE
feat: add create and createWithId to contentType in plain client

### DIFF
--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -232,7 +232,7 @@ export type PlainClientAPI = {
     ): Promise<ContentTypeProps>
     createWithId(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { contentTypeId: string }>,
-      rawData: ContentTypeProps
+      rawData: CreateContentTypeProps
     ): Promise<ContentTypeProps>
     omitAndDeleteField(
       params: OptionalDefaults<GetContentTypeParams>,

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -42,7 +42,7 @@ import {
   AssetProps,
   CreateAssetProps,
 } from '../entities/asset'
-import { ContentTypeProps } from '../entities/content-type'
+import { ContentTypeProps, CreateContentTypeProps } from '../entities/content-type'
 import { EditorInterfaceProps } from '../entities/editor-interface'
 import { CreateEntryProps, EntryProps, EntryReferenceProps } from '../entities/entry'
 import { CreateEnvironmentProps, EnvironmentProps } from '../entities/environment'
@@ -226,6 +226,14 @@ export type PlainClientAPI = {
       rawData: ContentTypeProps
     ): Promise<ContentTypeProps>
     unpublish(params: OptionalDefaults<GetContentTypeParams>): Promise<ContentTypeProps>
+    create(
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
+      rawData: CreateContentTypeProps
+    ): Promise<ContentTypeProps>
+    createWithId(
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { contentTypeId: string }>,
+      rawData: ContentTypeProps
+    ): Promise<ContentTypeProps>
     omitAndDeleteField(
       params: OptionalDefaults<GetContentTypeParams>,
       contentType: ContentTypeProps,

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -100,6 +100,8 @@ export const createPlainClient = (
       delete: wrap(wrapParams, 'ContentType', 'delete'),
       publish: wrap(wrapParams, 'ContentType', 'publish'),
       unpublish: wrap(wrapParams, 'ContentType', 'unpublish'),
+      create: wrap(wrapParams, 'ContentType', 'create'),
+      createWithId: wrap(wrapParams, 'ContentType', 'createWithId'),
       omitAndDeleteField: (params, contentType, fieldId) =>
         omitAndDeleteField(
           makeRequest,


### PR DESCRIPTION
It adds the `create` and `createWithId` call in the plain client for `contentType`. 

## Motivation and Context
Was not implemented yet.

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
