### PR TITLE
feat: support xspace fields [Dante-708]

### DIFF
--- a/lib/entities/content-type-fields.ts
+++ b/lib/entities/content-type-fields.ts
@@ -40,6 +40,12 @@ interface Item {
   validations?: ContentTypeFieldValidation[]
 }
 
+interface ContentTypeAllowedResources {
+  type: string
+  source: string
+  contentTypes: string[]
+}
+
 export interface ContentFields<T = KeyValueMap> extends Item {
   id: string
   name: string
@@ -51,4 +57,5 @@ export interface ContentFields<T = KeyValueMap> extends Item {
   items?: Item
   apiName?: string
   defaultValue?: T
+  allowedResources?: ContentTypeAllowedResources[]
 }

--- a/lib/entities/field-type.ts
+++ b/lib/entities/field-type.ts
@@ -13,5 +13,5 @@ export type FieldType =
   | { type: 'ResourceLink'; linkType: 'Contentful:entry' }
   | { type: 'Array'; items: { type: 'Symbol' } }
   | { type: 'Array'; items: { type: 'Link'; linkType: 'Entry' } }
-  | { type: 'Array'; items: { type: 'Resourcelink'; linkType: 'Contentful:entry' } }
+  | { type: 'Array'; items: { type: 'Resourcelink'; linkType: 'Contentful:Entry' } }
   | { type: 'Array'; items: { type: 'Link'; linkType: 'Asset' } }

--- a/lib/entities/field-type.ts
+++ b/lib/entities/field-type.ts
@@ -10,7 +10,7 @@ export type FieldType =
   | { type: 'Location' }
   | { type: 'Link'; linkType: 'Asset' }
   | { type: 'Link'; linkType: 'Entry' }
-  | { type: 'ResourceLink'; linkType: 'Contentful:entry' }
+  | { type: 'ResourceLink'; linkType: 'Contentful:Entry' }
   | { type: 'Array'; items: { type: 'Symbol' } }
   | { type: 'Array'; items: { type: 'Link'; linkType: 'Entry' } }
   | { type: 'Array'; items: { type: 'Resourcelink'; linkType: 'Contentful:Entry' } }

--- a/lib/entities/field-type.ts
+++ b/lib/entities/field-type.ts
@@ -10,6 +10,8 @@ export type FieldType =
   | { type: 'Location' }
   | { type: 'Link'; linkType: 'Asset' }
   | { type: 'Link'; linkType: 'Entry' }
+  | { type: 'ResourceLink'; linkType: 'Contentful:entry' }
   | { type: 'Array'; items: { type: 'Symbol' } }
   | { type: 'Array'; items: { type: 'Link'; linkType: 'Entry' } }
+  | { type: 'Array'; items: { type: 'Resourcelink'; linkType: 'Contentful:entry' } }
   | { type: 'Array'; items: { type: 'Link'; linkType: 'Asset' } }

--- a/test/integration/content-type-integration.js
+++ b/test/integration/content-type-integration.js
@@ -78,6 +78,22 @@ describe('ContentType Api', async function () {
                 name: 'field2delete',
                 type: 'Text',
               },
+              {
+                id: 'multiRefXSpace',
+                name: 'multiRefXSpace',
+                type: 'Array',
+                items: {
+                  type: 'ResourceLink',
+                  validations: [],
+                },
+                allowedResources: [
+                  {
+                    type: 'Contentful:Entry',
+                    source: 'crn:contentful:::content:spaces/bkg4k0bz2fhq',
+                    contentTypes: ['textBlock'],
+                  },
+                ],
+              },
             ]
             return publishedContentType
               .update() // update with fields
@@ -85,6 +101,10 @@ describe('ContentType Api', async function () {
                 expect(updatedContentType.isUpdated(), 'contentType is updated').to.be.ok
                 expect(updatedContentType.fields[0].id).equals('field', 'field id')
                 expect(updatedContentType.fields[1].id).equals('field2delete', 'field2delete id')
+                expect(updatedContentType.fields[2].id).equals(
+                  'multiRefXSpace',
+                  'multiRefXSpace id'
+                )
                 return updatedContentType
                   .omitAndDeleteField('field2delete') // omit and delete field
                   .then((deletedFieldContentType) => {

--- a/test/integration/entry-integration.js
+++ b/test/integration/entry-integration.js
@@ -301,7 +301,7 @@ describe('Entry Api', () => {
     })
   })
 
-  describe('write', function () {
+  describe('write', () => {
     let space
     let environment
     let contentType
@@ -417,6 +417,126 @@ describe('Entry Api', () => {
       expect(response.items[0].sys.firstPublishedAt).to.not.be.undefined
       expect(response.items[0].sys.publishedVersion).to.not.be.undefined
       expect(response.items[0].sys.publishedAt).to.not.be.undefined
+    })
+  })
+
+  describe('write with xspace references', () => {
+    let xSpaceEnabledSpace
+    let xSpaceEnabledEnvironment
+    let xSpaceDisabledSpace
+    let xSpaceDisabledEnvironment
+    let contentTypeDisabledSpace
+    let contentTypeEnabledSpace
+    let contentTypeData = {
+      name: 'testCTXSpace',
+      fields: [
+        {
+          id: 'title',
+          name: 'Title',
+          type: 'Text',
+        },
+        {
+          id: 'multiRefXSpace',
+          name: 'multiRefXSpace',
+          type: 'Array',
+          items: {
+            type: 'ResourceLink',
+            validations: [],
+          },
+          allowedResources: [
+            {
+              type: 'Contentful:Entry',
+              source: 'crn:contentful:::content:spaces/6mqcevu5a50r',
+              contentTypes: ['testCtxSpace'],
+            },
+          ],
+        },
+      ],
+    }
+
+    let entryData = {
+      fields: {
+        title: { 'en-US': 'this is the title' },
+        multiRefXSpace: {
+          'en-US': [
+            {
+              sys: {
+                type: 'ResourceLink',
+                linkType: 'Contentful:Entry',
+                urn: 'crn:contentful:::content:spaces/6mqcevu5a50r/entries/4zimQzVMxDsSX607PCfo2u',
+              },
+            },
+          ],
+        },
+      },
+    }
+
+    before(async () => {
+      // default space has xspace enabled in it through the feature flags
+      xSpaceEnabledSpace = await getDefaultSpace()
+      xSpaceEnabledEnvironment = await xSpaceEnabledSpace.getEnvironment('master')
+      xSpaceDisabledSpace = await createTestSpace(initClient(), 'Entry')
+      xSpaceDisabledEnvironment = await createTestEnvironment(
+        xSpaceDisabledSpace,
+        'Testing Environment'
+      )
+      contentTypeDisabledSpace = await xSpaceDisabledEnvironment.createContentTypeWithId(
+        generateRandomId('test-content-type'),
+        contentTypeData
+      )
+      await contentTypeDisabledSpace.publish()
+
+      contentTypeEnabledSpace = await xSpaceEnabledEnvironment.createContentTypeWithId(
+        generateRandomId('test-content-type'),
+        contentTypeData
+      )
+      await contentTypeEnabledSpace.publish()
+    })
+
+    after(async () => {
+      await contentTypeDisabledSpace.unpublish().then((unpublishedContentType) =>
+        unpublishedContentType.delete().then(() => {
+          xSpaceDisabledSpace.delete()
+        })
+      )
+      await contentTypeEnabledSpace
+        .unpublish()
+        .then((unpublishedContentType) => unpublishedContentType.delete())
+    })
+
+    test('Blocks publishing an entry with xspace references if the feature is disabled for the space', async () => {
+      return xSpaceDisabledEnvironment
+        .createEntry(contentTypeDisabledSpace.sys.id, entryData)
+        .then((entry) => {
+          expect(entry.isDraft(), 'entry is in draft').ok
+          expect(entry.fields.title['en-US']).equals('this is the title', 'original title')
+          return entry.publish().catch((accessDeniedError) => {
+            let errorMessage = JSON.parse(accessDeniedError.message)
+            expect(accessDeniedError.name).equals('AccessDenied', 'Access Denied Error')
+            expect(errorMessage.status).equals(403, '403 forbidden status')
+            expect(errorMessage.details.reasons).equals(
+              'Cross space links feature is not enabled for this space',
+              'reason explained'
+            )
+            return xSpaceDisabledEnvironment.deleteEntry(entry.sys.id)
+          })
+        })
+    })
+
+    test('can create, publish, unpublish and delete an entry with xspace references if the feature is enabled for the space', async () => {
+      return xSpaceEnabledEnvironment
+        .createEntry(contentTypeEnabledSpace.sys.id, entryData)
+        .then((entry) => {
+          expect(entry.isDraft(), 'entry is in draft').ok
+          expect(entry.fields.title['en-US']).equals('this is the title', 'original title')
+          return entry.publish().then((publishedEntry) => {
+            expect(publishedEntry.isPublished(), 'entry is published').ok
+            return publishedEntry.unpublish().then((unpublishedEntry) => {
+              expect(unpublishedEntry.isDraft(), 'entry is back in draft').ok
+              return publishedEntry.delete()
+            })
+          })
+        })
     })
   })
 })


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->
This PR was created to support the new Cross Space fields added in the creation of content types and entries.

## Description

<!-- Describe your changes in detail -->
the new xspace field type should be recognized and handled in the JS SDKs

also when editing content types and entries with xspace fields

we do not implement xspace links resolution in the SDK, just return the link object/CRN as is

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes