### PR TITLE
fix: reduce the generic typings to be compatible with TS v4.8

### DIFF
--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -62,9 +62,9 @@ function createClient(
   }
 ): PlainClientAPI
 function createClient<
-  // T describes an array that contains the string "workflows" at any point in the list.
-  T extends (ReadonlyArray<string> | readonly ['workflows']) &
-    { [K in keyof T]: { [P in K]: 'workflows' } }[number]
+  // Originally, we used a magic expression from here: https://stackoverflow.com/a/57958451/4816930
+  // Right now it's fixed to this specific array until there is a need to revisit this.
+  T extends ['workflows']
 >(
   params: ClientOptions,
   opts: {


### PR DESCRIPTION
## Description

resolve #1493

Previously we had a generic that allows passing any array as long as it contains the string `workflows` so we ship the alpha client with this feature activated. This "black magic" from the SO post I linked in the comment doesn't work anymore for TS v4.8.x so I decided to keep it as simple as possible until we actually need a more general solution. Right now, workflows is the only alpha feature so it's fine to reduce this to a minimum.

## Motivation and Context

Pointed out by users: https://github.com/contentful/contentful-management.js/issues/1493
PR that introduced this generic type: https://github.com/contentful/contentful-management.js/pull/1122

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
