### PR TITLE
fix: rename initialValue property defaultValue [DANTE-182]

### DIFF
--- a/lib/entities/content-type-fields.ts
+++ b/lib/entities/content-type-fields.ts
@@ -50,5 +50,5 @@ export interface ContentFields<T = KeyValueMap> extends Item {
   deleted?: boolean
   items?: Item
   apiName?: string
-  initialValue?: T
+  defaultValue?: T
 }


### PR DESCRIPTION
## Summary

Rename `initialValue` property `defaultValue` in  content type field type.

## Description

Rename `initialValue` property `defaultValue` in  content type field type.

## Motivation and Context

See [DANTE-182](https://contentful.atlassian.net/browse/DANTE-182) and [DANTE-189](https://contentful.atlassian.net/browse/DANTE-189). After concluding the _inital values_ EAP it was decided to rename the feature _default values_. Because the feature was only available in the EAP, we don’t consider this a breaking change.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation
