### PR TITLE
fix: pages typing for cursor based pagination [MONET-883]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -236,7 +236,10 @@ export interface CollectionProp<TObj> {
 
 export interface CursorPaginatedCollectionProp<TObj>
   extends Omit<CollectionProp<TObj>, 'total' | 'skip'> {
-  pages?: BasicCursorPaginationOptions
+  pages?: {
+    next?: string
+    prev?: string
+  }
 }
 
 export interface Collection<T, TPlain>

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -8,7 +8,8 @@ import {
   MakeRequest,
   SysLink,
   ScheduledActionReferenceFilters,
-  CursorPaginatedCollectionProp,
+  BasicCursorPaginationOptions,
+  CollectionProp,
 } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -40,6 +41,11 @@ interface ScheduledActionFailedError {
   }
   message?: string
   details?: { errors: ErrorDetail[] }
+}
+
+export interface CursorPaginatedCollectionProp<TObj>
+  extends Omit<CollectionProp<TObj>, 'total' | 'skip'> {
+  pages?: BasicCursorPaginationOptions
 }
 
 export type ScheduledActionSysProps = {


### PR DESCRIPTION
## Summary

Follow up PR of #1511 to align cursor based pagination with the spec.

## Description

This aligns the typing of the `pages` property in the response object of a collection to the spec.