### PR TITLE
fix: fix query params for org installation calls

### DIFF
--- a/lib/adapters/REST/endpoints/app-definition.ts
+++ b/lib/adapters/REST/endpoints/app-definition.ts
@@ -25,9 +25,7 @@ export const getAppDefinitionUrl = (params: GetAppDefinitionParams) =>
   getBaseUrl(params) + `/${params.appDefinitionId}`
 
 const getBaseUrlForOrgInstallations = (params: GetAppInstallationsForOrgParams) =>
-  `/app_definitions/${params.appDefinitionId}/app_installations?sys.organization.sys.id[in]=${
-    params.organizationId || ''
-  }`
+  `/app_definitions/${params.appDefinitionId}/app_installations`
 
 export const get: RestEndpoint<'AppDefinition', 'get'> = (
   http: AxiosInstance,
@@ -90,7 +88,10 @@ export const getInstallationsForOrg: RestEndpoint<'AppDefinition', 'getInstallat
     http,
     getBaseUrlForOrgInstallations(params),
     {
-      params: normalizeSpaceId(normalizeSelect(params.query)),
+      params: {
+        ...normalizeSpaceId(normalizeSelect(params.query)),
+        'sys.organization.sys.id[in]': params.organizationId,
+      },
     }
   )
 }

--- a/lib/adapters/REST/endpoints/app-installation.ts
+++ b/lib/adapters/REST/endpoints/app-installation.ts
@@ -22,9 +22,7 @@ const getBaseUrl = (params: GetSpaceEnvironmentParams) =>
   `/spaces/${params.spaceId}/environments/${params.environmentId}/app_installations`
 
 const getBaseUrlForOrgInstallations = (params: GetAppInstallationsForOrgParams) =>
-  `/app_definitions/${params.appDefinitionId}/app_installations?sys.organization.sys.id[in]=${
-    params.organizationId || ''
-  }`
+  `/app_definitions/${params.appDefinitionId}/app_installations`
 
 export const getAppInstallationUrl = (params: GetAppInstallationParams) =>
   getBaseUrl(params) + `/${params.appDefinitionId}`
@@ -81,7 +79,10 @@ export const getForOrganization: RestEndpoint<'AppInstallation', 'getForOrganiza
     http,
     getBaseUrlForOrgInstallations(params),
     {
-      params: normalizeSpaceId(normalizeSelect(params.query)),
+      params: {
+        ...normalizeSpaceId(normalizeSelect(params.query)),
+        'sys.organization.sys.id[in]': params.organizationId,
+      },
     }
   )
 }

--- a/lib/adapters/REST/endpoints/utils.ts
+++ b/lib/adapters/REST/endpoints/utils.ts
@@ -12,9 +12,10 @@ export function normalizeSelect(query?: QueryOptions): QueryOptions | undefined 
 
 export function normalizeSpaceId(query?: QueryOptions): QueryOptions | undefined {
   if (query && query.spaceId) {
+    const { spaceId, ...rest } = query
     return {
-      ...query,
-      'sys.space.sys.id[in]': query.spaceId,
+      ...rest,
+      'sys.space.sys.id[in]': spaceId,
     }
   }
   return query

--- a/lib/create-app-definition-api.ts
+++ b/lib/create-app-definition-api.ts
@@ -170,7 +170,7 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
      * const client = contentful.createClient({
      *   accessToken: '<content_management_api_key>'
      * })
-     * client.getAppDefinition('<organization_id>', '<app_definition_id>'))
+     * client.getAppDefinition('<organization_id>', '<app_definition_id>')
      * .then((appDefinition) => appDefinition.getInstallationsForOrg(
      *   { spaceId: '<space_id>' } // optional
      * ))

--- a/test/unit/adapters/REST/endpoints/utils-test.js
+++ b/test/unit/adapters/REST/endpoints/utils-test.js
@@ -1,0 +1,31 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import { normalizeSpaceId } from '../../../../../lib/adapters/REST/endpoints/utils'
+
+describe('normalizeSpaceId', () => {
+  it('replaces the `spaceId` property of a query', () => {
+    const query = {
+      spaceId: 'some-space-id',
+    }
+
+    const expected = {
+      'sys.space.sys.id[in]': 'some-space-id',
+    }
+
+    expect(normalizeSpaceId(query)).to.deep.equal(expected)
+  })
+
+  it('does not replace other properties', () => {
+    const query = {
+      limit: 10,
+      spaceId: 'some-space-id',
+    }
+
+    const expected = {
+      limit: 10,
+      'sys.space.sys.id[in]': 'some-space-id',
+    }
+
+    expect(normalizeSpaceId(query)).to.deep.equal(expected)
+  })
+})


### PR DESCRIPTION
This PR contains 2 bug fixes: 

1/ Fix for a bug in `normalizeSpaceId` - we didn't remove the `spaceId` property from the query, now we do
2/ Handle the org id query param like other query params instead of doing string concatenation.