### PR TITLE
fix: add defaultLocale to SpaceProps

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -17,6 +17,7 @@ import { UsageQuery } from './entities/usage'
 import { UserProps } from './entities/user'
 
 export type ClientAPI = ReturnType<typeof createClientApi>
+type CreateSpaceProps = Omit<SpaceProps, 'sys'> & { defaultLocale?: string }
 
 /**
  * @private
@@ -100,7 +101,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * ```
      */
     createSpace: function createSpace(
-      spaceData: Omit<SpaceProps, 'sys'>,
+      spaceData: CreateSpaceProps,
       organizationId: string
     ): Promise<Space> {
       return makeRequest({


### PR DESCRIPTION
## Summary

`createSpace` params types are missing `defaultLocale` and misleading in TS environment

As per [docs](https://www.contentful.com/developers/docs/references/content-management-api/\#/reference/spaces/spaces-collection/create-a-space/console/js) our CMA API supports it

## Motivation and Context

See https://github.com/contentful/contentful-cli/pull/1583#discussion_r957541315

## Checklist

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation