### PR TITLE
fix(WorkflowsChangelog): use correct endpoint URL and enforce passing query for now

### DIFF
--- a/lib/adapters/REST/endpoints/workflows-changelog.ts
+++ b/lib/adapters/REST/endpoints/workflows-changelog.ts
@@ -8,11 +8,11 @@ import { RestEndpoint } from '../types'
 import * as raw from './raw'
 
 const getBaseUrl = (params: GetSpaceEnvironmentParams) =>
-  `/spaces/${params.spaceId}/environments/${params.environmentId}/workflows-changelog`
+  `/spaces/${params.spaceId}/environments/${params.environmentId}/workflows_changelog`
 
 export const getMany: RestEndpoint<'WorkflowsChangelog', 'getMany'> = (
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { query?: WorkflowsChangelogQueryOptions },
+  params: GetSpaceEnvironmentParams & { query: WorkflowsChangelogQueryOptions },
   headers?: Record<string, unknown>
 ) =>
   raw.get<CollectionProp<WorkflowsChangelogEntryProps>>(http, getBaseUrl(params), {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1428,7 +1428,7 @@ export type MRActions = {
   }
   WorkflowsChangelog: {
     getMany: {
-      params: GetSpaceEnvironmentParams & { query?: WorkflowsChangelogQueryOptions }
+      params: GetSpaceEnvironmentParams & { query: WorkflowsChangelogQueryOptions }
       headers?: Record<string, unknown>
       return: CollectionProp<WorkflowsChangelogEntryProps>
     }

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -930,7 +930,7 @@ export type AlphaWorkflowExtension = {
   workflowsChangelog: {
     getMany(
       params: OptionalDefaults<
-        GetSpaceEnvironmentParams & { query?: WorkflowsChangelogQueryOptions }
+        GetSpaceEnvironmentParams & { query: WorkflowsChangelogQueryOptions }
       >,
       headers?: Record<string, unknown>
     ): Promise<CollectionProp<WorkflowsChangelogEntryProps>>


### PR DESCRIPTION
## Summary

Accidentally, we used `/workflows-changelog` instead of `/workflows_changelog`.