### PR TITLE
fix: [EXT-3161] allow 'in' validation to contain numbers

### DIFF
--- a/lib/entities/content-type-fields.ts
+++ b/lib/entities/content-type-fields.ts
@@ -17,7 +17,7 @@ interface RegExp {
 
 export interface ContentTypeFieldValidation {
   linkContentType?: string[]
-  in?: string[]
+  in?: (string | number)[]
   linkMimetypeGroup?: string[]
   enabledNodeTypes?: string[]
   enabledMarks?: string[]


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary
In can also contain numbers when used for a number field 
![image](https://user-images.githubusercontent.com/20307225/136163012-3d14210d-06d9-4d56-8290-3635ac9a53f3.png)


## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
