### PR TITLE
fix: cursor based pagination query param interface [MONET-883]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -262,8 +262,8 @@ export interface BasicQueryOptions {
 }
 
 export interface BasicCursorPaginationOptions extends Omit<BasicQueryOptions, 'skip'> {
-  prev?: string
-  next?: string
+  pageNext?: string
+  pagePrev?: string
 }
 
 export type KeyValueMap = Record<string, any>

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -3,12 +3,12 @@ import copy from 'fast-copy'
 import {
   DefaultElements,
   ISO8601Timestamp,
-  BasicCursorPaginationOptions,
   MetaLinkProps,
   Link,
   MakeRequest,
   SysLink,
   ScheduledActionReferenceFilters,
+  CursorPaginatedCollectionProp,
 } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -101,19 +101,15 @@ export type CreateUpdateScheduledActionProps = Pick<
   'action' | 'entity' | 'environment' | 'scheduledFor' | 'payload'
 >
 
-export interface ScheduledActionCollection {
-  sys: {
-    type: 'Array'
-  }
-  pages: BasicCursorPaginationOptions
-  limit: number
-  items: ScheduledActionProps[]
-}
+export type ScheduledActionCollection = CursorPaginatedCollectionProp<ScheduledActionProps>
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-export interface ScheduledActionQueryOptions extends BasicCursorPaginationOptions {
+export interface ScheduledActionQueryOptions {
   'environment.sys.id': string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any
+  limit?: number
+  next?: string
+  prev?: string
 }
 
 export type ScheduledActionApi = {


### PR DESCRIPTION
## Summary

Align the cursor base pagination url parameters to our spec.

## Description

Iterating through pages by adding `pageNext` or `pagePrev` as a url parameter. The current implementation was using `next` and `prev` which was not aligned with our spec.

## Motivation and Context

The current implementation did not fit the definition in our spec.
