### PR TITLE
chore(organization-membership): type user as UserProps

### DIFF
--- a/lib/entities/organization-membership.ts
+++ b/lib/entities/organization-membership.ts
@@ -2,13 +2,14 @@ import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
-import { MetaSysProps, DefaultElements, MetaLinkProps, MakeRequest } from '../common-types'
+import { MetaSysProps, DefaultElements, MakeRequest } from '../common-types'
+import { UserProps } from './user'
 
 export type OrganizationMembershipProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { user: { sys: MetaLinkProps } }
+  sys: MetaSysProps & { user: UserProps }
 
   /**
    * Role


### PR DESCRIPTION
## Summary

Type `user` in `OrganizationMembership` as `UserProps`.

## Description

I'm assuming there's a reason we don't do this already, does anyone know why? 😅 Are there situations where the full user object is not returned?

## Motivation and Context

This is to avoid casting the `user` object to `UserProps` manually in consuming apps.