### PR TITLE
fix: Allow raw patch requests

### DIFF
--- a/lib/adapters/REST/endpoints/http.ts
+++ b/lib/adapters/REST/endpoints/http.ts
@@ -26,6 +26,14 @@ export const put: RestEndpoint<'Http', 'put'> = <T = any>(
   return raw.put<T>(http, url, payload, config)
 }
 
+export const patch: RestEndpoint<'Http', 'patch'> = <T = any>(
+  http: AxiosInstance,
+  { url, config }: { url: string; config?: AxiosRequestConfig },
+  payload?: any
+) => {
+  return raw.patch<T>(http, url, payload, config)
+}
+
 export const del: RestEndpoint<'Http', 'delete'> = <T = any>(
   http: AxiosInstance,
   { url, config }: { url: string; config?: AxiosRequestConfig }

--- a/test/unit/adapters/REST/endpoints/http-test.js
+++ b/test/unit/adapters/REST/endpoints/http-test.js
@@ -58,6 +58,21 @@ describe('Rest Http', () => {
     expect(httpMock.put.args[0][2]).to.contain(CONFIG)
   })
 
+  test('patch', async () => {
+    const { httpMock, adapterMock: adapter } = setup()
+
+    await adapter.makeRequest({
+      entityType: 'Http',
+      action: 'patch',
+      params: { url: URL, config: CONFIG },
+      payload: PAYLOAD,
+    })
+
+    expect(httpMock.patch.args[0][0]).to.equal(URL)
+    expect(httpMock.patch.args[0][1]).to.equal(PAYLOAD)
+    expect(httpMock.patch.args[0][2]).to.contain(CONFIG)
+  })
+
   test('delete', async () => {
     const { httpMock, adapterMock: adapter } = setup()
 

--- a/test/unit/mocks/http.js
+++ b/test/unit/mocks/http.js
@@ -19,6 +19,7 @@ export default function setupHttpMock(promise = Promise.resolve({ data: {} })) {
   mock.get = sinon.stub().returns(promise)
   mock.post = sinon.stub().returns(promise)
   mock.put = sinon.stub().returns(promise)
+  mock.patch = sinon.stub().returns(promise)
   mock.delete = sinon.stub().returns(promise)
   mock.defaults = {
     baseURL: 'https://api.contentful.com/spaces/',


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

At the moment using `cma.raw.patch` fails with `Unknown endpoint` thrown in https://github.com/contentful/contentful-management.js/blob/master/lib/adapters/REST/rest-adapter.ts#L69-L71 It looks to me like the `patch` method is just missing in the Http endpoint module.

## Description

Add a patch method to the Http endpoint module.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
