### PR TITLE
fix(tests): remove .only from release test []

### DIFF
--- a/test/integration/release-integration.ts
+++ b/test/integration/release-integration.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { after, before, describe, test } from 'mocha'
+import { before, describe, test } from 'mocha'
 import { Environment, Space } from '../../lib/export-types'
 
 import { waitForReleaseActionProcessing } from '../../lib/methods/release-action'
@@ -7,8 +7,7 @@ import { TestDefaults } from '../defaults'
 import { createTestSpace, initPlainClient, initClient } from '../helpers'
 import { makeLink } from '../utils'
 
-// eslint-disable-next-line no-only-tests/no-only-tests
-describe.only('Release Api', async function () {
+describe('Release Api', async function () {
   let testSpace: Space
   let testEnvironment: Environment
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

- A `.only` flag ended up being committed into `master`, this PR removes the flag.

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
