### PR TITLE
feat: [] add app action list for env

### DIFF
--- a/lib/adapters/REST/endpoints/app-action.ts
+++ b/lib/adapters/REST/endpoints/app-action.ts
@@ -3,11 +3,9 @@ import * as raw from './raw'
 import { normalizeSelect } from './utils'
 import {
   CollectionProp,
-  GetAppActionCallParams,
   GetAppActionParams,
   GetAppDefinitionParams,
   GetSpaceEnvironmentParams,
-  GetSpaceParams,
   QueryParams,
 } from '../../../common-types'
 import { RestEndpoint } from '../types'

--- a/lib/adapters/REST/endpoints/app-action.ts
+++ b/lib/adapters/REST/endpoints/app-action.ts
@@ -4,8 +4,8 @@ import { normalizeSelect } from './utils'
 import {
   CollectionProp,
   GetAppActionParams,
+  GetAppActionsForEnvParams,
   GetAppDefinitionParams,
-  GetSpaceEnvironmentParams,
   QueryParams,
 } from '../../../common-types'
 import { RestEndpoint } from '../types'
@@ -17,8 +17,12 @@ const getBaseUrl = (params: GetAppDefinitionParams) =>
 const getAppActionUrl = (params: GetAppActionParams) =>
   `${getBaseUrl(params)}/${params.appActionId}`
 
