### PR TITLE
fix(ApiAppActionCategories):  export the actual type [EXT-3618]

### DIFF
--- a/lib/entities/app-action.ts
+++ b/lib/entities/app-action.ts
@@ -13,15 +13,15 @@ type AppActionSys = Except<BasicMetaSysProps, 'version'> & {
 
 export type AppActionParameterDefinition = Omit<ParameterDefinition, 'labels'>
 
-export enum AppActionCategory {
+export enum AppActionCategoryType {
   EntryListV1Beta = 'EntryList.v1.0-beta',
   NotificationV1Beta = 'Notification.v1.0-beta',
   Custom = 'Custom',
 }
 
-export type ApiAppActionCategory = {
+export type AppActionCategory = {
   sys: {
-    id: AppActionCategory
+    id: AppActionCategoryType
     type: 'AppActionCategory'
     version: string
   }
@@ -34,14 +34,14 @@ type BuiltInCategoriesProps = {
   /**
    * Category identifying the shape of the action.
    */
-  category: AppActionCategory.EntryListV1Beta | AppActionCategory.NotificationV1Beta
+  category: AppActionCategoryType.EntryListV1Beta | AppActionCategoryType.NotificationV1Beta
 }
 
 type CustomAppActionProps = {
   /**
    * "Custom" category requires "parameters"
    */
-  category: AppActionCategory.Custom
+  category: AppActionCategoryType.Custom
   parameters: AppActionParameterDefinition[]
 }
 

--- a/lib/entities/app-action.ts
+++ b/lib/entities/app-action.ts
@@ -19,6 +19,17 @@ export enum AppActionCategory {
   Custom = 'Custom',
 }
 
+export type ApiAppActionCategory = {
+  sys: {
+    id: AppActionCategory
+    type: 'AppActionCategory'
+    version: string
+  }
+  name: string
+  description: string
+  parameters?: AppActionParameterDefinition[]
+}
+
 type BuiltInCategoriesProps = {
   /**
    * Category identifying the shape of the action.

--- a/lib/entities/app-action.ts
+++ b/lib/entities/app-action.ts
@@ -19,7 +19,7 @@ export enum AppActionCategoryType {
   Custom = 'Custom',
 }
 
-export type AppActionCategory = {
+export type AppActionCategoryProps = {
   sys: {
     id: AppActionCategoryType
     type: 'AppActionCategory'
@@ -45,14 +45,14 @@ type CustomAppActionProps = {
   parameters: AppActionParameterDefinition[]
 }
 
-type AppActionCategoryProps = BuiltInCategoriesProps | CustomAppActionProps
+type AppActionCategory = BuiltInCategoriesProps | CustomAppActionProps
 
-export type CreateAppActionProps = AppActionCategoryProps & {
+export type CreateAppActionProps = AppActionCategory & {
   url: string
   name: string
 }
 
-export type AppActionProps = AppActionCategoryProps & {
+export type AppActionProps = AppActionCategory & {
   /**
    * System metadata
    */

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -5,8 +5,8 @@ export type {
   AppActionProps,
   CreateAppActionProps,
   AppActionParameterDefinition,
+  AppActionCategoryType,
   AppActionCategory,
-  ApiAppActionCategory,
 } from './entities/app-action'
 export type {
   AppActionCall,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -6,6 +6,7 @@ export type {
   CreateAppActionProps,
   AppActionParameterDefinition,
   AppActionCategory,
+  ApiAppActionCategory,
 } from './entities/app-action'
 export type {
   AppActionCall,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -6,7 +6,7 @@ export type {
   CreateAppActionProps,
   AppActionParameterDefinition,
   AppActionCategoryType,
-  AppActionCategory,
+  AppActionCategoryProps,
 } from './entities/app-action'
 export type {
   AppActionCall,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16715,9 +16715,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3297,9 +3297,9 @@
       "dev": true
     },
     "axios": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.1.tgz",
-      "integrity": "sha512-ePNMai55xo5GsXajb/k756AqZqpqeDaGwGcdvbZLSSELbbYwsIn2jNmGfUPEwd8j/yu4OoMstLLIVa4t0MneEA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "requires": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2297,9 +2297,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
-      "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
+      "version": "17.0.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.30.tgz",
+      "integrity": "sha512-oNBIZjIqyHYP8VCNAV9uEytXVeXG2oR0w9lgAXro20eugRQfY002qr3CUl6BAe+Yf/z3CRjPdz27Pu6WWtuSRw==",
       "dev": true
     },
     "@types/normalize-package-data": {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

forgot to expose the new type in #1328  🤦🏾 

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
