### PR TITLE
feat: add support for release actions query endpoint [SPA-707]

### DIFF
--- a/lib/adapters/REST/endpoints/release-action.ts
+++ b/lib/adapters/REST/endpoints/release-action.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { AxiosInstance } from 'contentful-sdk-core'
-import { GetReleaseParams } from '../../../common-types'
+import { GetReleaseParams, GetSpaceEnvironmentParams } from '../../../common-types'
 import { ReleaseActionQueryOptions } from '../../../entities/release-action'
 import { RestEndpoint } from '../types'
 import * as raw from './raw'
@@ -15,15 +15,32 @@ export const get: RestEndpoint<'ReleaseAction', 'get'> = (
   )
 }
 
+export const getMany: RestEndpoint<'ReleaseAction', 'getMany'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams & { query?: ReleaseActionQueryOptions }
+) => {
+  return raw.get(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/release_actions`,
+    {
+      params: params.query,
+    }
+  )
+}
+
+/** @deprecated use getMany with `sys.release.sys.id[in]` */
 export const queryForRelease: RestEndpoint<'ReleaseAction', 'queryForRelease'> = (
   http: AxiosInstance,
   params: GetReleaseParams & { query?: ReleaseActionQueryOptions }
 ) => {
   return raw.get(
     http,
-    `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/actions`,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/release_actions`,
     {
-      params: params.query,
+      params: {
+        'sys.release.sys.id[in]': params.releaseId,
+        ...params.query,
+      },
     }
   )
 }

--- a/lib/adapters/REST/endpoints/release-action.ts
+++ b/lib/adapters/REST/endpoints/release-action.ts
@@ -28,7 +28,6 @@ export const getMany: RestEndpoint<'ReleaseAction', 'getMany'> = (
   )
 }
 
