### PR TITLE
feat: add entry tasks params support [ZEND-2486]

### DIFF
--- a/lib/adapters/REST/endpoints/task.ts
+++ b/lib/adapters/REST/endpoints/task.ts
@@ -1,7 +1,13 @@
 import { AxiosInstance, AxiosRequestHeaders } from 'axios'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
-import { CollectionProp, GetEntryParams, GetTaskParams, QueryParams } from '../../../common-types'
+import {
+  CollectionProp,
+  GetEntryParams,
+  GetTaskParams,
+  PaginationQueryOptions,
+  QueryParams,
+} from '../../../common-types'
 import {
   CreateTaskParams,
   CreateTaskProps,
@@ -22,7 +28,7 @@ export const get: RestEndpoint<'Task', 'get'> = (http: AxiosInstance, params: Ge
 
 export const getMany: RestEndpoint<'Task', 'getMany'> = (
   http: AxiosInstance,
-  params: GetEntryParams & QueryParams
+  params: GetEntryParams & QueryParams & PaginationQueryOptions
 ) =>
   raw.get<CollectionProp<TaskProps>>(http, getBaseUrl(params), {
     params: normalizeSelect(params.query),

--- a/lib/create-entry-api.ts
+++ b/lib/create-entry-api.ts
@@ -432,12 +432,12 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    getTasks: function () {
+    getTasks: function (query = {}) {
       const { params } = getParams(this)
       return makeRequest({
         entityType: 'Task',
         action: 'getMany',
-        params,
+        params: { ...params, query },
       }).then((data) => wrapTaskCollection(makeRequest, data))
     },
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Add query parameters to the entry tasks endpoint.

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
