### PR TITLE
fix: typo in error message of 'AssetProcessingTimeout'

### DIFF
--- a/lib/adapters/REST/endpoints/asset.ts
+++ b/lib/adapters/REST/endpoints/asset.ts
@@ -224,7 +224,7 @@ function checkIfAssetHasUrl(
     } else if (checkCount === processingCheckRetries) {
       const error = new Error()
       error.name = 'AssetProcessingTimeout'
-      error.message = 'Asset is taking longer then expected to process.'
+      error.message = 'Asset is taking longer than expected to process.'
       reject(error)
     } else {
       checkCount++


### PR DESCRIPTION
## Summary

fix: typo in error message of 'AssetProcessingTimeout'

## Description

'Asset is taking longer then expected to process.'

should be

'Asset is taking longer than expected to process.'

...it's 'THAN' (comparison), not 'THEN' (meaning 'after which').
