### PR TITLE
fix: missing export for isArchived()

### DIFF
--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -16,7 +16,7 @@ import * as editorInterfaceDefaults from './constants/editor-interface-defaults'
 
 export type { ClientAPI } from './create-contentful-api'
 export { asIterator } from './plain/as-iterator'
-export { isDraft, isPublished, isUpdated } from './plain/checks'
+export * from './plain/checks'
 export type { PlainClientAPI, AlphaPlainClientAPI } from './plain/common-types'
 export { createClient }
 export { RestAdapter } from './adapters/REST/rest-adapter'


### PR DESCRIPTION
fix #1522

## Summary

Export all plain-checks.

## Description

All plain-checks are exported within contentful-management except for isArchived-method for no obvious reason.

## Motivation and Context

Would be great having it exported as well to be usable by consumers.

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
