### PR TITLE
fix(assets): fix asset upload timeout []

### DIFF
--- a/lib/adapters/REST/endpoints/asset.ts
+++ b/lib/adapters/REST/endpoints/asset.ts
@@ -153,10 +153,10 @@ export const createWithId: RestEndpoint<'Asset', 'createWithId'> = (
 
 export const createFromFiles: RestEndpoint<'Asset', 'createFromFiles'> = (
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams,
+  params: GetSpaceEnvironmentParams & { uploadTimeout?: number },
   data: Omit<AssetFileProp, 'sys'>
 ) => {
-  const httpUpload = getUploadHttpClient(http)
+  const httpUpload = getUploadHttpClient(http, { uploadTimeout: params.uploadTimeout })
 
   const { file } = data.fields
   return Promise.all(

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -845,7 +845,7 @@ export type MRActions = {
       return: AssetProps
     }
     createFromFiles: {
-      params: GetSpaceEnvironmentParams
+      params: GetSpaceEnvironmentParams & { uploadTimeout?: number }
       payload: Omit<AssetFileProp, 'sys'>
       return: AssetProps
     }

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -6,7 +6,12 @@ import entities from './entities'
 import type { CreateAppInstallationProps } from './entities/app-installation'
 import type { CreateAppSignedRequestProps } from './entities/app-signed-request'
 import type { CreateAppActionCallProps } from './entities/app-action-call'
-import type { AssetFileProp, AssetProps, CreateAssetProps } from './entities/asset'
+import type {
+  AssetFileProp,
+  AssetProps,
+  CreateAssetFromFilesOptions,
+  CreateAssetProps,
+} from './entities/asset'
 import type { CreateAssetKeyProps } from './entities/asset-key'
 import type {
   BulkAction,
@@ -1053,7 +1058,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    createAssetFromFiles(data: Omit<AssetFileProp, 'sys'>) {
+    createAssetFromFiles(data: Omit<AssetFileProp, 'sys'>, options?: CreateAssetFromFilesOptions) {
       const raw = this.toPlainObject() as EnvironmentProps
       return makeRequest({
         entityType: 'Asset',
@@ -1061,6 +1066,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
         params: {
           spaceId: raw.sys.space.sys.id,
           environmentId: raw.sys.id,
+          uploadTimeout: options?.uploadTimeout,
         },
         payload: data,
       }).then((response) => wrapAsset(makeRequest, response))

--- a/lib/entities/asset.ts
+++ b/lib/entities/asset.ts
@@ -39,6 +39,8 @@ export type AssetProps = {
 
 export type CreateAssetProps = Omit<AssetProps, 'sys'>
 
+export type CreateAssetFromFilesOptions = { uploadTimeout?: number }
+
 export interface AssetFileProp {
   sys: MetaSysProps
   fields: {

--- a/lib/upload-http-client.ts
+++ b/lib/upload-http-client.ts
@@ -1,12 +1,24 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 
+type UploadHttpClientOpts = {
+  uploadTimeout?: number
+}
+
 /**
  * @private
  */
-export function getUploadHttpClient(http: AxiosInstance): AxiosInstance {
-  const { hostUpload, defaultHostnameUpload } = http.httpClientParams as Record<string, any>
+export function getUploadHttpClient(
+  http: AxiosInstance,
+  options?: UploadHttpClientOpts
+): AxiosInstance {
+  const { hostUpload, defaultHostnameUpload, timeout } = http.httpClientParams as Record<
+    string,
+    any
+  >
   const uploadHttp = http.cloneWithNewParams({
     host: hostUpload || defaultHostnameUpload,
+    // Using client presets, options or 5 minute default timeout
+    timeout: timeout ?? options?.uploadTimeout ?? 300000,
   })
   return uploadHttp
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -16,11 +16,12 @@ const env = process.env !== undefined ? process.env : window.__env__
 // Eg: getAll() fn in prod doesn't have any args. I change it in my PR to getAll({ query })
 // if I used testUtils.initClient(), it would have the version of cma repo that would still have getAll() without args
 // making it impossible for me to cover my changes with tests
-export const initClient = () => {
+export const initClient = (options) => {
   const accessToken = env.CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN
   return createClient({
     accessToken,
     ...params,
+    ...options,
   })
 }
 


### PR DESCRIPTION
## Summary

We saw that occassionally asset uploads would fail for bigger files (on slower connections) since the default upload timeout would be 30 seconds. This PR changes the default timeout to 5 minutes and provides the option to set the upload timeout as an option in the `createAssetFromFiles` function.
Setting the timeout to 100 seconds could then look something like this:
`environment.createAssetFromFiles(fileData, { uploadTimeout: 100000 })`

I realize that there are many variants how to get those options into the library. I found this to be the most straightforward one without applying this option to functions you might not expect to be affected. I am very happy about any suggestions though.



