### PR TITLE
feat: rename getAll to getMany for tasks and comments

### DIFF
--- a/lib/adapters/REST/endpoints/comment.ts
+++ b/lib/adapters/REST/endpoints/comment.ts
@@ -27,7 +27,7 @@ export const get: RestEndpoint<'Comment', 'get'> = (
   params: GetCommentParams
 ) => raw.get<CommentProps>(http, getCommentUrl(params))
 
-export const getManyForEntry: RestEndpoint<'Comment', 'getManyForEntry'> = (
+export const getMany: RestEndpoint<'Comment', 'getMany'> = (
   http: AxiosInstance,
   params: GetEntryParams & QueryParams
 ) =>
@@ -36,9 +36,9 @@ export const getManyForEntry: RestEndpoint<'Comment', 'getManyForEntry'> = (
   })
 
 /**
- * @deprecated use `getManyForEntry` instead. `getAll` may never be removed for app compatibility reasons.
+ * @deprecated use `getMany` instead. `getAll` may never be removed for app compatibility reasons.
  */
-export const getAll: RestEndpoint<'Comment', 'getAll'> = getManyForEntry
+export const getAll: RestEndpoint<'Comment', 'getAll'> = getMany
 
 export const create: RestEndpoint<'Comment', 'create'> = (
   http: AxiosInstance,

--- a/lib/adapters/REST/endpoints/comment.ts
+++ b/lib/adapters/REST/endpoints/comment.ts
@@ -1,7 +1,12 @@
 import { AxiosInstance, AxiosRequestHeaders } from 'axios'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
-import { CollectionProp, GetEntryParams, GetCommentParams } from '../../../common-types'
+import {
+  CollectionProp,
+  GetEntryParams,
+  GetCommentParams,
+  QueryParams,
+} from '../../../common-types'
 import {
   CreateCommentParams,
   CreateCommentProps,
@@ -11,6 +16,7 @@ import {
 } from '../../../entities/comment'
 import { RestEndpoint } from '../types'
 import * as raw from './raw'
+import { normalizeSelect } from './utils'
 
 const getBaseUrl = (params: GetEntryParams) =>
   `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}/comments`
@@ -21,10 +27,13 @@ export const get: RestEndpoint<'Comment', 'get'> = (
   params: GetCommentParams
 ) => raw.get<CommentProps>(http, getCommentUrl(params))
 
-export const getAll: RestEndpoint<'Comment', 'getAll'> = (
+export const getManyForEntry: RestEndpoint<'Comment', 'getManyForEntry'> = (
   http: AxiosInstance,
-  params: GetEntryParams
-) => raw.get<CollectionProp<CommentProps>>(http, getBaseUrl(params))
+  params: GetEntryParams & QueryParams
+) =>
+  raw.get<CollectionProp<CommentProps>>(http, getBaseUrl(params), {
+    params: normalizeSelect(params.query),
+  })
 
 export const create: RestEndpoint<'Comment', 'create'> = (
   http: AxiosInstance,

--- a/lib/adapters/REST/endpoints/comment.ts
+++ b/lib/adapters/REST/endpoints/comment.ts
@@ -35,6 +35,11 @@ export const getManyForEntry: RestEndpoint<'Comment', 'getManyForEntry'> = (
     params: normalizeSelect(params.query),
   })
 
+/**
+ * @deprecated use `getManyForEntry` instead. `getAll` may never be removed for app compatibility reasons.
+ */
+export const getAll: RestEndpoint<'Comment', 'getAll'> = getManyForEntry
+
 export const create: RestEndpoint<'Comment', 'create'> = (
   http: AxiosInstance,
   params: CreateCommentParams,

--- a/lib/adapters/REST/endpoints/task.ts
+++ b/lib/adapters/REST/endpoints/task.ts
@@ -1,14 +1,7 @@
 import { AxiosInstance, AxiosRequestHeaders } from 'axios'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
-import {
-  CollectionProp,
-  GetEntryParams,
-  GetSnapshotForEntryParams,
-  GetTaskParams,
-  KeyValueMap,
-  QueryParams,
-} from '../../../common-types'
+import { CollectionProp, GetEntryParams, GetTaskParams, QueryParams } from '../../../common-types'
 import {
   CreateTaskParams,
   CreateTaskProps,
@@ -18,8 +11,6 @@ import {
 } from '../../../entities/task'
 import { RestEndpoint } from '../types'
 import * as raw from './raw'
-import { SnapshotProps } from '../../../entities/snapshot'
-import { EntryProps } from '../../../entities/entry'
 import { normalizeSelect } from './utils'
 
 const getBaseUrl = (params: GetEntryParams) =>
@@ -29,21 +20,13 @@ const getTaskUrl = (params: GetTaskParams) => `${getBaseUrl(params)}/${params.ta
 export const get: RestEndpoint<'Task', 'get'> = (http: AxiosInstance, params: GetTaskParams) =>
   raw.get<TaskProps>(http, getTaskUrl(params))
 
-export const getAll: RestEndpoint<'Task', 'getAll'> = (
-  http: AxiosInstance,
-  params: GetEntryParams
-) => raw.get<CollectionProp<TaskProps>>(http, getBaseUrl(params))
-
-export const getManyForEntry: RestEndpoint<'Task', 'getManyForEntry'> = <
-  T extends KeyValueMap = KeyValueMap
->(
+export const getManyForEntry: RestEndpoint<'Task', 'getManyForEntry'> = (
   http: AxiosInstance,
   params: GetEntryParams & QueryParams
-) => {
-  return raw.get<CollectionProp<TaskProps>>(http, getBaseUrl(params), {
+) =>
+  raw.get<CollectionProp<TaskProps>>(http, getBaseUrl(params), {
     params: normalizeSelect(params.query),
   })
-}
 
 export const create: RestEndpoint<'Task', 'create'> = (
   http: AxiosInstance,

--- a/lib/adapters/REST/endpoints/task.ts
+++ b/lib/adapters/REST/endpoints/task.ts
@@ -1,7 +1,14 @@
 import { AxiosInstance, AxiosRequestHeaders } from 'axios'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
-import { CollectionProp, GetEntryParams, GetTaskParams } from '../../../common-types'
+import {
+  CollectionProp,
+  GetEntryParams,
+  GetSnapshotForEntryParams,
+  GetTaskParams,
+  KeyValueMap,
+  QueryParams,
+} from '../../../common-types'
 import {
   CreateTaskParams,
   CreateTaskProps,
@@ -11,6 +18,9 @@ import {
 } from '../../../entities/task'
 import { RestEndpoint } from '../types'
 import * as raw from './raw'
+import { SnapshotProps } from '../../../entities/snapshot'
+import { EntryProps } from '../../../entities/entry'
+import { normalizeSelect } from './utils'
 
 const getBaseUrl = (params: GetEntryParams) =>
   `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}/tasks`
@@ -23,6 +33,17 @@ export const getAll: RestEndpoint<'Task', 'getAll'> = (
   http: AxiosInstance,
   params: GetEntryParams
 ) => raw.get<CollectionProp<TaskProps>>(http, getBaseUrl(params))
+
+export const getManyForEntry: RestEndpoint<'Task', 'getManyForEntry'> = <
+  T extends KeyValueMap = KeyValueMap
+>(
+  http: AxiosInstance,
+  params: GetEntryParams & QueryParams
+) => {
+  return raw.get<CollectionProp<TaskProps>>(http, getBaseUrl(params), {
+    params: normalizeSelect(params.query),
+  })
+}
 
 export const create: RestEndpoint<'Task', 'create'> = (
   http: AxiosInstance,

--- a/lib/adapters/REST/endpoints/task.ts
+++ b/lib/adapters/REST/endpoints/task.ts
@@ -28,6 +28,11 @@ export const getManyForEntry: RestEndpoint<'Task', 'getManyForEntry'> = (
     params: normalizeSelect(params.query),
   })
 
+/**
+ * @deprecated use `getManyForEntry` instead. `getAll` may never be removed for app compatibility reasons.
+ */
+export const getAll: RestEndpoint<'Task', 'getAll'> = getManyForEntry
+
 export const create: RestEndpoint<'Task', 'create'> = (
   http: AxiosInstance,
   params: CreateTaskParams,

--- a/lib/adapters/REST/endpoints/task.ts
+++ b/lib/adapters/REST/endpoints/task.ts
@@ -20,7 +20,7 @@ const getTaskUrl = (params: GetTaskParams) => `${getBaseUrl(params)}/${params.ta
 export const get: RestEndpoint<'Task', 'get'> = (http: AxiosInstance, params: GetTaskParams) =>
   raw.get<TaskProps>(http, getTaskUrl(params))
 
-export const getManyForEntry: RestEndpoint<'Task', 'getManyForEntry'> = (
+export const getMany: RestEndpoint<'Task', 'getMany'> = (
   http: AxiosInstance,
   params: GetEntryParams & QueryParams
 ) =>
@@ -29,9 +29,9 @@ export const getManyForEntry: RestEndpoint<'Task', 'getManyForEntry'> = (
   })
 
 /**
- * @deprecated use `getManyForEntry` instead. `getAll` may never be removed for app compatibility reasons.
+ * @deprecated use `getMany` instead. `getAll` may never be removed for app compatibility reasons.
  */
-export const getAll: RestEndpoint<'Task', 'getAll'> = getManyForEntry
+export const getAll: RestEndpoint<'Task', 'getAll'> = getMany
 
 export const create: RestEndpoint<'Task', 'create'> = (
   http: AxiosInstance,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1236,6 +1236,10 @@ export type MRActions = {
   Task: {
     get: { params: GetTaskParams; return: TaskProps }
     getAll: { params: GetEntryParams; return: CollectionProp<TaskProps> }
+    getManyForEntry: {
+      params: GetEntryParams & QueryParams
+      return: CollectionProp<TaskProps>
+    }
     create: { params: CreateTaskParams; payload: CreateTaskProps; return: TaskProps }
     update: {
       params: UpdateTaskParams

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -328,6 +328,7 @@ type MRInternal<UA extends boolean> = {
 
   (opts: MROpts<'Comment', 'get', UA>): MRReturn<'Comment', 'get'>
   (opts: MROpts<'Comment', 'getManyForEntry', UA>): MRReturn<'Comment', 'getManyForEntry'>
+  (opts: MROpts<'Comment', 'getAll', UA>): MRReturn<'Comment', 'getAll'>
   (opts: MROpts<'Comment', 'create', UA>): MRReturn<'Comment', 'create'>
   (opts: MROpts<'Comment', 'update', UA>): MRReturn<'Comment', 'update'>
   (opts: MROpts<'Comment', 'delete', UA>): MRReturn<'Comment', 'delete'>
@@ -486,6 +487,7 @@ type MRInternal<UA extends boolean> = {
 
   (opts: MROpts<'Task', 'get', UA>): MRReturn<'Task', 'get'>
   (opts: MROpts<'Task', 'getManyForEntry', UA>): MRReturn<'Task', 'getManyForEntry'>
+  (opts: MROpts<'Task', 'getAll', UA>): MRReturn<'Task', 'getAll'>
   (opts: MROpts<'Task', 'create', UA>): MRReturn<'Task', 'create'>
   (opts: MROpts<'Task', 'update', UA>): MRReturn<'Task', 'update'>
   (opts: MROpts<'Task', 'delete', UA>): MRReturn<'Task', 'delete'>
@@ -816,6 +818,10 @@ export type MRActions = {
   Comment: {
     get: { params: GetCommentParams; return: CommentProps }
     getManyForEntry: {
+      params: GetEntryParams & QueryParams
+      return: CollectionProp<CommentProps>
+    }
+    getAll: {
       params: GetEntryParams & QueryParams
       return: CollectionProp<CommentProps>
     }
@@ -1239,6 +1245,10 @@ export type MRActions = {
   Task: {
     get: { params: GetTaskParams; return: TaskProps }
     getManyForEntry: {
+      params: GetEntryParams & QueryParams
+      return: CollectionProp<TaskProps>
+    }
+    getAll: {
       params: GetEntryParams & QueryParams
       return: CollectionProp<TaskProps>
     }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -327,7 +327,7 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'BulkAction', 'validate', UA>): MRReturn<'BulkAction', 'validate'>
 
   (opts: MROpts<'Comment', 'get', UA>): MRReturn<'Comment', 'get'>
-  (opts: MROpts<'Comment', 'getAll', UA>): MRReturn<'Comment', 'getAll'>
+  (opts: MROpts<'Comment', 'getManyForEntry', UA>): MRReturn<'Comment', 'getManyForEntry'>
   (opts: MROpts<'Comment', 'create', UA>): MRReturn<'Comment', 'create'>
   (opts: MROpts<'Comment', 'update', UA>): MRReturn<'Comment', 'update'>
   (opts: MROpts<'Comment', 'delete', UA>): MRReturn<'Comment', 'delete'>
@@ -485,7 +485,7 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Tag', 'delete', UA>): MRReturn<'Tag', 'delete'>
 
   (opts: MROpts<'Task', 'get', UA>): MRReturn<'Task', 'get'>
-  (opts: MROpts<'Task', 'getAll', UA>): MRReturn<'Task', 'getAll'>
+  (opts: MROpts<'Task', 'getManyForEntry', UA>): MRReturn<'Task', 'getManyForEntry'>
   (opts: MROpts<'Task', 'create', UA>): MRReturn<'Task', 'create'>
   (opts: MROpts<'Task', 'update', UA>): MRReturn<'Task', 'update'>
   (opts: MROpts<'Task', 'delete', UA>): MRReturn<'Task', 'delete'>
@@ -815,7 +815,10 @@ export type MRActions = {
   }
   Comment: {
     get: { params: GetCommentParams; return: CommentProps }
-    getAll: { params: GetEntryParams; return: CollectionProp<CommentProps> }
+    getManyForEntry: {
+      params: GetEntryParams & QueryParams
+      return: CollectionProp<CommentProps>
+    }
     create: { params: CreateCommentParams; payload: CreateCommentProps; return: CommentProps }
     update: {
       params: UpdateCommentParams
@@ -1235,7 +1238,6 @@ export type MRActions = {
   }
   Task: {
     get: { params: GetTaskParams; return: TaskProps }
-    getAll: { params: GetEntryParams; return: CollectionProp<TaskProps> }
     getManyForEntry: {
       params: GetEntryParams & QueryParams
       return: CollectionProp<TaskProps>

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -327,7 +327,7 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'BulkAction', 'validate', UA>): MRReturn<'BulkAction', 'validate'>
 
   (opts: MROpts<'Comment', 'get', UA>): MRReturn<'Comment', 'get'>
-  (opts: MROpts<'Comment', 'getManyForEntry', UA>): MRReturn<'Comment', 'getManyForEntry'>
+  (opts: MROpts<'Comment', 'getMany', UA>): MRReturn<'Comment', 'getMany'>
   (opts: MROpts<'Comment', 'getAll', UA>): MRReturn<'Comment', 'getAll'>
   (opts: MROpts<'Comment', 'create', UA>): MRReturn<'Comment', 'create'>
   (opts: MROpts<'Comment', 'update', UA>): MRReturn<'Comment', 'update'>
@@ -486,7 +486,7 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Tag', 'delete', UA>): MRReturn<'Tag', 'delete'>
 
   (opts: MROpts<'Task', 'get', UA>): MRReturn<'Task', 'get'>
-  (opts: MROpts<'Task', 'getManyForEntry', UA>): MRReturn<'Task', 'getManyForEntry'>
+  (opts: MROpts<'Task', 'getMany', UA>): MRReturn<'Task', 'getMany'>
   (opts: MROpts<'Task', 'getAll', UA>): MRReturn<'Task', 'getAll'>
   (opts: MROpts<'Task', 'create', UA>): MRReturn<'Task', 'create'>
   (opts: MROpts<'Task', 'update', UA>): MRReturn<'Task', 'update'>
@@ -817,7 +817,7 @@ export type MRActions = {
   }
   Comment: {
     get: { params: GetCommentParams; return: CommentProps }
-    getManyForEntry: {
+    getMany: {
       params: GetEntryParams & QueryParams
       return: CollectionProp<CommentProps>
     }
@@ -1244,7 +1244,7 @@ export type MRActions = {
   }
   Task: {
     get: { params: GetTaskParams; return: TaskProps }
-    getManyForEntry: {
+    getMany: {
       params: GetEntryParams & QueryParams
       return: CollectionProp<TaskProps>
     }

--- a/lib/create-entry-api.ts
+++ b/lib/create-entry-api.ts
@@ -348,7 +348,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
       const { params } = getParams(this)
       return makeRequest({
         entityType: 'Comment',
-        action: 'getManyForEntry',
+        action: 'getMany',
         params,
       }).then((data) => wrapCommentCollection(makeRequest, data))
     },
@@ -436,7 +436,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
       const { params } = getParams(this)
       return makeRequest({
         entityType: 'Task',
-        action: 'getManyForEntry',
+        action: 'getMany',
         params,
       }).then((data) => wrapTaskCollection(makeRequest, data))
     },

--- a/lib/create-entry-api.ts
+++ b/lib/create-entry-api.ts
@@ -348,7 +348,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
       const { params } = getParams(this)
       return makeRequest({
         entityType: 'Comment',
-        action: 'getAll',
+        action: 'getManyForEntry',
         params,
       }).then((data) => wrapCommentCollection(makeRequest, data))
     },
@@ -436,7 +436,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
       const { params } = getParams(this)
       return makeRequest({
         entityType: 'Task',
-        action: 'getAll',
+        action: 'getManyForEntry',
         params,
       }).then((data) => wrapTaskCollection(makeRequest, data))
     },

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -298,7 +298,7 @@ export type PlainClientAPI = {
   }
   comment: {
     get(params: OptionalDefaults<GetCommentParams>): Promise<CommentProps>
-    getManyForEntry(
+    getMany(
       params: OptionalDefaults<GetEntryParams & QueryParams>
     ): Promise<CollectionProp<CommentProps>>
     create(
@@ -800,7 +800,7 @@ export type PlainClientAPI = {
   }
   task: {
     get(params: OptionalDefaults<GetTaskParams>): Promise<TaskProps>
-    getManyForEntry(
+    getMany(
       params: OptionalDefaults<GetEntryParams & QueryParams>
     ): Promise<CollectionProp<TaskProps>>
     create(

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -298,7 +298,9 @@ export type PlainClientAPI = {
   }
   comment: {
     get(params: OptionalDefaults<GetCommentParams>): Promise<CommentProps>
-    getAll(params: OptionalDefaults<GetEntryParams>): Promise<CollectionProp<CommentProps>>
+    getManyForEntry(
+      params: OptionalDefaults<GetEntryParams & QueryParams>
+    ): Promise<CollectionProp<CommentProps>>
     create(
       params: OptionalDefaults<CreateCommentParams>,
       rawData: CreateCommentProps,
@@ -798,7 +800,6 @@ export type PlainClientAPI = {
   }
   task: {
     get(params: OptionalDefaults<GetTaskParams>): Promise<TaskProps>
-    getAll(params: OptionalDefaults<GetEntryParams>): Promise<CollectionProp<TaskProps>>
     getManyForEntry(
       params: OptionalDefaults<GetEntryParams & QueryParams>
     ): Promise<CollectionProp<TaskProps>>

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -799,6 +799,9 @@ export type PlainClientAPI = {
   task: {
     get(params: OptionalDefaults<GetTaskParams>): Promise<TaskProps>
     getAll(params: OptionalDefaults<GetEntryParams>): Promise<CollectionProp<TaskProps>>
+    getManyForEntry(
+      params: OptionalDefaults<GetEntryParams & QueryParams>
+    ): Promise<CollectionProp<TaskProps>>
     create(
       params: OptionalDefaults<CreateTaskParams>,
       rawData: CreateTaskProps,

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -123,7 +123,7 @@ export const createPlainClient = (
     },
     comment: {
       get: wrap(wrapParams, 'Comment', 'get'),
-      getManyForEntry: wrap(wrapParams, 'Comment', 'getManyForEntry'),
+      getMany: wrap(wrapParams, 'Comment', 'getMany'),
       create: wrap(wrapParams, 'Comment', 'create'),
       update: wrap(wrapParams, 'Comment', 'update'),
       delete: wrap(wrapParams, 'Comment', 'delete'),
@@ -153,7 +153,7 @@ export const createPlainClient = (
     },
     task: {
       get: wrap(wrapParams, 'Task', 'get'),
-      getManyForEntry: wrap(wrapParams, 'Task', 'getManyForEntry'),
+      getMany: wrap(wrapParams, 'Task', 'getMany'),
       create: wrap(wrapParams, 'Task', 'create'),
       update: wrap(wrapParams, 'Task', 'update'),
       delete: wrap(wrapParams, 'Task', 'delete'),

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -154,6 +154,7 @@ export const createPlainClient = (
     task: {
       get: wrap(wrapParams, 'Task', 'get'),
       getAll: wrap(wrapParams, 'Task', 'getAll'),
+      getManyForEntry: wrap(wrapParams, 'Task', 'getManyForEntry'),
       create: wrap(wrapParams, 'Task', 'create'),
       update: wrap(wrapParams, 'Task', 'update'),
       delete: wrap(wrapParams, 'Task', 'delete'),

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -123,7 +123,7 @@ export const createPlainClient = (
     },
     comment: {
       get: wrap(wrapParams, 'Comment', 'get'),
-      getAll: wrap(wrapParams, 'Comment', 'getAll'),
+      getManyForEntry: wrap(wrapParams, 'Comment', 'getManyForEntry'),
       create: wrap(wrapParams, 'Comment', 'create'),
       update: wrap(wrapParams, 'Comment', 'update'),
       delete: wrap(wrapParams, 'Comment', 'delete'),
@@ -153,7 +153,6 @@ export const createPlainClient = (
     },
     task: {
       get: wrap(wrapParams, 'Task', 'get'),
-      getAll: wrap(wrapParams, 'Task', 'getAll'),
       getManyForEntry: wrap(wrapParams, 'Task', 'getManyForEntry'),
       create: wrap(wrapParams, 'Task', 'create'),
       update: wrap(wrapParams, 'Task', 'update'),


### PR DESCRIPTION
## Summary

- Add task.getManyForEntry
- feat: rename to getManyForEntry for consistency and allow passing pagination parameters


BREAKING CHANGE: Rename `getAll` to `getManyForEntry` for tasks and comments in plain client.

## Description

Due to pipeline issues in https://github.com/contentful/contentful-management.js/pull/1262 and some missing fixes & improvements I cherry picked the commit by @dmsolutionsmn (for keeping authorship) and added the refactoring & fix.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
