### PR TITLE
feat: [EXT-3864] add home to app locations

### DIFF
--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -22,6 +22,7 @@ type LocationType =
   | 'dialog'
   | 'page'
   | 'entry-list'
+  | 'home'
 
 export interface SimpleLocation {
   location: LocationType


### PR DESCRIPTION
## Summary

We need to allow 'home' to be passed as a location when creating a new app definition. This will allow users to create app definitions that can be rendered in the new 'home' location, that we will be supporting from now on.

## Description

Update the app definition location type to include 'home'

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
