### PR TITLE
feat(releases): expose title[match] on release query

### DIFF
--- a/lib/entities/release.ts
+++ b/lib/entities/release.ts
@@ -26,6 +26,8 @@ export interface ReleaseQueryOptions {
   'entities.sys.id[in]'?: string
   /** Find releases by using a comma-separated list of Ids */
   'sys.id[in]'?: string
+  /** Find releases using full text phrase and term matching */
+  'title[match]'?: string
   /** If present, will return results based on a pagination cursor */
   pageNext?: string
   /**


### PR DESCRIPTION
## Summary

This PR adds the newly-support `title[match]` operator on Release.query operations.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] All new public types are exported from `./lib/export-types.ts`
- [x] The new operation is added to the documentation
