### PR TITLE
feat(scheduledActions): add get and delete function [SPA-321]

### DIFF
--- a/lib/adapters/REST/endpoints/scheduled-action.ts
+++ b/lib/adapters/REST/endpoints/scheduled-action.ts
@@ -10,6 +10,21 @@ import { RestEndpoint } from '../types'
 import * as raw from './raw'
 import { normalizeSelect } from './utils'
 
+export const get: RestEndpoint<'ScheduledAction', 'get'> = (
+  http: AxiosInstance,
+  params: GetSpaceParams & { environmentId: string; scheduledActionId: string }
+) => {
+  return raw.get<ScheduledActionProps>(
+    http,
+    `/spaces/${params.spaceId}/scheduled_actions/${params.scheduledActionId}`,
+    {
+      params: {
+        'environment.sys.id': params.environmentId,
+      },
+    }
+  )
+}
+
 export const getMany: RestEndpoint<'ScheduledAction', 'getMany'> = (
   http: AxiosInstance,
   params: GetSpaceParams & QueryParams

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -379,6 +379,7 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Role', 'update', UA>): MRReturn<'Role', 'update'>
   (opts: MROpts<'Role', 'delete', UA>): MRReturn<'Role', 'delete'>
 
+  (opts: MROpts<'ScheduledAction', 'get', UA>): MRReturn<'ScheduledAction', 'get'>
   (opts: MROpts<'ScheduledAction', 'getMany', UA>): MRReturn<'ScheduledAction', 'getMany'>
   (opts: MROpts<'ScheduledAction', 'create', UA>): MRReturn<'ScheduledAction', 'create'>
   (opts: MROpts<'ScheduledAction', 'update', UA>): MRReturn<'ScheduledAction', 'update'>
@@ -967,6 +968,10 @@ export type MRActions = {
     delete: { params: GetSpaceParams & { roleId: string }; return: any }
   }
   ScheduledAction: {
+    get: {
+      params: GetSpaceParams & { scheduledActionId: string; environmentId: string }
+      return: ScheduledActionProps
+    }
     getMany: { params: GetSpaceParams & QueryParams; return: CollectionProp<ScheduledActionProps> }
     create: {
       params: GetSpaceParams

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -1131,6 +1131,46 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
       }).then((response) => wrapScheduledActionCollection(makeRequest, response))
     },
     /**
+     * Get a Scheduled Action in the current space by environment and ID
+     * @returns Promise with the Scheduled Action
+     *
+     * @example ```javascript
+     *  const contentful = require('contentful-management');
+     *
+     *  const client = contentful.createClient({
+     *    accessToken: '<content_management_api_key>'
+     *  })
+     *
+     *  client.getSpace('<space_id>')
+     *    .then((space) => space.getScheduledAction({
+     *      scheduledActionId: '<scheduled-action-id>',
+     *      environmentId: '<environmentId>'
+     *    }))
+     *    .then((scheduledAction) => console.log(scheduledAction))
+     *    .catch(console.error)
+     * ```
+     */
+    getScheduledAction({
+      scheduledActionId,
+      environmentId,
+    }: {
+      scheduledActionId: string
+      environmentId: string
+    }) {
+      const space = this.toPlainObject() as SpaceProps
+
+      return makeRequest({
+        entityType: 'ScheduledAction',
+        action: 'get',
+        params: {
+          spaceId: space.sys.id,
+          environmentId,
+          scheduledActionId,
+        },
+      }).then((scheduledAction) => wrapScheduledAction(makeRequest, scheduledAction))
+    },
+
+    /**
      * Creates a scheduled action
      * @param data - Object representation of the scheduled action to be created
      * @return Promise for the newly created scheduled actions

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -1285,5 +1285,50 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
         payload,
       }).then((response) => wrapScheduledAction(makeRequest, response))
     },
+    /**
+     * Cancels a Scheduled Action.
+     * Only cancels actions that have not yet executed.
+     *
+     * @param {object} options
+     * @param options.scheduledActionId the id of the scheduled action to be canceled
+     * @param options.environmentId the environment ID of the scheduled action to be canceled
+     * @throws if the Scheduled Action cannot be found or the user doesn't have permissions in the entity in the action.
+     * @returns Promise containing a wrapped Scheduled Action with helper methods
+     * @example ```javascript
+     *  const contentful = require('contentful-management');
+     *
+     *  const client = contentful.createClient({
+     *    accessToken: '<content_management_api_key>'
+     *  })
+     *
+     *  // Given that an Scheduled Action is scheduled
+     *  client.getSpace('<space_id>')
+     *    .then((space) => space.deleteScheduledAction({
+     *        environmentId: '<environment-id>',
+     *        scheduledActionId: '<scheduled-action-id>'
+     *     }))
+     *     // The scheduled Action sys.status is now 'canceled'
+     *    .then((scheduledAction) => console.log(scheduledAction))
+     *    .catch(console.error);
+     * ```
+     */
+    deleteScheduledAction({
+      scheduledActionId,
+      environmentId,
+    }: {
+      scheduledActionId: string
+      environmentId: string
+    }) {
+      const spaceProps = this.toPlainObject() as SpaceProps
+      return makeRequest({
+        entityType: 'ScheduledAction',
+        action: 'delete',
+        params: {
+          spaceId: spaceProps.sys.id,
+          environmentId,
+          scheduledActionId,
+        },
+      }).then((response) => wrapScheduledAction(makeRequest, response))
+    },
   }
 }

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -1131,9 +1131,10 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
       }).then((response) => wrapScheduledActionCollection(makeRequest, response))
     },
     /**
-     * Get a Scheduled Action in the current space by environment and ID
-     * @returns Promise with the Scheduled Action
+     * Get a Scheduled Action in the current space by environment and ID.
      *
+     * @throws if the Scheduled Action cannot be found or the user doesn't have permission to read schedules from the entity of the scheduled action itself.
+     * @returns Promise with the Scheduled Action
      * @example ```javascript
      *  const contentful = require('contentful-management');
      *

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -147,7 +147,7 @@ export default function getInstanceMethods(makeRequest: MakeRequest): ScheduledA
       }).then((data) => wrapScheduledAction(makeRequest, data))
     },
     /**
-     * Update current scheduled actions. All changes made to the current object will be saved, if the request succeeds.
+     * Update the current scheduled action. Currently, only changes made to the `scheduledFor` property will be saved.
      *
      * @example ```javascript
      *  const contentful = require('contentful-management');

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -102,7 +102,7 @@ export default function getInstanceMethods(makeRequest: MakeRequest): ScheduledA
 
   return {
     /**
-     * Delete current scheduled action.
+     * Cancels the current Scheduled Action schedule.
      *
      * @example ```javascript
      *  const contentful = require('contentful-management');
@@ -147,8 +147,7 @@ export default function getInstanceMethods(makeRequest: MakeRequest): ScheduledA
       }).then((data) => wrapScheduledAction(makeRequest, data))
     },
     /**
-     * Update current scheduled actions. All changes made to current instance will be saved in the database,
-     * provided the request succeeds.
+     * Update current scheduled actions. All changes made to the current object will be saved, if the request succeeds.
      *
      * @example ```javascript
      *  const contentful = require('contentful-management');

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -466,6 +466,12 @@ export type PlainClientAPI = {
     delete(params: OptionalDefaults<GetSpaceParams & { roleId: string }>): Promise<any>
   }
   scheduledActions: {
+    get(
+      params: OptionalDefaults<GetSpaceParams> & {
+        scheduledActionId: string
+        environmentId: string
+      }
+    ): Promise<ScheduledActionProps>
     getMany(
       params: OptionalDefaults<GetSpaceParams & QueryParams>
     ): Promise<CursorPaginatedCollectionProp<ScheduledActionProps>>

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -231,6 +231,7 @@ export const createPlainClient = (
       delete: wrap(wrapParams, 'Role', 'delete'),
     },
     scheduledActions: {
+      get: wrap(wrapParams, 'ScheduledAction', 'get'),
       getMany: wrap(wrapParams, 'ScheduledAction', 'getMany'),
       create: wrap(wrapParams, 'ScheduledAction', 'create'),
       delete: wrap(wrapParams, 'ScheduledAction', 'delete'),

--- a/test/integration/scheduled-action-integration.ts
+++ b/test/integration/scheduled-action-integration.ts
@@ -256,7 +256,10 @@ describe('Scheduled Actions API', async function () {
       })
 
       // Calling delete will cancel the scheduled action (not actually delete it)
-      await scheduledAction.delete()
+      await testSpace.deleteScheduledAction({
+        environmentId: environment.sys.id,
+        scheduledActionId: scheduledAction.sys.id,
+      })
 
       const deletedScheduledAction = await testSpace.getScheduledAction({
         environmentId: scheduledAction.environment.sys.id,

--- a/test/integration/scheduled-action-integration.ts
+++ b/test/integration/scheduled-action-integration.ts
@@ -245,49 +245,6 @@ describe('Scheduled Actions API', async function () {
       })
     })
 
-    test('fails to update with unsupported property changes in the scheduled action', async () => {
-      const updatedSchedule = new Date(new Date(datetime).getTime() + ONE_DAY_MS).toISOString()
-
-      const scheduledAction = await testSpace.createScheduledAction({
-        entity: makeLink('Asset', asset.sys.id),
-        environment: makeLink('Environment', environment.sys.id),
-        action: 'unpublish',
-        scheduledFor: {
-          datetime,
-        },
-      })
-
-      expect(scheduledAction.entity).to.eql(makeLink('Asset', asset.sys.id))
-      expect(scheduledAction.scheduledFor).to.deep.equal({
-        datetime,
-      })
-
-      try {
-        await testSpace.updateScheduledAction({
-          scheduledActionId: scheduledAction.sys.id,
-          version: scheduledAction.sys.version,
-          payload: {
-            entity: makeLink('Entry', TestDefaults.entry.testEntryId),
-            environment: makeLink('Environment', environment.sys.id),
-            action: 'publish',
-            scheduledFor: {
-              datetime: updatedSchedule,
-            },
-          },
-        })
-      } catch (error) {
-        const parsedError = JSON.parse(error.message)
-        expect(parsedError.status).to.eql(400)
-        expect(parsedError.statusText).to.eql('Bad Request'),
-          expect(parsedError.message).to.eql(
-            'Can only update scheduleFor.datetime and scheduleFor.timezone properties'
-          )
-      }
-
-      // cleanup
-      await scheduledAction.delete()
-    })
-
     test('delete scheduled action', async () => {
       const scheduledAction = await testSpace.createScheduledAction({
         entity: makeLink('Asset', asset.sys.id),

--- a/test/integration/scheduled-action-integration.ts
+++ b/test/integration/scheduled-action-integration.ts
@@ -19,7 +19,7 @@ const cleanup = async (testSpace: Space, environmentId: string) => {
   await Promise.all(scheduledActions.items.map((action) => action.delete()))
 }
 
-describe('Scheduled actions api', async function () {
+describe('Scheduled Actions API', async function () {
   let testSpace: Space
   let asset: Asset
   let environment: Environment
@@ -39,7 +39,7 @@ describe('Scheduled actions api', async function () {
     await cleanup(testSpace, environment.sys.id)
   })
 
-  afterEach(async () => {
+  after(async () => {
     await cleanup(testSpace, environment.sys.id)
   })
 
@@ -54,23 +54,17 @@ describe('Scheduled actions api', async function () {
         },
       })
 
-      const fetchedActions = await testSpace.getScheduledActions({
-        'environment.sys.id': environment.sys.id,
-        'sys.status': 'scheduled',
-        'sys.id[in]': createdAction.sys.id,
+      const fetchedAction = await testSpace.getScheduledAction({
+        environmentId: environment.sys.id,
+        scheduledActionId: createdAction.sys.id,
       })
 
-      expect(fetchedActions.items.length).to.eql(1)
-      const fetchedAction = fetchedActions.items[0]
       expect(fetchedAction.sys.id).to.eql(createdAction.sys.id)
       expect(fetchedAction.action).to.eql(createdAction.action)
       expect(fetchedAction.entity).to.eql(createdAction.entity)
-
-      // cleanup
-      await fetchedAction.delete()
     })
 
-    test('Get Scheduled Actions', async () => {
+    test('Query Scheduled Actions', async () => {
       // Creates 2 scheduled actions
       const [action1, action2] = await Promise.all([
         testSpace.createScheduledAction({
@@ -101,15 +95,13 @@ describe('Scheduled actions api', async function () {
       const queryResult = await testSpace.getScheduledActions({
         'environment.sys.id': TestDefaults.environmentId,
         'sys.status': 'scheduled',
+        'sys.id[in]': `${action1.sys.id}, ${action2.sys.id}`,
         limit: queryLimit,
       })
 
       // Returns the filtered results based on the limit
       expect(queryResult.items.length).to.eql(queryLimit)
       expect(queryResult).to.have.property('pages')
-
-      // cleanup
-      await Promise.all([action1.delete(), action2.delete()])
     })
   })
 
@@ -131,9 +123,6 @@ describe('Scheduled actions api', async function () {
       expect(scheduledAction.scheduledFor).to.deep.equal({
         datetime,
       })
-
-      // cleanup
-      await scheduledAction.delete()
     })
 
     test('create scheduled action for an asset', async () => {
@@ -151,9 +140,6 @@ describe('Scheduled actions api', async function () {
       expect(scheduledAction.scheduledFor).to.deep.equal({
         datetime,
       })
-
-      // cleanup
-      await scheduledAction.delete()
     })
 
     test('create invalid scheduled action', async () => {
@@ -207,12 +193,10 @@ describe('Scheduled actions api', async function () {
         },
       })
 
-      const actions = await testSpace.getScheduledActions({
-        'environment.sys.id': payload.environment.sys.id,
-        'sys.status': 'scheduled',
-        'sys.id[in]': scheduledAction.sys.id,
+      const updatedAction = await testSpace.getScheduledAction({
+        environmentId: payload.environment.sys.id,
+        scheduledActionId: scheduledAction.sys.id,
       })
-      const updatedAction = actions.items[0]
 
       expect(updatedAction.entity).to.deep.equal(makeLink('Asset', asset.sys.id))
       expect(updatedAction.action).to.eql('unpublish')
@@ -248,12 +232,10 @@ describe('Scheduled actions api', async function () {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { sys, ...payload } = await scheduledAction.update()
 
-      const actions = await testSpace.getScheduledActions({
-        'environment.sys.id': payload.environment.sys.id,
-        'sys.status': 'scheduled',
-        'sys.id[in]': scheduledAction.sys.id,
+      const updatedAction = await testSpace.getScheduledAction({
+        environmentId: payload.environment.sys.id,
+        scheduledActionId: scheduledAction.sys.id,
       })
-      const updatedAction = actions.items[0]
 
       expect(updatedAction.entity).to.deep.equal(makeLink('Asset', asset.sys.id))
       expect(updatedAction.action).to.eql('unpublish')
@@ -261,12 +243,9 @@ describe('Scheduled actions api', async function () {
         datetime: updatedSchedule,
         timezone: 'Europe/Kiev',
       })
-
-      // cleanup
-      await updatedAction.delete()
     })
 
-    test('fails to update unsupported property of scheduled actions', async () => {
+    test('fails to update with unsupported property changes in the scheduled action', async () => {
       const updatedSchedule = new Date(new Date(datetime).getTime() + ONE_DAY_MS).toISOString()
 
       const scheduledAction = await testSpace.createScheduledAction({
@@ -283,12 +262,10 @@ describe('Scheduled actions api', async function () {
         datetime,
       })
 
-      const { sys } = scheduledAction
-
       try {
         await testSpace.updateScheduledAction({
-          scheduledActionId: sys.id,
-          version: sys.version,
+          scheduledActionId: scheduledAction.sys.id,
+          version: scheduledAction.sys.version,
           payload: {
             entity: makeLink('Entry', TestDefaults.entry.testEntryId),
             environment: makeLink('Environment', environment.sys.id),
@@ -321,13 +298,15 @@ describe('Scheduled actions api', async function () {
         },
       })
 
+      // Calling delete will cancel the scheduled action (not actually delete it)
       await scheduledAction.delete()
 
-      const response = await testSpace.getScheduledActions({
-        'environment.sys.id': scheduledAction.environment.sys.id,
-        'sys.status': 'scheduled',
+      const deletedScheduledAction = await testSpace.getScheduledAction({
+        environmentId: scheduledAction.environment.sys.id,
+        scheduledActionId: scheduledAction.sys.id,
       })
-      expect(response.items.length).to.equal(0)
+
+      expect(deletedScheduledAction.sys.status).to.eql('canceled')
     })
   })
 
@@ -337,7 +316,7 @@ describe('Scheduled actions api', async function () {
       spaceId: TestDefaults.spaceId,
     }
 
-    test('lifecycle', async () => {
+    test('lifecycle of a scheduled action (create, read, update, delete)', async () => {
       const plainClient = getPlainClient(defaultParams)
       const entry = await plainClient.entry.get({
         entryId: TestDefaults.entry.testEntryReferenceId,
@@ -355,14 +334,12 @@ describe('Scheduled actions api', async function () {
         }
       )
 
-      const scheduledActions = await plainClient.scheduledActions.getMany({
-        query: {
-          'environment.sys.id': environment.sys.id,
-          'sys.status': 'scheduled',
-        },
+      const scheduledAction = await plainClient.scheduledActions.get({
+        environmentId: environment.sys.id,
+        scheduledActionId: action.sys.id,
       })
-      expect(scheduledActions.items.length).to.equal(1)
-      expect(scheduledActions.items[0].sys.id).to.equal(action.sys.id)
+
+      expect(scheduledAction.sys.id).to.equal(action.sys.id)
 
       const { sys, ...payload } = action
       const updatedAction = await plainClient.scheduledActions.update(
@@ -371,18 +348,12 @@ describe('Scheduled actions api', async function () {
           ...payload,
           scheduledFor: {
             ...payload.scheduledFor,
-            timezone: 'Europe/Berlin',
+            timezone: 'Europe/Berlin', // adds timezone
           },
         }
       )
 
       expect(updatedAction.scheduledFor.timezone).to.equal('Europe/Berlin')
-
-      // cleanup
-      await plainClient.scheduledActions.delete({
-        scheduledActionId: action.sys.id,
-        environmentId: action.environment.sys.id,
-      })
     })
   })
 })

--- a/test/unit/entities/scheduled-action-test.js
+++ b/test/unit/entities/scheduled-action-test.js
@@ -7,7 +7,6 @@ import {
   wrapScheduledActionCollection,
 } from '../../../lib/entities/scheduled-action'
 import {
-  entityActionTest,
   entityCollectionWrappedTest,
   entityDeleteTest,
   entityUpdateTest,
@@ -32,13 +31,6 @@ describe('Entity ScheduledAction', () => {
   test('Scheduled action collection is wrapped', async () => {
     return entityCollectionWrappedTest(setup, {
       wrapperMethod: wrapScheduledActionCollection,
-    })
-  })
-
-  test('Scheduled action get', async () => {
-    return entityActionTest(setup, {
-      wrapperMethod: wrapScheduledAction,
-      actionMethod: 'get',
     })
   })
 

--- a/test/unit/entities/scheduled-action-test.js
+++ b/test/unit/entities/scheduled-action-test.js
@@ -7,6 +7,7 @@ import {
   wrapScheduledActionCollection,
 } from '../../../lib/entities/scheduled-action'
 import {
+  entityActionTest,
   entityCollectionWrappedTest,
   entityDeleteTest,
   entityUpdateTest,
@@ -31,6 +32,13 @@ describe('Entity ScheduledAction', () => {
   test('Scheduled action collection is wrapped', async () => {
     return entityCollectionWrappedTest(setup, {
       wrapperMethod: wrapScheduledActionCollection,
+    })
+  })
+
+  test('Scheduled action get', async () => {
+    return entityActionTest(setup, {
+      wrapperMethod: wrapScheduledAction,
+      actionMethod: 'get',
     })
   })
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

- Adds `getScheduledAction`, previously missing from the SDK support.

## Description

- Adds the `read` method for a scheduled Action and refactor some tests to use it.

## Motivation and Context

- It was missing from the overall SDK support

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
