### PR TITLE
docs: [] createClient example

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ contentfulApp.init((sdk) => {
     {
       type: 'plain',
       defaults: {
-        environmentId: sdk.ids.environment,
+        environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
         spaceId: sdk.ids.space,
       },
     }


### PR DESCRIPTION
## Summary
Fixing the client init example with environment alias (should be same as [in the docs](https://www.contentful.com/developers/docs/extensibility/app-framework/sdk/#using-the-contentful-management-library)).
