### PR TITLE
fix: add browser field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Client for Contentful's Content Management API",
   "homepage": "https://www.contentful.com/developers/documentation/content-management-api/",
   "main": "./dist/contentful-management.node.js",
+  "browser": "./dist/contentful-management.browser.js",
   "types": "./dist/typings/contentful-management.d.ts",
   "module": "./dist/es-modules/contentful-management.js",
   "engines": {


### PR DESCRIPTION
## Summary

Add `browser` field to `package.json`.

Any reason why this wasn't done before?

## Motivation and Context

When using contentful-management in browser context without esm support, the node bundle is used. This bundle requires native node libraries that are not available in the browser. For that reason you cannot use CMA.js in stackblitz: https://stackblitz.com/edit/js-u7mabv

By adding the `browser` field, the correct bundle (should) be selected and stackblitz should work correctly.

https://docs.npmjs.com/cli/v7/configuring-npm/package-json#browser

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

