### PR TITLE
fix(rest-adapter): headers

### DIFF
--- a/lib/adapters/REST/rest-adapter.ts
+++ b/lib/adapters/REST/rest-adapter.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import axios, { AxiosRequestConfig } from 'axios'
 import { AxiosInstance, createHttpClient, CreateHttpClientParams } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { OpPatch } from 'json-patch'
@@ -80,10 +80,21 @@ export class RestAdapter implements Adapter {
       'X-Contentful-User-Agent': userAgent,
     }
 
-    return await endpoint(this.http, params, payload, {
+    const mergedHeaders = {
       ...requiredHeaders,
+      ...params?.config?.headers,
       ...this.params.headers,
       ...headers,
-    })
+    }
+
+    const mergedParams = copy(params) || {}
+
+    if (!mergedParams.config) {
+      mergedParams.config = {}
+    }
+
+    mergedParams.config.headers = mergedHeaders
+
+    return await endpoint(this.http, mergedParams, payload, mergedHeaders)
   }
 }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1309,7 +1309,7 @@ export interface MakeRequestPayload {}
 export interface MakeRequestOptions {
   entityType: keyof MRActions
   action: string
-  params?: Record<string, unknown>
+  params?: Record<string, unknown> & { config?: AxiosRequestConfig }
   payload?: Record<string, unknown> | OpPatch[] | MakeRequestPayload
   headers?: Record<string, unknown>
   userAgent: string

--- a/test/unit/adapters/REST/endpoints/http-test.js
+++ b/test/unit/adapters/REST/endpoints/http-test.js
@@ -6,6 +6,19 @@ function setup(promise, params = {}) {
   return setupRestAdapter(promise, params)
 }
 
+const DEFAULT_HEADERS = {
+  'Content-Type': 'application/vnd.contentful.management.v1+json',
+  'X-Contentful-User-Agent': undefined,
+}
+
+const requestWithDefaults = (request) => {
+  return {
+    baseURL: 'https://api.contentful.com',
+    ...request,
+    headers: { ...DEFAULT_HEADERS, ...request.headers },
+  }
+}
+
 describe('Rest Http', () => {
   const URL = '/some/random/endpoint'
   const CONFIG = {
@@ -21,11 +34,14 @@ describe('Rest Http', () => {
     await adapter.makeRequest({
       entityType: 'Http',
       action: 'get',
-      params: { url: URL, config: CONFIG },
+      params: {
+        url: URL,
+        config: CONFIG,
+      },
     })
 
     expect(httpMock.get.args[0][0]).to.equal(URL)
-    expect(httpMock.get.args[0][1]).to.contain(CONFIG)
+    expect(httpMock.get.args[0][1]).to.eql(requestWithDefaults(CONFIG))
   })
 
   test('post', async () => {
@@ -34,13 +50,16 @@ describe('Rest Http', () => {
     await adapter.makeRequest({
       entityType: 'Http',
       action: 'post',
-      params: { url: URL, config: CONFIG },
+      params: {
+        url: URL,
+        config: CONFIG,
+      },
       payload: PAYLOAD,
     })
 
     expect(httpMock.post.args[0][0]).to.equal(URL)
     expect(httpMock.post.args[0][1]).to.equal(PAYLOAD)
-    expect(httpMock.post.args[0][2]).to.contain(CONFIG)
+    expect(httpMock.post.args[0][2]).to.eql(requestWithDefaults(CONFIG))
   })
 
   test('put', async () => {
@@ -49,13 +68,16 @@ describe('Rest Http', () => {
     await adapter.makeRequest({
       entityType: 'Http',
       action: 'put',
-      params: { url: URL, config: CONFIG },
+      params: {
+        url: URL,
+        config: CONFIG,
+      },
       payload: PAYLOAD,
     })
 
     expect(httpMock.put.args[0][0]).to.equal(URL)
     expect(httpMock.put.args[0][1]).to.equal(PAYLOAD)
-    expect(httpMock.put.args[0][2]).to.contain(CONFIG)
+    expect(httpMock.put.args[0][2]).to.eql(requestWithDefaults(CONFIG))
   })
 
   test('delete', async () => {
@@ -64,24 +86,33 @@ describe('Rest Http', () => {
     await adapter.makeRequest({
       entityType: 'Http',
       action: 'delete',
-      params: { url: URL, config: CONFIG },
+      params: {
+        url: URL,
+        config: CONFIG,
+      },
     })
 
     expect(httpMock.delete.args[0][0]).to.equal(URL)
-    expect(httpMock.delete.args[0][1]).to.contain(CONFIG)
+    expect(httpMock.delete.args[0][1]).to.eql(requestWithDefaults(CONFIG))
   })
   test('request', async () => {
     const { httpMock, adapterMock: adapter } = setup()
 
-    const requestConfig = { ...CONFIG, method: 'put' }
+    const requestConfig = {
+      ...CONFIG,
+      method: 'put',
+    }
     await adapter.makeRequest({
       entityType: 'Http',
       action: 'request',
-      params: { url: URL, config: requestConfig },
+      params: {
+        url: URL,
+        config: requestConfig,
+      },
       payload: PAYLOAD,
     })
 
     expect(httpMock.args[0][0]).to.equal(URL)
-    expect(httpMock.args[0][1]).to.contain(requestConfig)
+    expect(httpMock.args[0][1]).to.eql(requestWithDefaults(requestConfig))
   })
 })


### PR DESCRIPTION
The change to single axios instance (#973) dropped all headers, except those defined in `params.config.headers` .
This change adds the calculated set of headers to that field.

<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
