### PR TITLE
docs: exclude internal types/constants/functions

### DIFF
--- a/lib/adapters/REST/rest-adapter.ts
+++ b/lib/adapters/REST/rest-adapter.ts
@@ -23,7 +23,10 @@ export type RestAdapterParams = CreateHttpClientParams & {
   hostUpload?: string
 }
 
-export const defaultHostParameters = {
+/**
+ * @private
+ */
+const defaultHostParameters = {
   defaultHostname: 'api.contentful.com',
   defaultHostnameUpload: 'upload.contentful.com',
 }

--- a/lib/adapters/REST/types.ts
+++ b/lib/adapters/REST/types.ts
@@ -1,6 +1,9 @@
 import { AxiosInstance } from 'contentful-sdk-core'
 import { MRActions, MROpts, MRReturn } from '../../common-types'
 
+/**
+ * @private
+ */
 export type RestEndpoint<
   ET extends keyof MRActions,
   Action extends keyof MRActions[ET],

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -215,6 +215,9 @@ export interface BasicCursorPaginationOptions {
 
 export type KeyValueMap = Record<string, any>
 
+/**
+ * @private
+ */
 type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Http', 'get', UA>): MRReturn<'Http', 'get'>
   (opts: MROpts<'Http', 'patch', UA>): MRReturn<'Http', 'patch'>
@@ -487,13 +490,23 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Webhook', 'delete', UA>): MRReturn<'Webhook', 'delete'>
 }
 
+/**
+ * @private
+ */
 export type MakeRequestWithUserAgent = MRInternal<true>
+
+/**
+ * @private
+ */
 export type MakeRequest = MRInternal<false>
 
 export interface Adapter {
   makeRequest: MakeRequestWithUserAgent
 }
 
+/**
+ * @private
+ */
 export type MRActions = {
   Http: {
     get: { params: { url: string; config?: AxiosRequestConfig }; return: any }
@@ -1204,6 +1217,9 @@ export type MRActions = {
   }
 }
 
+/**
+ * @private
+ */
 export type MROpts<
   ET extends keyof MRActions,
   Action extends keyof MRActions[ET],
@@ -1228,6 +1244,9 @@ export type MROpts<
       : { headers: MRActions[ET][Action]['headers'] }
     : {})
 
+/**
+ * @private
+ */
 export type MRReturn<
   ET extends keyof MRActions,
   Action extends keyof MRActions[ET]

--- a/lib/common-utils.ts
+++ b/lib/common-utils.ts
@@ -4,6 +4,9 @@ import { toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { Collection, CollectionProp, MakeRequest } from './common-types'
 
+/**
+ * @private
+ */
 export const wrapCollection = <R, T, Rest extends any[]>(
   fn: (makeRequest: MakeRequest, entity: T, ...rest: Rest) => R
 ) => (makeRequest: MakeRequest, data: CollectionProp<T>, ...rest: Rest): Collection<R, T> => {

--- a/lib/constants/editor-interface-defaults/controls-defaults.ts
+++ b/lib/constants/editor-interface-defaults/controls-defaults.ts
@@ -154,7 +154,9 @@ function getDefaultWidget(field: keyof typeof DEFAULTS_WIDGET, fieldId: string) 
   return defaultWidget
 }
 
-// Given our internal identifier returns a minimal API field object.
+/**
+ * Given our internal identifier returns a minimal API field object.
+ */
 export function toApiFieldType(internal: keyof typeof INTERNAL_TO_API) {
   return INTERNAL_TO_API[internal]
 }

--- a/lib/constants/editor-interface-defaults/types.ts
+++ b/lib/constants/editor-interface-defaults/types.ts
@@ -8,4 +8,7 @@ export enum WidgetNamespace {
 
 export const DEFAULT_EDITOR_ID = 'default-editor'
 
+/**
+ * @private
+ */
 export const in_ = <K extends string, O>(key: K, object: O): key is K & keyof O => key in object

--- a/lib/create-app-definition-api.ts
+++ b/lib/create-app-definition-api.ts
@@ -3,8 +3,14 @@ import entities from './entities'
 import { CreateAppBundleProps } from './entities/app-bundle'
 import { AppDefinitionProps, wrapAppDefinition } from './entities/app-definition'
 
+/**
+ * @private
+ */
 export type ContentfulAppDefinitionAPI = ReturnType<typeof createAppDefinitionApi>
 
+/**
+ * @private
+ */
 export default function createAppDefinitionApi(makeRequest: MakeRequest) {
   const { wrapAppBundle, wrapAppBundleCollection } = entities.appBundle
 

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -10,6 +10,9 @@ import { UserProps } from './entities/user'
 
 export type ClientAPI = ReturnType<typeof createClientApi>
 
+/**
+ * @private
+ */
 export default function createClientApi(makeRequest: MakeRequest) {
   const { wrapSpace, wrapSpaceCollection } = entities.space
   const { wrapUser } = entities.user
@@ -18,7 +21,6 @@ export default function createClientApi(makeRequest: MakeRequest) {
     wrapPersonalAccessTokenCollection,
   } = entities.personalAccessToken
   const { wrapOrganization, wrapOrganizationCollection } = entities.organization
-  const { wrapTeamCollection } = entities.team
   const { wrapUsageCollection } = entities.usage
 
   return {

--- a/lib/create-entry-api.ts
+++ b/lib/create-entry-api.ts
@@ -5,8 +5,14 @@ import { CreateTaskProps } from './entities/task'
 import * as checks from './plain/checks'
 import entities from './entities'
 
+/**
+ * @private
+ */
 export type ContentfulEntryApi = ReturnType<typeof createEntryApi>
 
+/**
+ * @private
+ */
 export default function createEntryApi(makeRequest: MakeRequest) {
   const { wrapEntry, wrapEntryCollection } = entities.entry
   const { wrapSnapshot, wrapSnapshotCollection } = entities.snapshot

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -40,12 +40,16 @@ import type { CreateExtensionProps } from './entities/extension'
 import type { CreateLocaleProps } from './entities/locale'
 import { TagVisibility, wrapTag, wrapTagCollection } from './entities/tag'
 
+/**
+ * @private
+ */
 export type ContentfulEnvironmentAPI = ReturnType<typeof createEnvironmentApi>
 
 /**
  * Creates API object with methods to access the Environment API
  * @param {ContentfulEnvironmentAPI} makeRequest - function to make requests via an adapter
  * @return {ContentfulSpaceAPI}
+ * @private
  */
 export default function createEnvironmentApi(makeRequest: MakeRequest) {
   const { wrapEnvironment } = entities.environment

--- a/lib/create-organization-api.ts
+++ b/lib/create-organization-api.ts
@@ -8,12 +8,16 @@ import { MakeRequest, QueryOptions } from './common-types'
 import { CreateAppDefinitionProps } from './entities/app-definition'
 import { OrganizationProp } from './entities/organization'
 
+/**
+ * @private
+ */
 export type ContentfulOrganizationAPI = ReturnType<typeof createOrganizationApi>
 
 /**
  * Creates API object with methods to access the Organization API
  * @param {MakeRequest} makeRequest - function to make requests via an adapter
  * @return {ContentfulOrganizationAPI}
+ * @private
  */
 export default function createOrganizationApi(makeRequest: MakeRequest) {
   const { wrapAppDefinition, wrapAppDefinitionCollection } = entities.appDefinition

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -16,12 +16,16 @@ import { CreateSpaceMembershipProps } from './entities/space-membership'
 import { CreateTeamSpaceMembershipProps } from './entities/team-space-membership'
 import { CreateWebhooksProps } from './entities/webhook'
 
+/**
+ * @private
+ */
 export type ContentfulSpaceAPI = ReturnType<typeof createSpaceApi>
 
 /**
  * Creates API object with methods to access the Space API
  * @param {MakeRequest} makeRequest - function to make requests via an adapter
  * @return {ContentfulSpaceAPI}
+ * @private
  */
 export default function createSpaceApi(makeRequest: MakeRequest) {
   const { wrapSpace } = entities.space

--- a/lib/entities/api-key.ts
+++ b/lib/entities/api-key.ts
@@ -58,6 +58,9 @@ export interface ApiKey extends ApiKeyProps, DefaultElements<ApiKeyProps> {
   update(): Promise<ApiKey>
 }
 
+/**
+ * @private
+ */
 function createApiKeyApi(makeRequest: MakeRequest) {
   const getParams = (data: ApiKeyProps) => ({
     spaceId: data.sys.space?.sys.id ?? '',

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -57,6 +57,9 @@ export interface AppBundle extends AppBundleProps, DefaultElements<AppBundleProp
   delete(): Promise<void>
 }
 
+/**
+ * @private
+ */
 function createAppBundleApi(makeRequest: MakeRequest) {
   const getParams = (data: AppBundleProps) => ({
     organizationId: data.sys.organization.sys.id,

--- a/lib/entities/app-installation.ts
+++ b/lib/entities/app-installation.ts
@@ -66,6 +66,9 @@ export interface AppInstallation
   delete(): Promise<void>
 }
 
+/**
+ * @private
+ */
 function createAppInstallationApi(makeRequest: MakeRequest) {
   const getParams = (data: AppInstallationProps) => ({
     spaceId: data.sys.space.sys.id,

--- a/lib/entities/app-upload.ts
+++ b/lib/entities/app-upload.ts
@@ -35,6 +35,9 @@ export interface AppUpload extends AppUploadProps, DefaultElements<AppUploadProp
   delete(): Promise<void>
 }
 
+/**
+ * @private
+ */
 function createAppUploadApi(makeRequest: MakeRequest) {
   const getParams = (data: AppUploadProps) => ({
     organizationId: data.sys.organization.sys.id,

--- a/lib/entities/asset.ts
+++ b/lib/entities/asset.ts
@@ -270,6 +270,9 @@ type AssetApi = {
 
 export interface Asset extends AssetProps, DefaultElements<AssetProps>, AssetApi {}
 
+/**
+ * @private
+ */
 function createAssetApi(makeRequest: MakeRequest): AssetApi {
   const getParams = (raw: AssetProps) => {
     return {

--- a/lib/entities/bulk-action.ts
+++ b/lib/entities/bulk-action.ts
@@ -96,6 +96,9 @@ export interface BulkActionApiMethods {
   waitProcessing(options?: AsyncActionProcessingOptions): Promise<BulkAction>
 }
 
+/**
+ * @private
+ */
 function createBulkActionApi(makeRequest: MakeRequest) {
   const getParams = (self: BulkAction) => {
     const bulkAction = self.toPlainObject()
@@ -130,6 +133,7 @@ export interface BulkAction<T extends BulkActionPayload = any>
     DefaultElements<BulkActionProps<T>> {}
 
 /**
+ * @private
  * @param makeRequest - function to make requests via an adapter
  * @param data - Raw BulkAction data
  * @return Wrapped BulkAction data

--- a/lib/entities/content-type.ts
+++ b/lib/entities/content-type.ts
@@ -208,6 +208,9 @@ export interface ContentType
     DefaultElements<ContentTypeProps>,
     ContentTypeApi {}
 
+/**
+ * @private
+ */
 function createContentTypeApi(makeRequest: MakeRequest): ContentTypeApi {
   const getParams = (self: ContentType) => {
     const contentType = self.toPlainObject() as ContentTypeProps

--- a/lib/entities/editor-interface.ts
+++ b/lib/entities/editor-interface.ts
@@ -167,6 +167,9 @@ export interface EditorInterface
   update(): Promise<EditorInterface>
 }
 
+/**
+ * @private
+ */
 function createEditorInterfaceApi(makeRequest: MakeRequest) {
   return {
     update: function () {

--- a/lib/entities/environment-alias.ts
+++ b/lib/entities/environment-alias.ts
@@ -71,6 +71,9 @@ export interface EnvironmentAlias
   delete(): Promise<void>
 }
 
+/**
+ * @private
+ */
 function createEnvironmentAliasApi(makeRequest: MakeRequest) {
   const getParams = (alias: EnvironmentAliasProps) => ({
     spaceId: alias.sys.space.sys.id,

--- a/lib/entities/extension.ts
+++ b/lib/entities/extension.ts
@@ -101,6 +101,9 @@ export interface Extension extends ExtensionProps, DefaultElements<ExtensionProp
   delete(): Promise<void>
 }
 
+/**
+ * @private
+ */
 function createExtensionApi(makeRequest: MakeRequest) {
   const getParams = (data: ExtensionProps) => ({
     spaceId: data.sys.space.sys.id,

--- a/lib/entities/locale.ts
+++ b/lib/entities/locale.ts
@@ -93,6 +93,9 @@ export interface Locale extends LocaleProps, DefaultElements<LocaleProps> {
   update(): Promise<Locale>
 }
 
+/**
+ * @private
+ */
 function createLocaleApi(makeRequest: MakeRequest) {
   const getParams = (locale: LocaleProps) => ({
     spaceId: locale.sys.space.sys.id,

--- a/lib/entities/organization-membership.ts
+++ b/lib/entities/organization-membership.ts
@@ -64,6 +64,9 @@ export interface OrganizationMembership
   delete(): Promise<void>
 }
 
+/**
+ * @private
+ */
 function createOrganizationMembershipApi(makeRequest: MakeRequest, organizationId: string) {
   const getParams = (data: OrganizationMembershipProps) => ({
     organizationMembershipId: data.sys.id,

--- a/lib/entities/preview-api-key.ts
+++ b/lib/entities/preview-api-key.ts
@@ -12,6 +12,9 @@ export type PreviewApiKeyProps = {
 
 export interface PreviewApiKey extends PreviewApiKeyProps, DefaultElements<PreviewApiKeyProps> {}
 
+/**
+ * @private
+ */
 function createPreviewApiKeyApi() {
   return {}
 }

--- a/lib/entities/release-action.ts
+++ b/lib/entities/release-action.ts
@@ -44,6 +44,9 @@ export interface ReleaseActionApiMethods {
   waitProcessing(options?: AsyncActionProcessingOptions): ReleaseActionProps
 }
 
+/**
+ * @private
+ */
 function createReleaseActionApi(makeRequest: MakeRequest) {
   const getParams = (self: ReleaseAction) => {
     const action = self.toPlainObject()
@@ -79,6 +82,7 @@ export interface ReleaseAction<T extends ReleaseActionTypes = any>
     DefaultElements<ReleaseActionProps<T>> {}
 
 /**
+ * @private
  * @param makeRequest - function to make requests via an adapter
  * @param data - Raw Release data
  * @return Wrapped Release data
@@ -95,4 +99,7 @@ export function wrapReleaseAction(
   return freezeSys(releaseActionWithApiMethods)
 }
 
+/**
+ * @private
+ */
 export const wrapReleaseActionCollection = wrapCollection(wrapReleaseAction)

--- a/lib/entities/release.ts
+++ b/lib/entities/release.ts
@@ -90,6 +90,9 @@ export interface ReleaseApiMethods {
   }): Promise<ReleaseActionProps<'validate'>>
 }
 
+/**
+ * @private
+ */
 function createReleaseApi(makeRequest: MakeRequest) {
   const getParams = (self: Release) => {
     const release = self.toPlainObject()
@@ -166,6 +169,7 @@ export interface Release extends ReleaseProps, ReleaseApiMethods, DefaultElement
 
 /**
  * Return a Release object enhanced with its own API helper functions.
+ * @private
  * @param makeRequest - function to make requests via an adapter
  * @param data - Raw Release data
  * @return Wrapped Release data
@@ -176,6 +180,9 @@ export function wrapRelease(makeRequest: MakeRequest, data: ReleaseProps): Relea
   return freezeSys(releaseWithApiMethods)
 }
 
+/**
+ * @private
+ */
 export const wrapReleaseCollection: (
   makeRequest: MakeRequest,
   data: CollectionProp<ReleaseProps>

--- a/lib/entities/role.ts
+++ b/lib/entities/role.ts
@@ -87,6 +87,9 @@ export interface Role extends RoleProps, DefaultElements<RoleProps> {
   update(): Promise<Role>
 }
 
+/**
+ * @private
+ */
 function createRoleApi(makeRequest: MakeRequest) {
   const getParams = (data: RoleProps) => ({
     spaceId: data.sys.space.sys.id,

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -232,6 +232,9 @@ export default function getInstanceMethods(makeRequest: MakeRequest): ScheduledA
   }
 }
 
+/**
+ * @private
+ */
 export function wrapScheduledAction(
   makeRequest: MakeRequest,
   data: ScheduledActionProps
@@ -244,4 +247,7 @@ export function wrapScheduledAction(
   return freezeSys(scheduledActionWithMethods)
 }
 
+/**
+ * @private
+ */
 export const wrapScheduledActionCollection = wrapCollection(wrapScheduledAction)

--- a/lib/entities/snapshot.ts
+++ b/lib/entities/snapshot.ts
@@ -14,6 +14,9 @@ export type SnapshotProps<T> = {
 
 export interface Snapshot<T> extends SnapshotProps<T>, DefaultElements<SnapshotProps<T>> {}
 
+/**
+ * @private
+ */
 function createSnapshotApi() {
   return {
     /* In case the snapshot object evolve later */

--- a/lib/entities/space-membership.ts
+++ b/lib/entities/space-membership.ts
@@ -58,6 +58,9 @@ export interface SpaceMembership
   update(): Promise<SpaceMembership>
 }
 
+/**
+ * @private
+ */
 function createSpaceMembershipApi(makeRequest: MakeRequest) {
   const getParams = (data: SpaceMembershipProps) => ({
     spaceId: data.sys.space.sys.id,

--- a/lib/entities/tag.ts
+++ b/lib/entities/tag.ts
@@ -46,6 +46,9 @@ type TagApi = {
 
 export interface Tag extends TagProps, DefaultElements<TagProps>, TagApi {}
 
+/**
+ * @private
+ */
 export default function createTagApi(makeRequest: MakeRequest): TagApi {
   const getParams = (tag: TagProps) => ({
     spaceId: tag.sys.space.sys.id,
@@ -82,10 +85,16 @@ export default function createTagApi(makeRequest: MakeRequest): TagApi {
   }
 }
 
+/**
+ * @private
+ */
 export function wrapTag(makeRequest: MakeRequest, data: TagProps): Tag {
   const tag = toPlainObject(copy(data))
   const tagWithMethods = enhanceWithMethods(tag, createTagApi(makeRequest))
   return freezeSys(tagWithMethods)
 }
 
+/**
+ * @private
+ */
 export const wrapTagCollection = wrapCollection(wrapTag)

--- a/lib/entities/task.ts
+++ b/lib/entities/task.ts
@@ -46,6 +46,9 @@ type TaskApi = {
 
 export interface Task extends TaskProps, DefaultElements<TaskProps>, TaskApi {}
 
+/**
+ * @private
+ */
 export default function createTaskApi(makeRequest: MakeRequest): TaskApi {
   const getParams = (task: TaskProps): GetTaskParams => ({
     spaceId: task.sys.space.sys.id,
@@ -83,10 +86,16 @@ export default function createTaskApi(makeRequest: MakeRequest): TaskApi {
   }
 }
 
+/**
+ * @private
+ */
 export function wrapTask(makeRequest: MakeRequest, data: TaskProps): Task {
   const task = toPlainObject(copy(data))
   const taskWithMethods = enhanceWithMethods(task, createTaskApi(makeRequest))
   return freezeSys(taskWithMethods)
 }
 
+/**
+ * @private
+ */
 export const wrapTaskCollection = wrapCollection(wrapTask)

--- a/lib/entities/team-membership.ts
+++ b/lib/entities/team-membership.ts
@@ -70,6 +70,9 @@ export interface TeamMembership extends TeamMembershipProps, DefaultElements<Tea
   update(): Promise<TeamMembership>
 }
 
+/**
+ * @private
+ */
 function createTeamMembershipApi(makeRequest: MakeRequest) {
   const getParams = (data: TeamMembershipProps) => ({
     teamMembershipId: data.sys.id,
@@ -98,6 +101,7 @@ function createTeamMembershipApi(makeRequest: MakeRequest) {
     },
   }
 }
+
 /**
  * @private
  * @param makeRequest - function to make requests via an adapter

--- a/lib/entities/team-space-membership.ts
+++ b/lib/entities/team-space-membership.ts
@@ -86,6 +86,9 @@ export interface TeamSpaceMembership
   update(): Promise<TeamSpaceMembership>
 }
 
+/**
+ * @private
+ */
 function createTeamSpaceMembershipApi(makeRequest: MakeRequest) {
   const getParams = (data: TeamSpaceMembershipProps) => ({
     teamSpaceMembershipId: data.sys.id,

--- a/lib/entities/upload.ts
+++ b/lib/entities/upload.ts
@@ -31,6 +31,9 @@ export interface Upload extends UploadProps, DefaultElements<UploadProps> {
   delete(): Promise<void>
 }
 
+/**
+ * @private
+ */
 function createUploadApi(makeRequest: MakeRequest) {
   return {
     delete: async function del() {

--- a/lib/entities/webhook.ts
+++ b/lib/entities/webhook.ts
@@ -284,6 +284,9 @@ export interface WebHooks extends WebhookProps, DefaultElements<WebhookProps> {
   getHealth(): Promise<WebhookHealthProps>
 }
 
+/**
+ * @private
+ */
 function createWebhookApi(makeRequest: MakeRequest) {
   const getParams = (data: WebhookProps) => ({
     spaceId: data.sys.space.sys.id,

--- a/lib/methods/utils.ts
+++ b/lib/methods/utils.ts
@@ -1,4 +1,7 @@
-/** Helper function that resolves a Promise after the specified duration (in milliseconds) */
+/**
+ * Helper function that resolves a Promise after the specified duration (in milliseconds)
+ * @private
+ */
 export function sleep(durationMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, durationMs))
 }

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -5,6 +5,9 @@ import { DefaultParams, wrap } from './wrappers/wrap'
 
 export type { DefaultParams } from './wrappers/wrap'
 
+/**
+ * @private
+ */
 export const createPlainClient = (
   makeRequest: MakeRequest,
   defaults: DefaultParams | undefined

--- a/lib/plain/wrappers/wrap.ts
+++ b/lib/plain/wrappers/wrap.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { MakeRequest, MRActions, MRReturn } from '../../common-types'
 
 export type DefaultParams = {
@@ -8,16 +6,25 @@ export type DefaultParams = {
   organizationId?: string
 }
 
+/**
+ * @private
+ */
 export type OptionalDefaults<T> = Omit<T, keyof DefaultParams> &
   ('organizationId' extends keyof T ? { organizationId?: string } : {}) &
   ('spaceId' extends keyof T ? { spaceId?: string } : {}) &
   ('environmentId' extends keyof T ? { environmentId?: string } : {})
 
+/**
+ * @private
+ */
 export type WrapParams = {
   makeRequest: MakeRequest
   defaults?: DefaultParams
 }
 
+/**
+ * @private
+ */
 export type WrapFn<
   ET extends keyof MRActions,
   Action extends keyof MRActions[ET],
@@ -39,6 +46,9 @@ export type WrapFn<
   ? (params: Params, payload: Payload) => Return
   : (params: Params, payload: Payload, headers: Headers) => Return
 
+/**
+ * @private
+ */
 export const wrap = <ET extends keyof MRActions, Action extends keyof MRActions[ET]>(
   { makeRequest, defaults }: WrapParams,
   entityType: ET,

--- a/lib/upload-http-client.ts
+++ b/lib/upload-http-client.ts
@@ -1,5 +1,8 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 
+/**
+ * @private
+ */
 export function getUploadHttpClient(http: AxiosInstance): AxiosInstance {
   const { hostUpload, defaultHostnameUpload } = http.httpClientParams as Record<string, any>
   const uploadHttp = http.cloneWithNewParams({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "out": "./out",
     "readme": "README.md",
     "name": "contentful-management.js",
+    "exclude": ["./lib/adapters/REST/endpoints/*"],
     "includeVersion": true,
     "hideGenerator": true,
     "excludePrivate": true,


### PR DESCRIPTION
Due to a major refactoring in version 7.13.0 the size of the type docs was significantly increased.

This PR marks many types/constants/functions as `@private` to exclude them from the generated documentation.

This removed the size of the `globals.html` by 20k lines.