-const getAppActionsEnvUrl = (params: GetSpaceEnvironmentParams) =>
-  `/spaces/${params.spaceId}/environments/${params.environmentId}/actions`
+const getAppActionsEnvUrl = (params: GetAppActionsForEnvParams) => {
+  if (params.environmentId) {
+    return `/spaces/${params.spaceId}/environments/${params.environmentId}/actions`
+  }
+  return `/spaces/${params.spaceId}/actions`
+}
 
 export const get: RestEndpoint<'AppAction', 'get'> = (
   http: AxiosInstance,
@@ -38,7 +42,7 @@ export const getMany: RestEndpoint<'AppAction', 'getMany'> = (
 
 export const getManyForEnvironment: RestEndpoint<'AppAction', 'getManyForEnvironment'> = (
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & QueryParams
+  params: GetAppActionsForEnvParams & QueryParams
 ) => {
   return raw.get<CollectionProp<AppActionProps>>(http, getAppActionsEnvUrl(params), {
     params: normalizeSelect(params.query),

--- a/lib/adapters/REST/endpoints/app-action.ts
+++ b/lib/adapters/REST/endpoints/app-action.ts
@@ -3,8 +3,11 @@ import * as raw from './raw'
 import { normalizeSelect } from './utils'
 import {
   CollectionProp,
+  GetAppActionCallParams,
   GetAppActionParams,
   GetAppDefinitionParams,
+  GetSpaceEnvironmentParams,
+  GetSpaceParams,
   QueryParams,
 } from '../../../common-types'
 import { RestEndpoint } from '../types'
@@ -15,6 +18,9 @@ const getBaseUrl = (params: GetAppDefinitionParams) =>
 
 const getAppActionUrl = (params: GetAppActionParams) =>
   `${getBaseUrl(params)}/${params.appActionId}`
+
+const getAppActionsEnvUrl = (params: GetSpaceEnvironmentParams) =>
+  `/spaces/${params.spaceId}/environments/${params.environmentId}/actions`
 
 export const get: RestEndpoint<'AppAction', 'get'> = (
   http: AxiosInstance,
@@ -28,6 +34,15 @@ export const getMany: RestEndpoint<'AppAction', 'getMany'> = (
   params: GetAppDefinitionParams & QueryParams
 ) => {
   return raw.get<CollectionProp<AppActionProps>>(http, getBaseUrl(params), {
+    params: normalizeSelect(params.query),
+  })
+}
+
+export const getManyForEnvironment: RestEndpoint<'AppAction', 'getManyForEnvironment'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams & QueryParams
+) => {
+  return raw.get<CollectionProp<AppActionProps>>(http, getAppActionsEnvUrl(params), {
     params: normalizeSelect(params.query),
   })
 }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -605,7 +605,7 @@ export type MRActions = {
       return: CollectionProp<AppActionProps>
     }
     getManyForEnvironment: {
-      params: GetAppDefinitionParams & QueryParams
+      params: GetSpaceEnvironmentParams & QueryParams
       return: CollectionProp<AppActionProps>
     }
     delete: { params: GetAppActionParams; return: void }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -604,6 +604,10 @@ export type MRActions = {
       params: GetAppDefinitionParams & QueryParams
       return: CollectionProp<AppActionProps>
     }
+    getManyForEnvironment: {
+      params: GetAppDefinitionParams & QueryParams
+      return: CollectionProp<AppActionProps>
+    }
     delete: { params: GetAppActionParams; return: void }
     create: {
       params: GetAppDefinitionParams

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -601,11 +601,11 @@ export type MRActions = {
   AppAction: {
     get: { params: GetAppActionParams; return: AppActionProps }
     getMany: {
-      params: GetAppActionsForEnvParams & QueryParams
+      params: GetAppDefinitionParams & QueryParams
       return: CollectionProp<AppActionProps>
     }
     getManyForEnvironment: {
-      params: GetSpaceEnvironmentParams & QueryParams
+      params: GetAppActionsForEnvParams & QueryParams
       return: CollectionProp<AppActionProps>
     }
     delete: { params: GetAppActionParams; return: void }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -601,7 +601,7 @@ export type MRActions = {
   AppAction: {
     get: { params: GetAppActionParams; return: AppActionProps }
     getMany: {
-      params: GetAppDefinitionParams & QueryParams
+      params: GetAppActionsForEnvParams & QueryParams
       return: CollectionProp<AppActionProps>
     }
     getManyForEnvironment: {
@@ -1524,6 +1524,7 @@ export interface MakeRequestOptions {
 }
 
 export type GetAppActionParams = GetAppDefinitionParams & { appActionId: string }
+export type GetAppActionsForEnvParams = GetSpaceParams & { environmentId?: string }
 export type GetAppActionCallParams = GetAppInstallationParams & { appActionId: string }
 export type GetAppBundleParams = GetAppDefinitionParams & { appBundleId: string }
 export type GetAppDefinitionParams = GetOrganizationParams & { appDefinitionId: string }

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -171,6 +171,9 @@ export type PlainClientAPI = {
     getMany(
       params: OptionalDefaults<GetAppDefinitionParams & QueryParams>
     ): Promise<CollectionProp<AppActionProps>>
+    getManyForEnvironment(
+      params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>
+    ): Promise<CollectionProp<AppActionProps>>
     delete(params: OptionalDefaults<GetAppActionParams>): Promise<void>
     create(
       params: OptionalDefaults<GetAppDefinitionParams>,

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -36,6 +36,7 @@ import {
   GetEntryParams,
   CursorPaginatedCollectionProp,
   GetWorkflowDefinitionParams,
+  GetAppActionsForEnvParams,
 } from '../common-types'
 import { ApiKeyProps, CreateApiKeyProps } from '../entities/api-key'
 import {
@@ -172,7 +173,7 @@ export type PlainClientAPI = {
       params: OptionalDefaults<GetAppDefinitionParams & QueryParams>
     ): Promise<CollectionProp<AppActionProps>>
     getManyForEnvironment(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>
+      params: OptionalDefaults<GetAppActionsForEnvParams & QueryParams>
     ): Promise<CollectionProp<AppActionProps>>
     delete(params: OptionalDefaults<GetAppActionParams>): Promise<void>
     create(

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -62,6 +62,7 @@ export const createPlainClient = (
     appAction: {
       get: wrap(wrapParams, 'AppAction', 'get'),
       getMany: wrap(wrapParams, 'AppAction', 'getMany'),
+      getManyForEnvironment: wrap(wrapParams, 'AppAction', 'getManyForEnvironment'),
       delete: wrap(wrapParams, 'AppAction', 'delete'),
       create: wrap(wrapParams, 'AppAction', 'create'),
       update: wrap(wrapParams, 'AppAction', 'update'),

--- a/test/integration/app-action-integration.ts
+++ b/test/integration/app-action-integration.ts
@@ -69,7 +69,6 @@ describe('AppAction api', function () {
 
     const actions = await client.appAction.getManyForEnvironment({
       spaceId: space.sys.id,
-      environmentId: 'master',
     })
 
     expect(actions.items.length).equals(1)


### PR DESCRIPTION
Adds the method for listing all app actions of an environment. 

url: `/spaces/:sid/environments/:env_id/actions`

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
