### PR TITLE
feat(requests): introduce throttleing

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,12 @@ initialized with provided configuration.
 > The Adapter will take precedence over the other options. Therefore, ensure you're providing the Adapter all the
 > information it needs to issue the request (e.g., host or auth headers)
 
+#### throttle (default: `0`)
+Maximum number of requests per second.
+- `1`-`30` (fixed number of limit), 
+- `'auto'` (calculated limit based on your plan), 
+- `'0%'` - `'100%'` (calculated % limit based on your plan)
+
 ### Reference documentation
 
 The [Contentful's JS library reference](https://contentful.github.io/contentful-management.js) documents what objects and methods are exposed by this library, what arguments they expect and what kind of data is returned.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7708,12 +7708,13 @@
       }
     },
     "contentful-sdk-core": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.9.1.tgz",
-      "integrity": "sha512-5AV21J1evUa1Wi+ehSWUJVpZ/NUy4mQPEk73ORxbv/FYcPNtOXBo0CPmXZZHQ80SADhYXgiiLLUGH2+UIGwYMQ==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.10.1.tgz",
+      "integrity": "sha512-q1dh5AHL3FoBc3CZThQMtnaxgFbs9BrJW8wDysdp/IT/Q2edgUQASh2fvj02T6cCh3ftMspRRe/HMfZDF9FfIQ==",
       "requires": {
         "fast-copy": "^2.1.0",
         "lodash": "^4.17.21",
+        "p-throttle": "^4.1.1",
         "qs": "^6.9.4"
       }
     },
@@ -17155,6 +17156,11 @@
         "@types/retry": "^0.12.0",
         "retry": "^0.13.1"
       }
+    },
+    "p-throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-4.1.1.tgz",
+      "integrity": "sha512-TuU8Ato+pRTPJoDzYD4s7ocJYcNSEZRvlxoq3hcPI2kZDZ49IQ1Wkj7/gDJc3X7XiEAAvRGtDzdXJI0tC3IL1g=="
     },
     "p-try": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@types/json-patch": "0.0.30",
     "axios": "^0.21.4",
-    "contentful-sdk-core": "^6.9.0",
+    "contentful-sdk-core": "^6.10.1",
     "fast-copy": "^2.1.0",
     "lodash.isplainobject": "^4.0.6",
     "type-fest": "^0.21.3"


### PR DESCRIPTION
## Summary

Introduce an [optional parameter](https://github.com/contentful/contentful-sdk-core/blob/master/src/types.ts#L108) to limit the number of requests sent per second to not exceed [rate limits](https://www.contentful.com/developers/docs/technical-limits/).

With that, we're not only relying on retries based on `429` responses but can also control the max count of requests we send per second.

## Description

See [description](https://github.com/contentful/contentful-management.js/compare/feat/request-throtteling?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R339-R344) of parameter


## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation