### PR TITLE
fix(tests): add wait for environment creation function to prevent flaky tests []

### DIFF
--- a/test/integration/app-signed-request-integration.ts
+++ b/test/integration/app-signed-request-integration.ts
@@ -6,6 +6,7 @@ import {
   createTestEnvironment,
   getTestOrganization,
   createTestSpace,
+  waitForEnvironmentToBeReady,
 } from '../helpers'
 
 describe('AppSignedRequest api', function () {
@@ -32,6 +33,7 @@ describe('AppSignedRequest api', function () {
 
     space = await createTestSpace(initClient(), 'SignedRequest')
     environment = await createTestEnvironment(space, 'Testing Environment')
+    await waitForEnvironmentToBeReady(space, environment)
     appInstallation = await environment.createAppInstallation(appDefinition.sys.id, {})
   })
 

--- a/test/integration/comment-integration.js
+++ b/test/integration/comment-integration.js
@@ -1,6 +1,11 @@
 import { expect } from 'chai'
 import { before, describe, test, after } from 'mocha'
-import { initClient, createTestEnvironment, createTestSpace } from '../helpers'
+import {
+  initClient,
+  createTestEnvironment,
+  createTestSpace,
+  waitForEnvironmentToBeReady,
+} from '../helpers'
 
 describe('Comment Api', () => {
   let space
@@ -11,6 +16,7 @@ describe('Comment Api', () => {
   before(async () => {
     space = await createTestSpace(initClient(), 'Comment')
     environment = await createTestEnvironment(space, 'Comment Testing Environment')
+    await waitForEnvironmentToBeReady(space, environment)
     const contentType = await environment.createContentType({ name: 'Content Type' })
     await contentType.publish()
     entry = await environment.createEntry(contentType.sys.id, { fields: {} })

--- a/test/integration/content-type-integration.js
+++ b/test/integration/content-type-integration.js
@@ -6,6 +6,7 @@ import {
   createTestSpace,
   generateRandomId,
   getDefaultSpace,
+  waitForEnvironmentToBeReady,
 } from '../helpers'
 
 describe('ContentType Api', async function () {
@@ -22,6 +23,7 @@ describe('ContentType Api', async function () {
 
     writeSpace = await createTestSpace(initClient(), 'ContentType')
     writeEnvironment = await createTestEnvironment(writeSpace, 'Testing Environment')
+    await waitForEnvironmentToBeReady(writeSpace, writeEnvironment)
   })
 
   after(async () => {

--- a/test/integration/entry-integration.js
+++ b/test/integration/entry-integration.js
@@ -6,6 +6,7 @@ import {
   createTestSpace,
   generateRandomId,
   getDefaultSpace,
+  waitForEnvironmentToBeReady,
 } from '../helpers'
 
 describe('Entry Api', () => {
@@ -301,6 +302,7 @@ describe('Entry Api', () => {
     before(async () => {
       space = await createTestSpace(initClient(), 'Entry')
       environment = await createTestEnvironment(space, 'Testing Environment')
+      await waitForEnvironmentToBeReady(space, environment)
     })
 
     after(async () => {

--- a/test/integration/locale-integration.js
+++ b/test/integration/locale-integration.js
@@ -1,5 +1,10 @@
 import { after, before, describe, test } from 'mocha'
-import { initClient, createTestEnvironment, createTestSpace } from '../helpers'
+import {
+  initClient,
+  createTestEnvironment,
+  createTestSpace,
+  waitForEnvironmentToBeReady,
+} from '../helpers'
 import { expect } from 'chai'
 
 describe('Locale Api', function () {
@@ -9,6 +14,7 @@ describe('Locale Api', function () {
   before(async () => {
     space = await createTestSpace(initClient(), 'Locale')
     environment = await createTestEnvironment(space, 'Test')
+    await waitForEnvironmentToBeReady(space, environment)
   })
 
   after(async () => {

--- a/test/integration/ui-extension-integration.js
+++ b/test/integration/ui-extension-integration.js
@@ -1,5 +1,10 @@
 import { after, before, describe, test } from 'mocha'
-import { initClient, createTestEnvironment, createTestSpace } from '../helpers'
+import {
+  initClient,
+  createTestEnvironment,
+  createTestSpace,
+  waitForEnvironmentToBeReady,
+} from '../helpers'
 import { expect } from 'chai'
 
 describe('Extension api', function () {
@@ -9,6 +14,7 @@ describe('Extension api', function () {
   before(async () => {
     space = await createTestSpace(initClient(), 'TSM')
     environment = await createTestEnvironment(space, 'Test')
+    await waitForEnvironmentToBeReady(space, environment)
   })
 
   after(async () => {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

- adds `waitForEnvironmentToBeReady` to most tests that are using `createEnvironment`

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
