### PR TITLE
feat(workflow-definitions): support new property WorkflowDefinition.startOnEntityCreation and improve type exports

### DIFF
--- a/lib/entities/workflow-definition.ts
+++ b/lib/entities/workflow-definition.ts
@@ -51,16 +51,16 @@ export type WorkflowStepAction =
   | WorkflowStepTaskAction
   | WorkflowStepAppAction
 
-type EmailActionRecipient = string | Link<'User'> | Link<'Team'>
+export type WorkflowStepEmailActionRecipient = string | Link<'User'> | Link<'Team'>
 
-type WorkflowStepEmailAction = {
+export type WorkflowStepEmailAction = {
   type: 'email'
   configuration: {
-    recipients: EmailActionRecipient[]
+    recipients: WorkflowStepEmailActionRecipient[]
   }
 }
 
-type WorkflowStepTaskAction = {
+export type WorkflowStepTaskAction = {
   type: 'task'
   configuration: {
     assignee: Link<'User'> | Link<'Team'>
@@ -69,7 +69,7 @@ type WorkflowStepTaskAction = {
   }
 }
 
-type WorkflowStepAppAction = {
+export type WorkflowStepAppAction = {
   type: 'app'
   appId: string
   appActionId: string
@@ -118,6 +118,7 @@ export type WorkflowDefinitionProps = {
   description?: string
   appliesTo?: WorkflowDefinitionValidationLink[]
   steps: WorkflowStepProps[]
+  startOnEntityCreation?: boolean
 }
 
 export type CreateWorkflowDefinitionProps = Omit<WorkflowDefinitionProps, 'sys' | 'steps'> & {

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -179,17 +179,43 @@ export type {
   UpdateWebhookProps,
 } from './entities/webhook'
 export type {
+  // General typings (props, params, options)
   WorkflowDefinition,
+  WorkflowDefinitionSysProps,
   WorkflowDefinitionProps,
   CreateWorkflowDefinitionProps,
   UpdateWorkflowDefinitionProps,
+  CreateWorkflowDefinitionParams,
+  UpdateWorkflowDefinitionParams,
+  DeleteWorkflowDefinitionParams,
+  WorkflowStepProps,
+  UpdateWorkflowStepProps,
+  CreateWorkflowStepProps,
   WorkflowDefinitionQueryOptions,
+  // Property: appliesTo
+  WorkflowDefinitionValidationLink,
+  // Property: step.actions
+  WorkflowStepAction,
+  WorkflowStepActionType,
+  // Property: step.permissions
+  WorkflowStepPermission,
+  WorkflowStepPermissionType,
+  WorkflowStepPermissionAction,
+  WorkflowStepPermissionEffect,
+  WorkflowStepPermissionActors,
+  WorkflowStepEmailActionRecipient,
+  WorkflowStepEmailAction,
+  WorkflowStepTaskAction,
+  WorkflowStepAppAction,
 } from './entities/workflow-definition'
 export type {
   Workflow,
   WorkflowProps,
   CreateWorkflowProps,
   UpdateWorkflowProps,
+  CreateWorkflowParams,
+  UpdateWorkflowParams,
+  DeleteWorkflowParams,
   WorkflowQueryOptions,
 } from './entities/workflow'
 export type {


### PR DESCRIPTION
## Summary

We invent the new property `startOnEntityCreation` to the workflow definition entity.

## Description

We now support the new prop for workflow definitions. Besides that, I also added all types and enums to the export that might be used. 

## Motivation and Context

Currently, our workflows app is missing many of them and needs to define them on its own.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
