### PR TITLE
feat: [EXT-3396] add active property to webhooks

### DIFF
--- a/lib/entities/webhook.ts
+++ b/lib/entities/webhook.ts
@@ -182,6 +182,11 @@ export type WebhookProps = {
    * Transformation to apply
    */
   transformation?: WebhookTransformation
+
+  /**
+   * Whether the Webhook is active. If set to false, no calls will be made
+   */
+  active?: boolean
 }
 
 export interface WebHooks extends WebhookProps, DefaultElements<WebhookProps> {

--- a/lib/entities/webhook.ts
+++ b/lib/entities/webhook.ts
@@ -73,11 +73,11 @@ export type WebhookTransformation = {
   body?: JsonValue
 }
 
-export type CreateWebhooksProps = SetOptional<Except<WebhookProps, 'sys'>, 'headers'>
+export type CreateWebhooksProps = SetOptional<Except<WebhookProps, 'sys'>, 'headers' | 'active'>
 
 export type UpdateWebhookProps = SetOptional<
   Except<WebhookProps, 'sys'>,
-  'headers' | 'name' | 'topics' | 'url'
+  'headers' | 'name' | 'topics' | 'url' | 'active'
 >
 
 export type WebhookCallDetailsProps = {
@@ -186,7 +186,7 @@ export type WebhookProps = {
   /**
    * Whether the Webhook is active. If set to false, no calls will be made
    */
-  active?: boolean
+  active: boolean
 }
 
 export interface WebHooks extends WebhookProps, DefaultElements<WebhookProps> {

--- a/test/integration/webhook-integration.js
+++ b/test/integration/webhook-integration.js
@@ -63,4 +63,23 @@ describe('Webhook Api', function () {
         })
       })
   })
+
+  test('Create disabled webhook', async () => {
+    return space
+      .createWebhook({
+        name: 'testname',
+        url: 'http://localhost:8080',
+        topics: ['Entry.publish'],
+        active: false,
+      })
+      .then((webhook) => {
+        expect(webhook.active).equals(false, 'active')
+        expect(webhook.url, 'url').ok
+        webhook.active = true
+        return webhook.update().then((updatedWebhook) => {
+          expect(updatedWebhook.active).equals(true, 'active')
+          return updatedWebhook.delete()
+        })
+      })
+  })
 })


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary
Add active property to webhooks. It will always be defined in the API response, but is optional when creating and updating webhooks. It not present, it defaults to true.
<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
