### PR TITLE
fix: mark get many releases to return cursor based collection [SPA-505]

### DIFF
--- a/lib/common-utils.ts
+++ b/lib/common-utils.ts
@@ -2,7 +2,13 @@
 
 import { toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import { Collection, CollectionProp, MakeRequest } from './common-types'
+import {
+  Collection,
+  CollectionProp,
+  CursorPaginatedCollection,
+  CursorPaginatedCollectionProp,
+  MakeRequest,
+} from './common-types'
 
 /**
  * @private
@@ -10,6 +16,20 @@ import { Collection, CollectionProp, MakeRequest } from './common-types'
 export const wrapCollection =
   <R, T, Rest extends any[]>(fn: (makeRequest: MakeRequest, entity: T, ...rest: Rest) => R) =>
   (makeRequest: MakeRequest, data: CollectionProp<T>, ...rest: Rest): Collection<R, T> => {
+    const collectionData = toPlainObject(copy(data))
+    // @ts-expect-error
+    collectionData.items = collectionData.items.map((entity) => fn(makeRequest, entity, ...rest))
+    // @ts-expect-error
+    return collectionData
+  }
+
+export const wrapCursorPaginatedCollection =
+  <R, T, Rest extends any[]>(fn: (makeRequest: MakeRequest, entity: T, ...rest: Rest) => R) =>
+  (
+    makeRequest: MakeRequest,
+    data: CursorPaginatedCollectionProp<T>,
+    ...rest: Rest
+  ): CursorPaginatedCollection<R, T> => {
     const collectionData = toPlainObject(copy(data))
     // @ts-expect-error
     collectionData.items = collectionData.items.map((entity) => fn(makeRequest, entity, ...rest))

--- a/lib/entities/release.ts
+++ b/lib/entities/release.ts
@@ -3,15 +3,15 @@ import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import {
   BaseCollection,
-  Collection,
-  CollectionProp,
+  CursorPaginatedCollection,
+  CursorPaginatedCollectionProp,
   DefaultElements,
   ISO8601Timestamp,
   Link,
   MakeRequest,
   MakeRequestPayload,
 } from '../common-types'
-import { wrapCollection } from '../common-utils'
+import { wrapCursorPaginatedCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 import { AsyncActionProcessingOptions } from '../methods/action'
 import { ReleaseActionProps, wrapReleaseAction } from './release-action'
@@ -185,5 +185,5 @@ export function wrapRelease(makeRequest: MakeRequest, data: ReleaseProps): Relea
  */
 export const wrapReleaseCollection: (
   makeRequest: MakeRequest,
-  data: CollectionProp<ReleaseProps>
-) => Collection<Release, ReleaseProps> & { pages?: { next: string } } = wrapCollection(wrapRelease)
+  data: CursorPaginatedCollectionProp<ReleaseProps>
+) => CursorPaginatedCollection<Release, ReleaseProps> = wrapCursorPaginatedCollection(wrapRelease)

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -475,7 +475,7 @@ export type PlainClientAPI = {
     get(params: OptionalDefaults<GetReleaseParams>): Promise<ReleaseProps>
     query(
       params: OptionalDefaults<GetSpaceEnvironmentParams> & { query?: ReleaseQueryOptions }
-    ): Promise<CollectionProp<ReleaseProps>>
+    ): Promise<CursorPaginatedCollectionProp<ReleaseProps>>
     create(
       params: OptionalDefaults<GetSpaceEnvironmentParams>,
       data: ReleasePayload


### PR DESCRIPTION
Changes the return type of releases `getReleases` and `plainClient.release.query` calls to return `CursorPaginatedCollectionProp` instead of `CollectionProp` (wrapped in `Promise` of course)

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [x] Added an integration test for the new method
- [ ] The new method is added to the documentation
