### PR TITLE
fix(workflows): use correct API endpoint for workflows

### DIFF
--- a/lib/adapters/REST/endpoints/workflow.ts
+++ b/lib/adapters/REST/endpoints/workflow.ts
@@ -16,7 +16,7 @@ import { RestEndpoint } from '../types'
 import * as raw from './raw'
 
 const getBaseUrl = (params: GetSpaceEnvironmentParams) =>
-  `/spaces/${params.spaceId}/environments/${params.environmentId}/workflow`
+  `/spaces/${params.spaceId}/environments/${params.environmentId}/workflows`
 
 const getWorkflowUrl = (params: GetWorkflowParams) => `${getBaseUrl(params)}/${params.workflowId}`
 


### PR DESCRIPTION
In a previous PR, we invented the workflows methods to the CMA but used the singular form which ended up in calling a not existing endpoint in the frontend.