### PR TITLE
feat(release): update release query options type with new query params [SPA-538]

### DIFF
--- a/lib/entities/release.ts
+++ b/lib/entities/release.ts
@@ -32,7 +32,7 @@ export interface ReleaseQueryOptions {
   /** Comma-separated  list of Ids to find (inclusion)  */
   'sys.id[in]'?: string
 
-  /** Filters by creator of release  */
+  /** Comma-separated list of user Ids to find releases by creator  */
   'sys.createdBy.sys.id[in]'?: string
 
   /** Comma-separated filter (inclusion) by Release status (active, archived) */

--- a/lib/entities/release.ts
+++ b/lib/entities/release.ts
@@ -18,16 +18,35 @@ import { ReleaseActionProps, wrapReleaseAction } from './release-action'
 
 /** Entity types supported by the Release API */
 type Entity = 'Entry' | 'Asset'
+type ReleaseStatus = 'active' | 'archived'
 
 export interface ReleaseQueryOptions {
   /** Find releases filtered by the Entity type (Asset, Entry) */
   'entities.sys.linkType'?: string
   /** Find releases containing the specified, comma-separated entities. Requires `entities.sys.linkType` */
   'entities.sys.id[in]'?: string
-  /** Find releases by using a comma-separated list of Ids */
+
+  /** Comma-separated list of ids to exclude from the query */
+  'sys.id[nin]'?: string
+
+  /** Comma-separated  list of Ids to find (inclusion)  */
   'sys.id[in]'?: string
+
+  /** Filters by creator of release  */
+  'sys.createdBy.sys.id[in]'?: string
+
+  /** Comma-separated filter (inclusion) by Release status (active, archived) */
+  'sys.status[in]'?: ReleaseStatus
+
+  /** Comma-separated filter (exclusion) by Release status (active, archived) */
+  'sys.status[nin]'?: ReleaseStatus
+
   /** Find releases using full text phrase and term matching */
   'title[match]'?: string
+
+  /** Filter by empty Releases (exists=false) or Releases with items (exists=true) */
+  'entities[exists]'?: boolean
+
   /** If present, will return results based on a pagination cursor */
   pageNext?: string
   /**
@@ -36,14 +55,14 @@ export interface ReleaseQueryOptions {
    * */
   limit?: number
   /**
-   * Order releases by
+   * Order releases
+   *  Supported values include
+   *  - `title`, `-title`
+   *  - `sys.updatedAt`, `-sys.updatedAt`
+   *  - `sys.createdAt`, `-sys.createdAt`
    * @default -sys.updatedAt
    * */
   order?: string
-  /**
-   * Filters by creator of release
-   */
-  'sys.createdBy.sys.id[in]'?: string
 }
 
 export type ReleaseSysProps = {

--- a/test/integration/release-integration.ts
+++ b/test/integration/release-integration.ts
@@ -88,6 +88,43 @@ describe('Release Api', async function () {
         testEnvironment.deleteRelease(release2.sys.id),
       ])
     })
+
+    test('Get Releases with query filters', async () => {
+      // Creates 2 releases, 1 empty and 1 containing a test entry
+      const [release1, release2] = await Promise.all([
+        testEnvironment.createRelease({
+          title: 'First release',
+          entities: {
+            sys: { type: 'Array' },
+            items: [makeLink('Entry', TestDefaults.entry.testEntryReleasesId)], // empty release
+          },
+        }),
+        testEnvironment.createRelease({
+          title: 'Second release',
+          entities: {
+            sys: { type: 'Array' },
+            items: [],
+          },
+        }),
+      ])
+
+      const queryResult = await testEnvironment.getReleases({
+        'entities[exists]': true,
+        'sys.status[in]': 'active',
+        limit: 1000,
+        order: '-title',
+      })
+
+      // Returns the filtered results -- considering only non-empty releases
+      expect(queryResult.items.length).to.eql(1)
+      expect(queryResult.items[0].title).to.eql('First release')
+
+      // cleanup
+      await Promise.all([
+        testEnvironment.deleteRelease(release1.sys.id),
+        testEnvironment.deleteRelease(release2.sys.id),
+      ])
+    })
   })
 
   describe('Write', () => {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

- Adds more type hints for the possible query options when using `environment.getReleases` (Client) or `releases.getMany` (PlainClient)


## Description

- More type hints and explanations for the filters available when querying releases.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [ ] The new method is added to the documentation
