### PR TITLE
feat: added isLocked to WorkflowDefinitionSysProps

### DIFF
--- a/lib/entities/workflow-definition.ts
+++ b/lib/entities/workflow-definition.ts
@@ -101,6 +101,7 @@ export type WorkflowDefinitionSysProps = Pick<
   type: 'WorkflowDefinition'
   space: SysLink
   environment: SysLink
+  isLocked: boolean
 }
 
 export type WorkflowDefinitionValidationLink = {

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -722,6 +722,7 @@ export const workflowDefinitionMock = {
     type: 'WorkflowDefinition',
     version: 1,
     environment: makeLink('Environment', 'master'),
+    isLocked: false,
   }),
   name: 'Test WorkflowDefinition',
   description: 'this is a definition of a workflow',


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

- To indicate that a workflow is locked and adjust the layout, we need to add the `isLocked` field to the SDK.
- Updated tests
