### PR TITLE
fix: dont enforce an array with exact one item for workflow validation links

### DIFF
--- a/lib/entities/workflow-definition.ts
+++ b/lib/entities/workflow-definition.ts
@@ -24,11 +24,9 @@ export type WorkflowDefinitionSysProps = Pick<
 
 type ValidationLink = {
   type: 'Link'
-  validations: [
-    {
-      linkContentType: string[]
-    }
-  ]
+  validations: Array<{
+    linkContentType: string[]
+  }>
   linkType: 'Entry'
 }
 


### PR DESCRIPTION
## Summary

TLDR; I accidentally type validationLinks as an array with exactly one item. This would break right away because we probably will start with no validation links being defined.