### PR TITLE
feat(scheduledAction): Expose error on Scheduled Actions API [SPA-314]

### DIFF
--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -31,6 +31,17 @@ enum ScheduledActionStatus {
 type SchedulableEntityType = 'Entry' | 'Asset' | 'Release'
 type SchedulableActionType = 'publish' | 'unpublish'
 
+type Collection<T> = Array<T>
+type ErrorDetail = { error: any }
+interface ScheduledActionFailedError {
+  sys: {
+    type: 'Error'
+    id: string
+  }
+  message?: string
+  details?: { errors: Collection<ErrorDetail> }
+}
+
 export type ScheduledActionSysProps = {
   id: string
   type: 'ScheduledAction'
@@ -62,6 +73,22 @@ export type ScheduledActionProps = {
      */
     timezone?: string
   }
+  /**
+   * The Contentful-style error that occurred during execution if sys.status is failed
+   *
+   * @example
+   * {
+   *   sys: {
+   *     type: 'Error',
+   *     id: 'InvalidEntry'
+   *   },
+   *   message: 'Entry is invalid',
+   *   details: {
+   *     errors: [...]
+   *   }
+   * }
+   */
+  error?: ScheduledActionFailedError
 }
 
 export interface ScheduledActionCollection {

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -31,7 +31,6 @@ enum ScheduledActionStatus {
 type SchedulableEntityType = 'Entry' | 'Asset' | 'Release'
 type SchedulableActionType = 'publish' | 'unpublish'
 
-type Collection<T> = Array<T>
 type ErrorDetail = { error: any }
 interface ScheduledActionFailedError {
   sys: {

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -39,7 +39,7 @@ interface ScheduledActionFailedError {
     id: string
   }
   message?: string
-  details?: { errors: Collection<ErrorDetail> }
+  details?: { errors: ErrorDetail[] }
 }
 
 export type ScheduledActionSysProps = {
@@ -91,7 +91,10 @@ export type ScheduledActionProps = {
   error?: ScheduledActionFailedError
 }
 
-export type CreateUpdateScheduledActionProps = Omit<ScheduledActionProps, 'sys' | 'error'>
+export type CreateUpdateScheduledActionProps = Pick<
+  ScheduledActionProps,
+  'action' | 'entity' | 'environment' | 'scheduledFor'
+>
 
 export interface ScheduledActionCollection {
   sys: {

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -91,6 +91,8 @@ export type ScheduledActionProps = {
   error?: ScheduledActionFailedError
 }
 
+export type CreateUpdateScheduledActionProps = Omit<ScheduledActionProps, 'sys' | 'error'>
+
 export interface ScheduledActionCollection {
   sys: {
     type: 'Array'

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -60,7 +60,10 @@ import {
 } from '../entities/personal-access-token'
 import { PreviewApiKeyProps } from '../entities/preview-api-key'
 import { CreateRoleProps, RoleProps } from '../entities/role'
-import { ScheduledActionProps } from '../entities/scheduled-action'
+import {
+  ScheduledActionProps,
+  CreateUpdateScheduledActionProps,
+} from '../entities/scheduled-action'
 import { SnapshotProps } from '../entities/snapshot'
 import { SpaceProps } from '../entities/space'
 import { SpaceMemberProps } from '../entities/space-member'
@@ -477,14 +480,14 @@ export type PlainClientAPI = {
     ): Promise<CursorPaginatedCollectionProp<ScheduledActionProps>>
     create(
       params: OptionalDefaults<GetSpaceParams>,
-      data: Omit<ScheduledActionProps, 'sys'>
+      data: CreateUpdateScheduledActionProps
     ): Promise<ScheduledActionProps>
     delete(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { scheduledActionId: string }>
     ): Promise<ScheduledActionProps>
     update(
       params: OptionalDefaults<GetSpaceParams & { scheduledActionId: string; version: number }>,
-      data: Omit<ScheduledActionProps, 'sys'>
+      data: CreateUpdateScheduledActionProps
     ): Promise<ScheduledActionProps>
   }
   previewApiKey: {


### PR DESCRIPTION

## Summary

Added error in ScheduledActionsProp

## Description

We have a [CEP](https://contentful.atlassian.net/wiki/spaces/ENG/pages/3282698277/CEP-0117+Add+error+to+scheduled+actions+payload) written with all the details and security considerations. 

## Motivation and Context

- Tracking error types for BI data warehousing (e.g. Segment)
- Exposing historical scheduled action errors in Contentful Launch
- Exposing historical scheduled action errors via customer API
- Sending errors via webhooks to external systems

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
