### PR TITLE
fix: add missing prop to interface

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -158,6 +158,7 @@ export interface EntityMetaSysProps extends MetaSysProps {
   publishedAt?: string
   firstPublishedAt?: string
   publishedCounter?: number
+  locale?: string
 }
 
 export interface MetaLinkProps {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

`EntityMetaSysProps` interface is missing the `locale` property.

## Description

It looks like the response object of the `getEntries` endpoint has been updated to include the `locale` field, but types have not.

## Motivation and Context

In a typescript script where we are accessing Contentful management APIs to get entries (via `contentfulClient.getEntries`), the response object for each entry, contains `locale` prop, which is not reflected in `EntityMetaSysProps` found in `common-types.ts`. As a result, we need to do some sort of type merging to keep the tslint happy.

I am putting this PR together to add the missing prop to the interface
## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
