### PR TITLE
fix: adjust create ui extension types

### DIFF
--- a/lib/entities/extension.ts
+++ b/lib/entities/extension.ts
@@ -50,10 +50,12 @@ export type ExtensionProps = {
   parameters?: DefinedParameters
 }
 
-export type CreateExtensionProps = RequireExactlyOne<
-  SetRequired<ExtensionProps['extension'], 'name' | 'fieldTypes' | 'sidebar'>,
-  'src' | 'srcdoc'
->
+export type CreateExtensionProps = {
+  extension: RequireExactlyOne<
+    SetRequired<ExtensionProps['extension'], 'name' | 'fieldTypes' | 'sidebar'>,
+    'src' | 'srcdoc'
+  >
+}
 
 export interface Extension extends ExtensionProps, DefaultElements<ExtensionProps> {
   /**


### PR DESCRIPTION
## Summary

Closing https://github.com/contentful/contentful-management.js/issues/868

`createUiExtension` and `createUiExtensionWithId` always expects the second argument to be wrapped in extension, only the types for this weren't correct.

This adjusts the types to be what we expect in the function



## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