-/** @deprecated use getMany with `sys.release.sys.id[in]` */
 export const queryForRelease: RestEndpoint<'ReleaseAction', 'queryForRelease'> = (
   http: AxiosInstance,
   params: GetReleaseParams & { query?: ReleaseActionQueryOptions }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -431,6 +431,7 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Release', 'validate', UA>): MRReturn<'Release', 'validate'>
 
   (opts: MROpts<'ReleaseAction', 'get', UA>): MRReturn<'ReleaseAction', 'get'>
+  (opts: MROpts<'ReleaseAction', 'getMany', UA>): MRReturn<'ReleaseAction', 'getMany'>
   (opts: MROpts<'ReleaseAction', 'queryForRelease', UA>): MRReturn<
     'ReleaseAction',
     'queryForRelease'
@@ -1119,6 +1120,10 @@ export type MRActions = {
     get: {
       params: GetReleaseParams & { actionId: string }
       return: ReleaseAction
+    }
+    getMany: {
+      params: GetSpaceEnvironmentParams & { query: ReleaseActionQueryOptions }
+      return: Collection<ReleaseAction, ReleaseActionProps>
     }
     queryForRelease: {
       params: GetReleaseParams & { query?: ReleaseActionQueryOptions }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1122,7 +1122,7 @@ export type MRActions = {
       return: ReleaseAction
     }
     getMany: {
-      params: GetSpaceEnvironmentParams & { query: ReleaseActionQueryOptions }
+      params: GetSpaceEnvironmentParams & { query?: ReleaseActionQueryOptions }
       return: Collection<ReleaseAction, ReleaseActionProps>
     }
     queryForRelease: {

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -2095,20 +2095,28 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
       releaseId,
       query,
     }: {
-      releaseId: string
+      /** @deprecated use the query options object with `sys.release.sys.id[in]` */
+      releaseId?: string
       query?: ReleaseActionQueryOptions
     }) {
       const raw: EnvironmentProps = this.toPlainObject()
+      const queryParams: ReleaseActionQueryOptions = query ?? {}
+      const params = {
+        spaceId: raw.sys.space.sys.id,
+        environmentId: raw.sys.id,
+        query: queryParams,
+      }
+
+      if (releaseId) {
+        queryParams['sys.release.sys.id[in]'] = releaseId
+      }
+
+      params.query = queryParams
 
       return makeRequest({
         entityType: 'ReleaseAction',
-        action: 'queryForRelease',
-        params: {
-          spaceId: raw.sys.space.sys.id,
-          environmentId: raw.sys.id,
-          releaseId,
-          query,
-        },
+        action: 'getMany',
+        params,
       }).then((data) => wrapReleaseActionCollection(makeRequest, data))
     },
   }

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -2091,32 +2091,17 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    getReleaseActions({
-      releaseId,
-      query,
-    }: {
-      /** @deprecated use the query options object with `sys.release.sys.id[in]` */
-      releaseId?: string
-      query?: ReleaseActionQueryOptions
-    }) {
+    getReleaseActions({ query }: { query?: ReleaseActionQueryOptions }) {
       const raw: EnvironmentProps = this.toPlainObject()
-      const queryParams: ReleaseActionQueryOptions = query ?? {}
-      const params = {
-        spaceId: raw.sys.space.sys.id,
-        environmentId: raw.sys.id,
-        query: queryParams,
-      }
-
-      if (releaseId) {
-        queryParams['sys.release.sys.id[in]'] = releaseId
-      }
-
-      params.query = queryParams
 
       return makeRequest({
         entityType: 'ReleaseAction',
         action: 'getMany',
-        params,
+        params: {
+          spaceId: raw.sys.space.sys.id,
+          environmentId: raw.sys.id,
+          query,
+        },
       }).then((data) => wrapReleaseActionCollection(makeRequest, data))
     },
   }

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -2086,7 +2086,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *
      * client.getSpace('<space_id>')
      * .then((space) => space.getEnvironment('<environment-id>'))
-     * .then((environment) => environment.getReleaseActions({ releaseId: '<release_id>', query: { 'sys.id[in]': '<id_1>,<id_2>' } }))
+     * .then((environment) => environment.getReleaseActions({ query: { 'sys.id[in]': '<id_1>,<id_2>', 'sys.release.sys.id[in]': '<id1>,<id2>' } }))
      * .then((releaseActions) => console.log(releaseActions))
      * .catch(console.error)
      * ```

--- a/lib/entities/release-action.ts
+++ b/lib/entities/release-action.ts
@@ -30,6 +30,15 @@ export interface ReleaseActionProps<T extends ReleaseActionTypes = any> {
 export interface ReleaseActionQueryOptions {
   /** Find Release Actions by using a comma-separated list of Ids */
   'sys.id[in]'?: string
+  'sys.release.sys.id[in]'?: string
+  'sys.status[in]'?: string
+  'sys.status[nin]'?: string
+  action?: ReleaseActionTypes
+  /** Get unique results by this field. Currently supports `sys.release.sys.id` */
+  uniqueBy?: string
+
+  /** @default -sys.updatedAt */
+  order?: string
   /**
    * Limit of how many records are returned in the query result
    * @default 100
@@ -41,7 +50,7 @@ export interface ReleaseActionApiMethods {
   /** Performs a new GET request and returns the wrapper Release */
   get(): ReleaseAction
   /** Waits until the Release Action has either succeeded or failed */
-  waitProcessing(options?: AsyncActionProcessingOptions): ReleaseActionProps
+  waitProcessing(options?: AsyncActionProcessingOptions): ReleaseAction
 }
 
 /**
@@ -70,8 +79,8 @@ function createReleaseActionApi(makeRequest: MakeRequest) {
     },
 
     /** Waits for a Release Action to complete */
-    async waitProcessing(options?: AsyncActionProcessingOptions): Promise<ReleaseActionProps> {
-      return pollAsyncActionStatus<ReleaseActionProps>(async () => this.get(), options)
+    async waitProcessing(options?: AsyncActionProcessingOptions): Promise<ReleaseAction> {
+      return pollAsyncActionStatus<ReleaseAction>(async () => this.get(), options)
     },
   }
 }

--- a/lib/entities/release.ts
+++ b/lib/entities/release.ts
@@ -14,7 +14,7 @@ import {
 import { wrapCursorPaginatedCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 import { AsyncActionProcessingOptions } from '../methods/action'
-import { ReleaseActionProps, wrapReleaseAction } from './release-action'
+import { ReleaseAction, wrapReleaseAction } from './release-action'
 
 /** Entity types supported by the Release API */
 type Entity = 'Entry' | 'Asset'
@@ -120,9 +120,9 @@ export interface ReleaseApiMethods {
   /** Deletes a Release and all ReleaseActions linked to it (non-reversible) */
   delete(): Promise<void>
   /** Publishes a Release and waits until the asynchronous action is completed */
-  publish(options?: AsyncActionProcessingOptions): Promise<ReleaseActionProps<'publish'>>
+  publish(options?: AsyncActionProcessingOptions): Promise<ReleaseAction<'publish'>>
   /** Unpublishes a Release and waits until the asynchronous action is completed */
-  unpublish(options?: AsyncActionProcessingOptions): Promise<ReleaseActionProps<'unpublish'>>
+  unpublish(options?: AsyncActionProcessingOptions): Promise<ReleaseAction<'unpublish'>>
   /** Validates a Release and waits until the asynchronous action is completed */
   validate({
     payload,
@@ -130,7 +130,7 @@ export interface ReleaseApiMethods {
   }?: {
     payload?: ReleaseValidatePayload
     options?: AsyncActionProcessingOptions
-  }): Promise<ReleaseActionProps<'validate'>>
+  }): Promise<ReleaseAction<'validate'>>
 }
 
 /**

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -551,6 +551,9 @@ export type PlainClientAPI = {
     get(
       params: OptionalDefaults<GetReleaseParams> & { actionId: string }
     ): Promise<ReleaseActionProps>
+    getMany(
+      params: OptionalDefaults<GetSpaceEnvironmentParams> & { query: ReleaseActionQueryOptions }
+    ): Promise<CollectionProp<ReleaseActionProps>>
     queryForRelease(
       params: OptionalDefaults<GetReleaseParams> & { query?: ReleaseActionQueryOptions }
     ): Promise<CollectionProp<ReleaseActionProps>>

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -552,7 +552,7 @@ export type PlainClientAPI = {
       params: OptionalDefaults<GetReleaseParams> & { actionId: string }
     ): Promise<ReleaseActionProps>
     getMany(
-      params: OptionalDefaults<GetSpaceEnvironmentParams> & { query: ReleaseActionQueryOptions }
+      params: OptionalDefaults<GetSpaceEnvironmentParams> & { query?: ReleaseActionQueryOptions }
     ): Promise<CollectionProp<ReleaseActionProps>>
     queryForRelease(
       params: OptionalDefaults<GetReleaseParams> & { query?: ReleaseActionQueryOptions }

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -257,6 +257,7 @@ export const createPlainClient = (
     },
     releaseAction: {
       get: wrap(wrapParams, 'ReleaseAction', 'get'),
+      getMany: wrap(wrapParams, 'ReleaseAction', 'getMany'),
       queryForRelease: wrap(wrapParams, 'ReleaseAction', 'queryForRelease'),
     },
     role: {

--- a/test/integration/environment-integration.js
+++ b/test/integration/environment-integration.js
@@ -23,31 +23,22 @@ describe('Environment Api', function () {
   test('creates an environment', async () => {
     const envName = 'test-env'
 
-    return space
-      .createEnvironment({ name: envName })
-      .then(async (env) => {
-        await waitForEnvironmentToBeReady(space, env)
-        return env
-      })
-      .then((response) => {
-        expect(response.sys.type).equals('Environment', 'env is created')
-        expect(response.name).equals(envName, 'env is created with name')
-      })
+    const environment = await space.createEnvironment({ name: envName })
+    await waitForEnvironmentToBeReady(space, environment)
+
+    expect(environment.sys.type).equals('Environment', 'env is created')
+    expect(environment.name).equals(envName, 'env is created with name')
   })
 
   test('creates an environment with an id', async () => {
     const envName = 'env-name'
     const envId = generateRandomId('env')
-    return space
-      .createEnvironmentWithId(envId, { name: envName })
-      .then(async (env) => {
-        await waitForEnvironmentToBeReady(space, env)
-        return env
-      })
-      .then((response) => {
-        expect(response.sys.type).equals('Environment', 'env is created')
-        expect(response.name).equals(envName, 'env was created with correct name')
-        expect(response.sys.id).equals(envId, 'env was created with correct id')
-      })
+
+    const environment = await space.createEnvironmentWithId(envId, { name: envName })
+    await waitForEnvironmentToBeReady(space, environment)
+
+    expect(environment.sys.type).equals('Environment', 'env is created')
+    expect(environment.name).equals(envName, 'env was created with correct name')
+    expect(environment.sys.id).equals(envId, 'env was created with correct id')
   })
 })

--- a/test/integration/release-action-integration.ts
+++ b/test/integration/release-action-integration.ts
@@ -53,8 +53,8 @@ describe('ReleaseAction Api', async () => {
     }
 
     ;[testRelease, testRelease2] = await Promise.all([
-      await testEnvironment.createRelease(releasePayload),
-      await testEnvironment.createRelease(releasePayload),
+      testEnvironment.createRelease(releasePayload),
+      testEnvironment.createRelease(releasePayload),
     ])
 
     /**

--- a/test/integration/release-action-integration.ts
+++ b/test/integration/release-action-integration.ts
@@ -104,18 +104,6 @@ describe('ReleaseAction Api', async () => {
       }
     })
 
-    test('Get ReleaseActions (deprecated param `releaseId`)', async () => {
-      const queryLimit = 1
-      const queryResult = await testEnvironment.getReleaseActions({
-        query: { limit: queryLimit },
-        releaseId: testRelease.sys.id,
-      })
-
-      // Returns the filtered results based on the limit
-      expect(queryResult.items.length).to.eql(queryLimit)
-      expect(queryResult.items[0].sys.release.sys.id).to.eql(testRelease.sys.id)
-    })
-
     test('Get ReleaseActions with query options', async () => {
       const queryLimit = 1
       const queryResult = await testEnvironment.getReleaseActions({

--- a/test/integration/release-action-integration.ts
+++ b/test/integration/release-action-integration.ts
@@ -1,46 +1,87 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from 'chai'
-import { before, describe, test, after } from 'mocha'
+import { before, describe, test } from 'mocha'
 import { Environment } from '../../lib/entities/environment'
-import { Release } from '../../lib/entities/release'
+import { Release, ReleasePayload } from '../../lib/entities/release'
+import { ReleaseAction } from '../../lib/entities/release-action'
 import { Space } from '../../lib/entities/space'
 import { TestDefaults } from '../defaults'
-import { getDefaultSpace } from '../helpers'
+import { createTestSpace, initClient, initPlainClient } from '../helpers'
 import { makeLink } from '../utils'
 
-describe('ReleaseAction Api', async function () {
+describe('ReleaseAction Api', async () => {
   let testSpace: Space
   let testEnvironment: Environment
   let testRelease: Release
+  let testRelease2: Release
+
+  let testReleaseAction: ReleaseAction
+  let testReleaseAction2: ReleaseAction
 
   before(async () => {
-    testSpace = await getDefaultSpace()
+    testSpace = (await createTestSpace(initClient(), 'Release Actions')) as unknown as Space
     testEnvironment = await testSpace.getEnvironment('master')
-    testRelease = await testEnvironment.createRelease({
+
+    const contentType = await testEnvironment.createContentTypeWithId('testContentType', {
+      name: 'testContentType',
+      fields: [
+        {
+          id: 'title',
+          name: 'Title',
+          localized: false,
+          required: false,
+          type: 'Symbol',
+        },
+      ],
+    })
+    await contentType.publish()
+    await testEnvironment.createEntryWithId(
+      'testContentType',
+      TestDefaults.entry.testEntryReleasesId,
+      {
+        fields: {
+          title: { 'en-US': 'Non-localized value' },
+        },
+      }
+    )
+
+    const releasePayload: ReleasePayload = {
       title: 'Release (test)',
       entities: {
         sys: { type: 'Array' },
         items: [makeLink('Entry', TestDefaults.entry.testEntryReleasesId)],
       },
-    })
-  })
+    }
 
-  after(async () => {
-    await testEnvironment.deleteRelease(testRelease.sys.id)
+    ;[testRelease, testRelease2] = await Promise.all([
+      await testEnvironment.createRelease(releasePayload),
+      await testEnvironment.createRelease(releasePayload),
+    ])
+
+    /**
+     * @summary Runs 2 Release Actions (validations) since we can only
+     * run 2 per minute per environment (backend limitation).
+     * **/
+    testReleaseAction = await testRelease.validate()
+    testReleaseAction2 = await testRelease2.validate()
   })
 
   describe('Read', () => {
     test('Get ReleaseAction', async () => {
-      const action = await testEnvironment.validateRelease({
-        releaseId: testRelease.sys.id,
-      })
-
       const releaseAction = await testEnvironment.getReleaseAction({
-        actionId: action.sys.id,
+        actionId: testReleaseAction.sys.id,
         releaseId: testRelease.sys.id,
       })
 
-      expect(releaseAction.sys.id).to.eql(action.sys.id)
+      expect(releaseAction.sys.id).to.eql(testReleaseAction.sys.id)
+    })
+
+    test('Get ReleaseAction with another release ID', async () => {
+      const releaseAction = await testEnvironment.getReleaseAction({
+        actionId: testReleaseAction2.sys.id,
+        releaseId: testRelease2.sys.id,
+      })
+
+      expect(releaseAction.sys.id).to.eql(testReleaseAction2.sys.id)
     })
 
     test('Get ReleaseAction with an incorrect ID', async () => {
@@ -63,9 +104,7 @@ describe('ReleaseAction Api', async function () {
       }
     })
 
-    test('Get ReleaseActions', async () => {
-      await testRelease.validate()
-
+    test('Get ReleaseActions (deprecated param `releaseId`)', async () => {
       const queryLimit = 1
       const queryResult = await testEnvironment.getReleaseActions({
         query: { limit: queryLimit },
@@ -74,6 +113,61 @@ describe('ReleaseAction Api', async function () {
 
       // Returns the filtered results based on the limit
       expect(queryResult.items.length).to.eql(queryLimit)
+      expect(queryResult.items[0].sys.release.sys.id).to.eql(testRelease.sys.id)
+    })
+
+    test('Get ReleaseActions with query options', async () => {
+      const queryLimit = 1
+      const queryResult = await testEnvironment.getReleaseActions({
+        query: {
+          'sys.release.sys.id[in]': testRelease2.sys.id,
+          limit: queryLimit,
+          order: 'sys.updatedAt',
+          action: 'validate',
+        },
+      })
+
+      // Returns the filtered results based on the limit
+      expect(queryResult.items.length).to.eql(queryLimit)
+      expect(queryResult.items[0].sys.release.sys.id).to.eql(testRelease2.sys.id)
+    })
+  })
+
+  describe('PlainClient API', () => {
+    test('releaseAction.getMany', async () => {
+      const defaultParams = {
+        environmentId: testEnvironment.sys.id,
+        spaceId: testSpace.sys.id,
+      }
+
+      const plainClient = initPlainClient(defaultParams)
+
+      const queryResult = await plainClient.releaseAction.getMany({
+        query: { 'sys.release.sys.id[in]': testRelease.sys.id, limit: 1, action: 'validate' },
+      })
+
+      // Returns the filtered results based on the limit
+      expect(queryResult.items.length).to.eql(1)
+      expect(queryResult.items[0].sys.release.sys.id).to.eql(testRelease.sys.id)
+    })
+
+    test('releaseAction.get', async () => {
+      const defaultParams = {
+        environmentId: testEnvironment.sys.id,
+        spaceId: testSpace.sys.id,
+      }
+
+      const plainClient = initPlainClient(defaultParams)
+
+      const queryResult = await plainClient.releaseAction.get({
+        releaseId: testRelease.sys.id,
+        actionId: testReleaseAction.sys.id,
+      })
+
+      // Returns the filtered results based on the limit
+      expect(queryResult.action).to.eql('validate')
+      expect(queryResult.sys.id).to.eql(testReleaseAction.sys.id)
+      expect(queryResult.sys.release.sys.id).to.eql(testRelease.sys.id)
     })
   })
 })

--- a/test/integration/task-integration.js
+++ b/test/integration/task-integration.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { before, describe, test, after } from 'mocha'
-import { initClient, createTestEnvironment, createTestSpace, getTestUser } from '../helpers'
+import { initClient, createTestSpace, getTestUser, waitForEnvironmentToBeReady } from '../helpers'
 
 describe('Task Api', () => {
   let space
@@ -16,7 +16,8 @@ describe('Task Api', () => {
 
   before(async () => {
     space = await createTestSpace(initClient(), 'Task')
-    environment = await createTestEnvironment(space, 'Task Testing Environment')
+    environment = await space.createEnvironment({ name: 'Task Testing Environment' })
+    await waitForEnvironmentToBeReady(space, environment)
     const contentType = await environment.createContentType({ name: 'Content Type' })
     await contentType.publish()
     entry = await environment.createEntry(contentType.sys.id, { fields: {} })


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Adds support for the new `GET /release_actions` endpoint, that is replacing the existing `GET /releases/:id/actions`
This new endpoint supports querying for multiple releases, actions or specific properties.

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

- Change the usage of `/releases/:id/actions` to use the new `/release_actions` endpoint
- Add deprecation notice for passing `releaseId` instead of `query { 'sys.release.sys.id[in]`: ... } `
- Add specs covering new query params

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
