### PR TITLE
chore: improve test space deletion 

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -135,5 +135,5 @@ export const generateRandomId = (prefix = 'randomId') => {
 }
 
 export const cleanupTestSpaces = async (dryRun = false) => {
-  return testUtils.cleanUpTestSpaces({ threshold: 60 * 60 * 1000, dryRun })
+  return testUtils.cleanUpTestSpaces({ threshold: 10 * 60 * 1000, dryRun })
 }

--- a/test/integration/release-action-integration.ts
+++ b/test/integration/release-action-integration.ts
@@ -65,6 +65,12 @@ describe('ReleaseAction Api', async () => {
     testReleaseAction2 = await testRelease2.validate()
   })
 
+  after(async () => {
+    if (testSpace) {
+      return testSpace.delete()
+    }
+  })
+
   describe('Read', () => {
     test('Get ReleaseAction', async () => {
       const releaseAction = await testEnvironment.getReleaseAction({

--- a/test/integration/release-integration.ts
+++ b/test/integration/release-integration.ts
@@ -42,6 +42,12 @@ describe('Release Api', async function () {
     }
   })
 
+  after(async () => {
+    if (testSpace) {
+      return testSpace.delete()
+    }
+  })
+
   describe('Read', () => {
     test('Get Release', async () => {
       const createdRelease = await testEnvironment.createRelease({

--- a/test/mocha-global.js
+++ b/test/mocha-global.js
@@ -4,8 +4,12 @@ import { cleanupTestSpaces } from './helpers'
 const housekeeping = async () => {
   try {
     await cleanupTestSpaces()
-  } catch {
-    // ignore if the cleanup fails. Usually fails locally due to missing credentials
+  } catch (err) {
+    if (err.message === 'Missing credential') {
+      console.log('Skipped deletion of old test spaces due to missing credentials.')
+    } else {
+      console.log('Skipped deletion of old test spaces. Error:', err.message)
+    }
   }
 }
 

--- a/test/mocha-global.js
+++ b/test/mocha-global.js
@@ -1,10 +1,19 @@
-import { after } from 'mocha'
+import { before, after } from 'mocha'
 import { cleanupTestSpaces } from './helpers'
 
-after('clean up test spaces', async () => {
+const housekeeping = async () => {
   try {
     await cleanupTestSpaces()
   } catch {
     // ignore if the cleanup fails. Usually fails locally due to missing credentials
   }
+}
+
+before('clean up test spaces', async () => {
+  await housekeeping()
+  console.log('Running tests...')
+})
+
+after('clean up test spaces', async () => {
+  await housekeeping()
 })


### PR DESCRIPTION
Improves the deletion of test spaces created during integration tests. 

Things done: 
- set lower threshold for space cleanup (10 minutes instead of 1 hour)
- add missing space cleanup to tests that create test spaces
- add a global `before`, as the `after` doesn't always run (e.g. when you stop the test run midway)