### PR TITLE
feat: add urn to entity meta sys props

### DIFF
--- a/lib/entities/entry.ts
+++ b/lib/entities/entry.ts
@@ -35,6 +35,12 @@ export type EntryReferenceOptionsProps = {
 
 export interface Entry extends EntryProps, DefaultElements<EntryProps>, ContentfulEntryApi {}
 
+export type WithResourceName<T extends { sys: unknown }> = T extends { sys: infer Sys }
+  ? Omit<T, 'sys'> & {
+      sys: Sys & { urn: string }
+    }
+  : never
+
 /**
  * @private
  * @param makeRequest - function to make requests via an adapter

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -88,7 +88,7 @@ export type {
   GroupControl,
   SidebarItem,
 } from './entities/editor-interface'
-export type { CreateEntryProps, Entry, EntryProps } from './entities/entry'
+export type { CreateEntryProps, Entry, EntryProps, WithResourceName } from './entities/entry'
 export type { CreateEnvironmentProps, Environment, EnvironmentProps } from './entities/environment'
 export type {
   CreateEnvironmentAliasProps,


### PR DESCRIPTION
## Summary

This PR is for adding urn as an optional parameter to EntityMetaSysProps.

## Motivation and Context

The type is used in field-editors repository. For this [PR](https://github.com/contentful/field-editors/compare/DANTE-648-urn-from-api-for-entries?expand=1) to get merged we need this change.

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
