### PR TITLE
fix: [EXT-2845] Add shared flag to app definitions typing

### DIFF
--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -35,7 +35,7 @@ export type AppDefinitionProps = {
   /**
    * System metadata
    */
-  sys: BasicMetaSysProps & { organization: SysLink }
+  sys: BasicMetaSysProps & { organization: SysLink, shared?: boolean }
   /**
    * App name
    */

--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -35,7 +35,7 @@ export type AppDefinitionProps = {
   /**
    * System metadata
    */
-  sys: BasicMetaSysProps & { organization: SysLink, shared?: boolean }
+  sys: BasicMetaSysProps & { organization: SysLink; shared?: boolean }
   /**
    * App name
    */


### PR DESCRIPTION
## Summary

The responses from app definitions endpoints are resolving with `shared` flag inside of `sys` property. But we don't have it in types so far. This PR fixes this inconsistency.
