### PR TITLE
refactor: [EXT-3877] cma endpoint appInstallation: getForOrganization

### DIFF
--- a/lib/adapters/REST/endpoints/app-definition.ts
+++ b/lib/adapters/REST/endpoints/app-definition.ts
@@ -81,7 +81,7 @@ export const del: RestEndpoint<'AppDefinition', 'delete'> = (
 ) => {
   return raw.del(http, getAppDefinitionUrl(params))
 }
-
+//todo - remove it after change in merge app
 export const getInstallationsForOrg: RestEndpoint<'AppDefinition', 'getInstallationsForOrg'> = (
   http: AxiosInstance,
   params: GetAppInstallationsForOrgParams & PaginationQueryParams

--- a/lib/adapters/REST/endpoints/app-installation.ts
+++ b/lib/adapters/REST/endpoints/app-installation.ts
@@ -7,16 +7,23 @@ import {
   GetAppInstallationParams,
   GetSpaceEnvironmentParams,
   PaginationQueryParams,
+  GetAppInstallationsForOrgParams,
 } from '../../../common-types'
 import {
   AppInstallationProps,
   CreateAppInstallationProps,
 } from '../../../entities/app-installation'
+import { AppInstallationsForOrganizationProps } from '../../../entities/app-definition'
 import { CollectionProp } from '../../../common-types'
 import { RestEndpoint } from '../types'
 
 const getBaseUrl = (params: GetSpaceEnvironmentParams) =>
   `/spaces/${params.spaceId}/environments/${params.environmentId}/app_installations`
+
+const getBaseUrlForOrgInstallations = (params: GetAppInstallationsForOrgParams) =>
+  `/app_definitions/${params.appDefinitionId}/app_installations?sys.organization.sys.id[in]=${
+    params.organizationId || ''
+  }`
 
 export const getAppInstallationUrl = (params: GetAppInstallationParams) =>
   getBaseUrl(params) + `/${params.appDefinitionId}`
@@ -63,4 +70,17 @@ export const del: RestEndpoint<'AppInstallation', 'delete'> = (
   params: GetAppInstallationParams
 ) => {
   return raw.del(http, getAppInstallationUrl(params))
+}
+
+export const getForOrganization: RestEndpoint<'AppInstallation', 'getForOrganization'> = (
+  http: AxiosInstance,
+  params: GetAppInstallationsForOrgParams & PaginationQueryParams
+) => {
+  return raw.get<AppInstallationsForOrganizationProps>(
+    http,
+    getBaseUrlForOrgInstallations(params),
+    {
+      params: normalizeSelect(params.query),
+    }
+  )
 }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -710,6 +710,10 @@ export type MRActions = {
       return: AppInstallationProps
     }
     delete: { params: GetAppInstallationParams; return: any }
+    getForOrganization: {
+      params: GetOrganizationParams & { appDefinitionId: string }
+      return: AppInstallationsForOrganizationProps
+    }
   }
   AppUpload: {
     get: {

--- a/lib/create-app-definition-api.ts
+++ b/lib/create-app-definition-api.ts
@@ -172,7 +172,7 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
      *   accessToken: '<content_management_api_key>'
      * })
      * client.getAppDefinition('<organizationId>', '<appDefinitionId>')
