### PR TITLE
fix: the entity link type to from entity to entry []

### DIFF
--- a/lib/entities/workflows-changelog-entry.ts
+++ b/lib/entities/workflows-changelog-entry.ts
@@ -24,7 +24,7 @@ export type WorkflowsChangelogEntryProps = {
   eventAt: string
   workflow: Link<'Workflow'>
   workflowDefinition: Link<'WorkflowDefinition'>
-  entity: Link<'Entity'>
+  entity: Link<'Entry'>
   stepId: string
   stepAnnotations: string[]
   stepName: string


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Fix the entity link type to from entity to entry

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
