### PR TITLE
fix(readme): Change ES6 import suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,24 +102,12 @@ You can use the es6 import with the library as follow
 
 ```js
 // import createClient directly
-import { createClient } from 'contentful-management'
-const client = createClient({
-  // This is the access token for this space. Normally you get the token in the Contentful web app
-  accessToken: 'YOUR_ACCESS_TOKEN',
-})
-//....
-```
-
-OR
-
-```js
-// import everything from contentful
-import * as contentful from 'contentful-management'
+import contentful from 'contentful-management'
 const client = contentful.createClient({
   // This is the access token for this space. Normally you get the token in the Contentful web app
   accessToken: 'YOUR_ACCESS_TOKEN',
 })
-// ....
+//....
 ```
 
 ## Your first request
@@ -327,7 +315,7 @@ Interceptor called on every response. Takes Axios response object as an arg. Def
 
 #### apiAdapter (default: `new RestAdapter(configuration)`)
 
-An [`Adapter`](https://github.com/contentful/contentful-management.js/blob/2350b47053459694b21b19c71025632fe57815cc/lib/common-types.ts#L493-L495) 
+An [`Adapter`](https://github.com/contentful/contentful-management.js/blob/2350b47053459694b21b19c71025632fe57815cc/lib/common-types.ts#L493-L495)
 that can be utilized to issue requests. It defaults to a [`RestAdapter`](https://github.com/contentful/contentful-management.js/blob/b50534c629a8ddc81637170a07bc63477d136cec/lib/adapters/REST/rest-adapter.ts)
 initialized with provided configuration.
 
@@ -337,9 +325,11 @@ initialized with provided configuration.
 > information it needs to issue the request (e.g., host or auth headers)
 
 #### throttle (default: `0`)
+
 Maximum number of requests per second.
-- `1`-`30` (fixed number of limit), 
-- `'auto'` (calculated limit based on your plan), 
+
+- `1`-`30` (fixed number of limit),
+- `'auto'` (calculated limit based on your plan),
 - `'0%'` - `'100%'` (calculated % limit based on your plan)
 
 ### Reference documentation


### PR DESCRIPTION
## Summary

Change the ES6 import part of the README to a working suggestion

## Motivation and Context

Both previous variants of the ES6 import suggestion in the README did not work. While the new variant works it is important to note that it does not actually serve the ESM build present in `dist/es-modules` but the `/dist/contentful-management.node.js` bundle.

In my tests I was able to force the package to serve the ESM variant by adding the following change in the package.json
`"exports":{
    "import":"./dist/es-modules/contentful-management.js"
  }`

That alone leads to the error:

`import { getUserAgentHeader } from 'contentful-sdk-core';
^^^^^^
SyntaxError: Cannot use import statement outside a module`

I assume because the closest package.json still suggests that this is using CommonJS. Forcing it by changing the file name to `contentful-management.mjs` introduces other errors:

`Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/andreasegger/Repos/js-demo/node_modules/contentful-management/dist/es-modules/create-adapter' imported from /Users/andreasegger/Repos/js-demo/node_modules/contentful-management/dist/es-modules/contentful-management.mjs`

**Long story short:** As far as I see it the build from the es-modules folder is never actually served when imported and the current suggested syntax therefore doesn't work so I think we should make this change to the README. 