-     * .then((appDefinition) => appDefinition.getInstallationsForOrg(<{organizationId: string, appDefinitionId: string}>))
+     * .then((appDefinition) => appDefinition.getInstallationsForOrg()
      * .then((appInstallationsForOrg) => console.log(appInstallationsForOrg.items))
      * .catch(console.error)
      * ```

--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -15,14 +15,7 @@ export interface NavigationItem {
   path: string
 }
 
-type LocationType =
-  | 'app-config'
-  | 'entry-sidebar'
-  | 'entry-editor'
-  | 'dialog'
-  | 'page'
-  | 'entry-list'
-  | 'home'
+type LocationType = 'app-config' | 'entry-sidebar' | 'entry-editor' | 'dialog' | 'page' | 'home'
 
 export interface SimpleLocation {
   location: LocationType

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -663,15 +663,18 @@ export type PlainClientAPI = {
       headers?: AxiosRequestHeaders
     ): Promise<AppDefinitionProps>
     delete(params: OptionalDefaults<GetAppDefinitionParams>): Promise<any>
-    getInstallationsForOrg(
-      params: OptionalDefaults<GetAppDefinitionParams>
-    ): Promise<AppInstallationsForOrganizationProps>
+    // getInstallationsForOrg(
+    //   params: OptionalDefaults<GetAppDefinitionParams>
+    // ): Promise<AppInstallationsForOrganizationProps>
   }
   appInstallation: {
     get(params: OptionalDefaults<GetAppInstallationParams>): Promise<AppInstallationProps>
     getMany(
       params: OptionalDefaults<GetSpaceEnvironmentParams & PaginationQueryParams>
     ): Promise<CollectionProp<AppInstallationProps>>
+    getForOrganization(
+      params: OptionalDefaults<GetAppDefinitionParams>
+    ): Promise<AppInstallationsForOrganizationProps>
     upsert(
       params: OptionalDefaults<GetAppInstallationParams>,
       rawData: CreateAppInstallationProps,

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -663,9 +663,9 @@ export type PlainClientAPI = {
       headers?: AxiosRequestHeaders
     ): Promise<AppDefinitionProps>
     delete(params: OptionalDefaults<GetAppDefinitionParams>): Promise<any>
-    // getInstallationsForOrg(
-    //   params: OptionalDefaults<GetAppDefinitionParams>
-    // ): Promise<AppInstallationsForOrganizationProps>
+    getInstallationsForOrg(
+      params: OptionalDefaults<GetAppDefinitionParams>
+    ): Promise<AppInstallationsForOrganizationProps>
   }
   appInstallation: {
     get(params: OptionalDefaults<GetAppInstallationParams>): Promise<AppInstallationProps>

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -294,11 +294,12 @@ export const createPlainClient = (
       create: wrap(wrapParams, 'AppDefinition', 'create'),
       update: wrap(wrapParams, 'AppDefinition', 'update'),
       delete: wrap(wrapParams, 'AppDefinition', 'delete'),
-      getInstallationsForOrg: wrap(wrapParams, 'AppDefinition', 'getInstallationsForOrg'),
+      // getInstallationsForOrg: wrap(wrapParams, 'AppDefinition', 'getInstallationsForOrg'),
     },
     appInstallation: {
       get: wrap(wrapParams, 'AppInstallation', 'get'),
       getMany: wrap(wrapParams, 'AppInstallation', 'getMany'),
+      getForOrganization: wrap(wrapParams, 'AppDefinition', 'getInstallationsForOrg'),
       upsert: wrap(wrapParams, 'AppInstallation', 'upsert'),
       delete: wrap(wrapParams, 'AppInstallation', 'delete'),
     },

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -294,12 +294,13 @@ export const createPlainClient = (
       create: wrap(wrapParams, 'AppDefinition', 'create'),
       update: wrap(wrapParams, 'AppDefinition', 'update'),
       delete: wrap(wrapParams, 'AppDefinition', 'delete'),
-      // getInstallationsForOrg: wrap(wrapParams, 'AppDefinition', 'getInstallationsForOrg'),
+      //todo - remove after change in merge app
+      getInstallationsForOrg: wrap(wrapParams, 'AppDefinition', 'getInstallationsForOrg'),
     },
     appInstallation: {
       get: wrap(wrapParams, 'AppInstallation', 'get'),
       getMany: wrap(wrapParams, 'AppInstallation', 'getMany'),
-      getForOrganization: wrap(wrapParams, 'AppDefinition', 'getInstallationsForOrg'),
+      getForOrganization: wrap(wrapParams, 'AppInstallation', 'getForOrganization'),
       upsert: wrap(wrapParams, 'AppInstallation', 'upsert'),
       delete: wrap(wrapParams, 'AppInstallation', 'delete'),
     },


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

Shift the getInstallationsForOrg function and change the action and entity if possible for the endpoint.
The endpoint should follow this pattern: cma.appInstallation.getForOrg()
Merge app is using this endpoint. Remove the old endpoint after changes in Merge app.
https://github.com/contentful/merge-app/blob/main/src/core/hooks/data/useFetchEnvironments.ts#L12

## Motivation and Context

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
