### PR TITLE
feat: update scheduled actions types [SPA-900]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1594,3 +1594,6 @@ export type GetUserUIConfigParams = GetUIConfigParams
 
 export type QueryParams = { query?: QueryOptions }
 export type PaginationQueryParams = { query?: PaginationQueryOptions }
+export enum ScheduledActionReferenceFilters {
+  contentTypeAnnotationNotIn = 'sys.contentType.metadata.annotations.ContentType[nin]',
+}

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -61,7 +61,7 @@ export const ScheduledActionReferenceFilters =
   'sys.contentType.metadata.annotations.ContentType[nin]'
 
 export type ScheduledActionPayloadProps = {
-  withReferences: Record<typeof ScheduledActionReferenceFilters, string[]>
+  withReferences?: Record<typeof ScheduledActionReferenceFilters, string[]>
 }
 
 export type ScheduledActionProps = {

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -57,10 +57,11 @@ export type ScheduledActionSysProps = {
   updatedBy: Link<'User'> | Link<'AppDefinition'>
 }
 
-type ScheduledActionReferenceFilters = 'sys.contentType.metadata.annotations.ContentType[nin]'
+export const ScheduledActionReferenceFilters =
+  'sys.contentType.metadata.annotations.ContentType[nin]'
 
 export type ScheduledActionPayloadProps = {
-  withReferences: Record<ScheduledActionReferenceFilters, string[]>
+  withReferences: Record<typeof ScheduledActionReferenceFilters, string[]>
 }
 
 export type ScheduledActionProps = {

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -8,6 +8,7 @@ import {
   Link,
   MakeRequest,
   SysLink,
+  ScheduledActionReferenceFilters,
 } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -57,11 +58,8 @@ export type ScheduledActionSysProps = {
   updatedBy: Link<'User'> | Link<'AppDefinition'>
 }
 
-export const ScheduledActionReferenceFilters =
-  'sys.contentType.metadata.annotations.ContentType[nin]'
-
 export type ScheduledActionPayloadProps = {
-  withReferences?: Record<typeof ScheduledActionReferenceFilters, string[]>
+  withReferences?: Record<ScheduledActionReferenceFilters, string[]>
 }
 
 export type ScheduledActionProps = {

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -57,6 +57,12 @@ export type ScheduledActionSysProps = {
   updatedBy: Link<'User'> | Link<'AppDefinition'>
 }
 
+type ScheduledActionReferenceFilters = 'sys.contentType.metadata.annotations.ContentType[nin]'
+
+export type ScheduledActionPayloadProps = {
+  withReferences: Record<ScheduledActionReferenceFilters, string[]>
+}
+
 export type ScheduledActionProps = {
   sys: ScheduledActionSysProps
   action: SchedulableActionType
@@ -88,11 +94,12 @@ export type ScheduledActionProps = {
    * }
    */
   error?: ScheduledActionFailedError
+  payload?: ScheduledActionPayloadProps
 }
 
 export type CreateUpdateScheduledActionProps = Pick<
   ScheduledActionProps,
-  'action' | 'entity' | 'environment' | 'scheduledFor'
+  'action' | 'entity' | 'environment' | 'scheduledFor' | 'payload'
 >
 
 export interface ScheduledActionCollection {

--- a/test/integration/scheduled-action-integration.ts
+++ b/test/integration/scheduled-action-integration.ts
@@ -4,9 +4,12 @@ import { before, after, describe, test, beforeEach, afterEach } from 'mocha'
 import { Asset } from '../../lib/entities/asset'
 import { Entry } from '../../lib/entities/entry'
 import { Environment } from '../../lib/entities/environment'
-import { ScheduledActionReferenceFilters } from '../../lib/entities/scheduled-action'
 import { Space } from '../../lib/entities/space'
-import { ContentType, ContentTypeMetadata } from '../../lib/export-types'
+import {
+  ContentType,
+  ContentTypeMetadata,
+  ScheduledActionReferenceFilters,
+} from '../../lib/export-types'
 import { TestDefaults } from '../defaults'
 import { getDefaultSpace, initPlainClient } from '../helpers'
 import { makeLink } from '../utils'
@@ -32,7 +35,7 @@ describe('Scheduled Actions API', async function () {
 
   const aggregateRootPayload = {
     withReferences: {
-      [ScheduledActionReferenceFilters]: ['Contentful:AggregateRoot'],
+      [ScheduledActionReferenceFilters.contentTypeAnnotationNotIn]: ['Contentful:AggregateRoot'],
     },
   }
 
@@ -167,9 +170,7 @@ describe('Scheduled Actions API', async function () {
       beforeEach(async () => {
         const aggregateRootAnnotation: ContentTypeMetadata = {
           annotations: {
-            ContentType: [
-              { sys: { id: 'Contentful:AggregateRoot', type: 'Link', linkType: 'Annotation' } },
-            ],
+            ContentType: [makeLink('Annotation', 'Contentful:AggregateRoot')],
           },
         }
         const environment = await testSpace.getEnvironment('master')
@@ -203,7 +204,7 @@ describe('Scheduled Actions API', async function () {
         const scheduledAction = await testSpace.createScheduledAction({
           entity: makeLink('Entry', entry.sys.id),
           environment: makeLink('Environment', environment.sys.id),
-          action: 'unpublish',
+          action: 'publish',
           scheduledFor: {
             datetime,
           },
@@ -211,7 +212,7 @@ describe('Scheduled Actions API', async function () {
         })
 
         expect(scheduledAction.entity).to.deep.equal(makeLink('Entry', entry.sys.id))
-        expect(scheduledAction.action).to.eql('unpublish')
+        expect(scheduledAction.action).to.eql('publish')
         expect(scheduledAction.scheduledFor).to.deep.equal({
           datetime,
         })
@@ -397,9 +398,7 @@ describe('Scheduled Actions API', async function () {
       beforeEach(async () => {
         const aggregateRootAnnotation: ContentTypeMetadata = {
           annotations: {
-            ContentType: [
-              { sys: { id: 'Contentful:AggregateRoot', type: 'Link', linkType: 'Annotation' } },
-            ],
+            ContentType: [makeLink('Annotation', 'Contentful:AggregateRoot')],
           },
         }
         const environment = await testSpace.getEnvironment('master')
@@ -436,7 +435,7 @@ describe('Scheduled Actions API', async function () {
           {},
           {
             entity: makeLink('Entry', entry.sys.id),
-            action: 'unpublish',
+            action: 'publish',
             environment: makeLink('Environment', environment.sys.id),
             scheduledFor: {
               datetime,


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Update scheduled actions types as per https://contentful.atlassian.net/wiki/spaces/ENG/pages/3891691521/CEP-0144+Enable+jobs-api+to+process+entry+aggregates#Recommended-Solution

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation - IN PROGRESS

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
