### PR TITLE
fix(organizationMemberships): query many paginated [ZEND-2681]

### DIFF
--- a/lib/adapters/REST/endpoints/organization-membership.ts
+++ b/lib/adapters/REST/endpoints/organization-membership.ts
@@ -4,7 +4,7 @@ import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
 import {
   CollectionProp,
-  GetOrganizationMembershipProps,
+  GetOrganizationMembershipParams,
   GetOrganizationParams,
   QueryParams,
 } from '../../../common-types'
@@ -15,12 +15,12 @@ import * as raw from './raw'
 const getBaseUrl = (params: GetOrganizationParams) =>
   `/organizations/${params.organizationId}/organization_memberships`
 
-const getEntityUrl = (params: GetOrganizationMembershipProps) =>
+const getEntityUrl = (params: GetOrganizationMembershipParams) =>
   `${getBaseUrl(params)}/${params.organizationMembershipId}`
 
 export const get: RestEndpoint<'OrganizationMembership', 'get'> = (
   http: AxiosInstance,
-  params: GetOrganizationMembershipProps
+  params: GetOrganizationMembershipParams
 ) => {
   return raw.get<OrganizationMembershipProps>(http, getEntityUrl(params))
 }
@@ -29,12 +29,14 @@ export const getMany: RestEndpoint<'OrganizationMembership', 'getMany'> = (
   http: AxiosInstance,
   params: GetOrganizationParams & QueryParams
 ) => {
-  return raw.get<CollectionProp<OrganizationMembershipProps>>(http, getBaseUrl(params))
+  return raw.get<CollectionProp<OrganizationMembershipProps>>(http, getBaseUrl(params), {
+    params: params.query,
+  })
 }
 
 export const update: RestEndpoint<'OrganizationMembership', 'update'> = (
   http: AxiosInstance,
-  params: GetOrganizationMembershipProps,
+  params: GetOrganizationMembershipParams,
   rawData: OrganizationMembershipProps,
   headers?: AxiosRequestHeaders
 ) => {
@@ -57,7 +59,7 @@ export const update: RestEndpoint<'OrganizationMembership', 'update'> = (
 
 export const del: RestEndpoint<'OrganizationMembership', 'delete'> = (
   http: AxiosInstance,
-  params: GetOrganizationMembershipProps
+  params: GetOrganizationMembershipParams
 ) => {
   return raw.del(http, getEntityUrl(params))
 }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -159,6 +159,7 @@ export interface QueryOptions extends PaginationQueryOptions {
   include?: number
   select?: string
   links_to_entry?: string
+
   [key: string]: any
 }
 
@@ -242,6 +243,7 @@ export interface QueryOptions extends BasicQueryOptions {
 export interface BasicQueryOptions {
   skip?: number
   limit?: number
+
   [key: string]: any
 }
 
@@ -1073,18 +1075,18 @@ export type MRActions = {
     }
   }
   OrganizationMembership: {
-    get: { params: GetOrganizationMembershipProps; return: OrganizationMembershipProps }
+    get: { params: GetOrganizationMembershipParams; return: OrganizationMembershipProps }
     getMany: {
       params: GetOrganizationParams & QueryParams
       return: CollectionProp<OrganizationMembershipProps>
     }
     update: {
-      params: GetOrganizationMembershipProps
+      params: GetOrganizationMembershipParams
       payload: OrganizationMembershipProps
       headers?: AxiosRequestHeaders
       return: OrganizationMembershipProps
     }
-    delete: { params: GetOrganizationMembershipProps; return: any }
+    delete: { params: GetOrganizationMembershipParams; return: any }
   }
   PersonalAccessToken: {
     get: { params: { tokenId: string }; return: PersonalAccessTokenProp }
@@ -1576,9 +1578,10 @@ export type GetTeamParams = { organizationId: string; teamId: string }
 export type GetTeamSpaceMembershipParams = GetSpaceParams & { teamSpaceMembershipId: string }
 export type GetWebhookCallDetailsUrl = GetWebhookParams & { callId: string }
 export type GetWebhookParams = GetSpaceParams & { webhookDefinitionId: string }
-export type GetOrganizationMembershipProps = GetOrganizationParams & {
+export type GetOrganizationMembershipParams = GetOrganizationParams & {
   organizationMembershipId: string
 }
+
 export type GetAppUploadParams = GetOrganizationParams & { appUploadId: string }
 export type GetWorkflowDefinitionParams = GetSpaceEnvironmentParams & {
   workflowDefinitionId: string

--- a/lib/create-organization-api.ts
+++ b/lib/create-organization-api.ts
@@ -4,7 +4,7 @@ import { Stream } from 'stream'
 import { CreateTeamMembershipProps } from './entities/team-membership'
 import { CreateTeamProps } from './entities/team'
 import { CreateOrganizationInvitationProps } from './entities/organization-invitation'
-import { MakeRequest, QueryOptions } from './common-types'
+import { MakeRequest, QueryOptions, QueryParams } from './common-types'
 import { CreateAppDefinitionProps } from './entities/app-definition'
 import { CreateAppActionProps } from './entities/app-action'
 import { CreateAppSigningSecretProps } from './entities/app-signing-secret'
@@ -119,7 +119,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
     },
     /**
      * Gets a collection of Organization Memberships
-     * @param  query - Object with search parameters. Check the <a href="https://www.contentful.com/developers/docs/javascript/tutorials/using-js-cda-sdk/#retrieving-entries-with-search-parameters">JS SDK tutorial</a> and the <a href="https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters">REST API reference</a> for more details.
+     * @param  params - Object with search parameters. Check the <a href="https://www.contentful.com/developers/docs/javascript/tutorials/using-js-cda-sdk/#retrieving-entries-with-search-parameters">JS SDK tutorial</a> and the <a href="https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters">REST API reference</a> for more details.
      * @return Promise for a collection of Organization Memberships
      * @example ```javascript
      * const contentful = require('contentful-management')
@@ -133,17 +133,17 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    getOrganizationMemberships(query: QueryOptions = {}) {
+
+    getOrganizationMemberships(params: QueryParams = {}) {
       const raw = this.toPlainObject() as OrganizationProp
-      const organizationId = raw.sys.id
       return makeRequest({
         entityType: 'OrganizationMembership',
         action: 'getMany',
         params: {
-          organizationId,
-          query: createRequestConfig({ query }).params,
+          organizationId: raw.sys.id,
+          ...params,
         },
-      }).then((data) => wrapOrganizationMembershipCollection(makeRequest, data, organizationId))
+      }).then((data) => wrapOrganizationMembershipCollection(makeRequest, data, raw.sys.id))
     },
     /**
      * Creates a Team

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -8,7 +8,7 @@ import {
   GetCommentParams,
   GetContentTypeParams,
   GetEditorInterfaceParams,
-  GetOrganizationMembershipProps,
+  GetOrganizationMembershipParams,
   GetOrganizationParams,
   GetSnapshotForContentTypeParams,
   GetSnapshotForEntryParams,
@@ -781,17 +781,17 @@ export type PlainClientAPI = {
   }
   organizationMembership: {
     get(
-      params: OptionalDefaults<GetOrganizationMembershipProps>
+      params: OptionalDefaults<GetOrganizationMembershipParams>
     ): Promise<OrganizationMembershipProps>
     getMany(
       params: OptionalDefaults<GetOrganizationParams & QueryParams>
     ): Promise<CollectionProp<OrganizationMembershipProps>>
     update(
-      params: OptionalDefaults<GetOrganizationMembershipProps>,
+      params: OptionalDefaults<GetOrganizationMembershipParams>,
       rawData: OrganizationMembershipProps,
       headers?: AxiosRequestHeaders
     ): Promise<OrganizationMembershipProps>
-    delete(params: OptionalDefaults<GetOrganizationMembershipProps>): Promise<any>
+    delete(params: OptionalDefaults<GetOrganizationMembershipParams>): Promise<any>
   }
   spaceMember: {
     get(

--- a/test/integration/organization-membership-integration.js
+++ b/test/integration/organization-membership-integration.js
@@ -36,7 +36,6 @@ describe('OrganizationMembership Api', function () {
         },
       })
       .then((response) => {
-        console.dir(response, { depth: Infinity })
         expect(response.sys, 'sys').ok
         expect(response.limit).equals(1)
         expect(response.skip).equals(1)

--- a/test/integration/organization-membership-integration.js
+++ b/test/integration/organization-membership-integration.js
@@ -26,4 +26,21 @@ describe('OrganizationMembership Api', function () {
       expect(response.sys.type).equals('OrganizationMembership')
     })
   })
+
+  test('Gets organizationMemberships paged', async () => {
+    return organization
+      .getOrganizationMemberships({
+        query: {
+          limit: 1,
+          skip: 1,
+        },
+      })
+      .then((response) => {
+        console.dir(response, { depth: Infinity })
+        expect(response.sys, 'sys').ok
+        expect(response.limit).equals(1)
+        expect(response.skip).equals(1)
+        expect(response.items.length).equals(1)
+      })
+  })
 })


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Apply provided params to the http client, to fetch `organizationMemberships` paginated

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
