### PR TITLE
feat: organizations query param support [SPA-50]

### DIFF
--- a/lib/adapters/REST/endpoints/organization.ts
+++ b/lib/adapters/REST/endpoints/organization.ts
@@ -1,18 +1,23 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import { CollectionProp, GetOrganizationParams } from '../../../common-types'
+import { CollectionProp, GetOrganizationParams, PaginationQueryParams } from '../../../common-types'
 import { OrganizationProp } from '../../../entities/organization'
 import { RestEndpoint } from '../types'
 import * as raw from './raw'
 
-export const getMany: RestEndpoint<'Organization', 'getMany'> = (http: AxiosInstance) => {
-  return raw.get<CollectionProp<OrganizationProp>>(http, `/organizations`)
+export const getMany: RestEndpoint<'Organization', 'getMany'> = (
+  http: AxiosInstance,
+  params?: PaginationQueryParams
+) => {
+  return raw.get<CollectionProp<OrganizationProp>>(http, `/organizations`, {
+    params: params?.query,
+  })
 }
 
 export const get: RestEndpoint<'Organization', 'get'> = (
   http: AxiosInstance,
   params: GetOrganizationParams
 ) => {
-  return getMany(http).then((data) => {
+  return getMany(http, { query: { limit: 100 } }).then((data) => {
     const org = data.items.find((org) => org.sys.id === params.organizationId)
     if (!org) {
       const error = new Error(

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -963,7 +963,7 @@ export type MRActions = {
     }
   }
   Organization: {
-    getMany: { return: CollectionProp<OrganizationProp> }
+    getMany: { params: PaginationQueryParams; return: CollectionProp<OrganizationProp> }
     get: { params: GetOrganizationParams; return: OrganizationProp }
   }
   OrganizationInvitation: {

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -1,6 +1,12 @@
 import { AxiosRequestConfig } from 'axios'
 import { createRequestConfig } from 'contentful-sdk-core'
-import { Collection, MakeRequest, QueryOptions, QueryParams } from './common-types'
+import {
+  Collection,
+  MakeRequest,
+  PaginationQueryParams,
+  QueryOptions,
+  QueryParams,
+} from './common-types'
 import entities from './entities'
 import { Organization, OrganizationProp } from './entities/organization'
 import { CreatePersonalAccessTokenProps } from './entities/personal-access-token'
@@ -141,12 +147,13 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    getOrganizations: function getOrganizations(): Promise<
-      Collection<Organization, OrganizationProp>
-    > {
+    getOrganizations: function getOrganizations(
+      query: PaginationQueryParams['query'] = {}
+    ): Promise<Collection<Organization, OrganizationProp>> {
       return makeRequest({
         entityType: 'Organization',
         action: 'getMany',
+        params: { query: createRequestConfig({ query }).params },
       }).then((data) => wrapOrganizationCollection(makeRequest, data))
     },
 

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -691,7 +691,9 @@ export type PlainClientAPI = {
     delete(params: OptionalDefaults<GetTagParams>, version: number): Promise<any>
   }
   organization: {
-    getAll(): Promise<CollectionProp<OrganizationProp>>
+    getAll(
+      params?: OptionalDefaults<PaginationQueryParams>
+    ): Promise<CollectionProp<OrganizationProp>>
     get(params: OptionalDefaults<GetOrganizationParams>): Promise<OrganizationProp>
   }
   organizationInvitation: {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -11,6 +11,11 @@ if (process.env.API_INTEGRATION_TESTS) {
 
 const env = process.env !== undefined ? process.env : window.__env__
 
+// Please do not replace it with testUtils.initClient(), becuase test-utils repo has contentful-management
+// as dependency and will make it impossible to test new changes to client's api.
+// Eg: getAll() fn in prod doesn't have any args. I change it in my PR to getAll({ query })
+// if I used testUtils.initClient(), it would have the version of cma repo that would still have getAll() without args
+// making it impossible for me to cover my changes with tests
 export const initClient = () => {
   const accessToken = env.CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN
   return createClient({

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -11,7 +11,13 @@ if (process.env.API_INTEGRATION_TESTS) {
 
 const env = process.env !== undefined ? process.env : window.__env__
 
-export const initClient = () => testUtils.initClient()
+export const initClient = () => {
+  const accessToken = env.CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN
+  return createClient({
+    accessToken,
+    ...params,
+  })
+}
 
 /**
  *

--- a/test/integration/organization-integration.ts
+++ b/test/integration/organization-integration.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from 'chai'
 import { describe, test } from 'mocha'
 import { TestDefaults } from '../defaults'
@@ -8,18 +7,30 @@ describe('Organization API', async function () {
   describe('Contentful client', () => {
     const client = initClient()
 
-    test('getOrganizations', async () => {
-      const collection = await client.getOrganizations()
-      const collectionWithLimit = await client.getOrganizations({ limit: 100 })
-      expect(collection.limit).to.equal(25)
-      expect(collectionWithLimit.limit).to.equal(100)
+    describe('getOrganizations', () => {
+      test('should return all organizations', async () => {
+        const collection = await client.getOrganizations()
+        const collectionWithLimit = await client.getOrganizations({ limit: 100 })
+        expect(collection.limit).to.equal(25)
+        expect(collectionWithLimit.limit).to.equal(100)
+      })
     })
 
-    test('getOrganization', async () => {
-      const testOrg = await getTestOrganization()
-      const fetchedOrg = await client.getOrganization(testOrg.sys.id)
+    describe('getOrganization', () => {
+      test('should return the organization by id', async () => {
+        const testOrg = await getTestOrganization()
+        const fetchedOrg = await client.getOrganization(testOrg.sys.id)
 
-      expect(testOrg.toPlainObject()).to.deep.equal(fetchedOrg.toPlainObject())
+        expect(testOrg.toPlainObject()).to.deep.equal(fetchedOrg.toPlainObject())
+      })
+
+      test('should return undefined if the organization wasn\t found', async () => {
+        try {
+          await client.getOrganization('nonExistingId')
+        } catch (e) {
+          expect(e.message).to.include('No organization was found with the ID nonExistingId')
+        }
+      })
     })
   })
 
@@ -31,18 +42,30 @@ describe('Organization API', async function () {
 
     const plainClient = initPlainClient(defaultParams)
 
-    test('getAll', async () => {
-      const orgsCollection = await plainClient.organization.getAll()
-      const orgsLimitCollection = await plainClient.organization.getAll({ query: { limit: 100 } })
+    describe('getAll', () => {
+      test('should return all organizations', async () => {
+        const orgsCollection = await plainClient.organization.getAll()
+        const orgsLimitCollection = await plainClient.organization.getAll({ query: { limit: 100 } })
 
-      expect(orgsCollection.limit).to.equal(25)
-      expect(orgsLimitCollection.limit).to.equal(100)
+        expect(orgsCollection.limit).to.equal(25)
+        expect(orgsLimitCollection.limit).to.equal(100)
+      })
     })
 
-    test('get', async () => {
-      const testOrg = await getTestOrganization()
-      const fetchedOrg = await plainClient.organization.get({ organizationId: testOrg.sys.id })
-      expect(testOrg.toPlainObject()).to.deep.equal(fetchedOrg)
+    describe('get', () => {
+      test('should get the organization by id', async () => {
+        const testOrg = await getTestOrganization()
+        const fetchedOrg = await plainClient.organization.get({ organizationId: testOrg.sys.id })
+        expect(testOrg.toPlainObject()).to.deep.equal(fetchedOrg)
+      })
+
+      test("should throw if organization wasn't found", async () => {
+        try {
+          await plainClient.organization.get({ organizationId: 'nonExistingId' })
+        } catch (e) {
+          expect(e.message).to.include('No organization was found with the ID nonExistingId')
+        }
+      })
     })
   })
 })

--- a/test/integration/organization-integration.ts
+++ b/test/integration/organization-integration.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from 'chai'
+import { describe, test } from 'mocha'
+import { TestDefaults } from '../defaults'
+import { initPlainClient, initClient } from '../helpers'
+
+describe('Organization API', async function () {
+  describe('Contentful client', () => {
+    test('getOrganizations', async () => {
+      const client = initClient()
+      const collection = await client.getOrganizations()
+      const collectionWithLimit = await client.getOrganizations({ limit: 100 })
+      expect(collection.limit).to.equal(25)
+      expect(collectionWithLimit.limit).to.equal(100)
+    })
+  })
+
+  describe('PlainClient', () => {
+    const defaultParams = {
+      environmentId: TestDefaults.environmentId,
+      spaceId: TestDefaults.spaceId,
+    }
+
+    test('getAll', async () => {
+      const plainClient = initPlainClient(defaultParams)
+      const orgsCollection = await plainClient.organization.getAll()
+      const orgsLimitCollection = await plainClient.organization.getAll({ query: { limit: 100 } })
+
+      expect(orgsCollection.limit).to.equal(25)
+      expect(orgsLimitCollection.limit).to.equal(100)
+    })
+  })
+})

--- a/test/integration/organization-integration.ts
+++ b/test/integration/organization-integration.ts
@@ -2,16 +2,24 @@
 import { expect } from 'chai'
 import { describe, test } from 'mocha'
 import { TestDefaults } from '../defaults'
-import { initPlainClient, initClient } from '../helpers'
+import { initPlainClient, initClient, getTestOrganization } from '../helpers'
 
 describe('Organization API', async function () {
   describe('Contentful client', () => {
+    const client = initClient()
+
     test('getOrganizations', async () => {
-      const client = initClient()
       const collection = await client.getOrganizations()
       const collectionWithLimit = await client.getOrganizations({ limit: 100 })
       expect(collection.limit).to.equal(25)
       expect(collectionWithLimit.limit).to.equal(100)
+    })
+
+    test('getOrganization', async () => {
+      const testOrg = await getTestOrganization()
+      const fetchedOrg = await client.getOrganization(testOrg.sys.id)
+
+      expect(testOrg.toPlainObject()).to.deep.equal(fetchedOrg.toPlainObject())
     })
   })
 
@@ -21,13 +29,20 @@ describe('Organization API', async function () {
       spaceId: TestDefaults.spaceId,
     }
 
+    const plainClient = initPlainClient(defaultParams)
+
     test('getAll', async () => {
-      const plainClient = initPlainClient(defaultParams)
       const orgsCollection = await plainClient.organization.getAll()
       const orgsLimitCollection = await plainClient.organization.getAll({ query: { limit: 100 } })
 
       expect(orgsCollection.limit).to.equal(25)
       expect(orgsLimitCollection.limit).to.equal(100)
+    })
+
+    test('get', async () => {
+      const testOrg = await getTestOrganization()
+      const fetchedOrg = await plainClient.organization.get({ organizationId: testOrg.sys.id })
+      expect(testOrg.toPlainObject()).to.deep.equal(fetchedOrg)
     })
   })
 })


### PR DESCRIPTION
## Summary

Adds ability to pass pagination query parameters to
`plainClient.organization.getAll()` and `client.getOrganizations()`

## Description

Before it would only fetch up to 25 organizations. With the changes in this PR, there will be ability to fetch more organizations.

## Motivation and Context

Users who had more than 25 organizations were not able to see more than 25 in response

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
