### PR TITLE
feat: [EXT-3173] Narrow types for a plain client with adapter

### DIFF
--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -9,7 +9,12 @@ import type { RestAdapterParams } from './adapters/REST/rest-adapter'
 import type { MakeRequest } from './common-types'
 import { AdapterParams, createAdapter } from './create-adapter'
 import createContentfulApi, { ClientAPI } from './create-contentful-api'
-import type { AlphaPlainClientAPI, PlainClientAPI } from './plain/common-types'
+import type {
+  AlphaPlainClientAPI,
+  AlphaPlainClientAPIWithAdapter,
+  PlainClientAPI,
+  PlainClientAPIWithAdapter,
+} from './plain/common-types'
 import type { DefaultParams } from './plain/plain-client'
 import { createPlainClient } from './plain/plain-client'
 import * as editorInterfaceDefaults from './constants/editor-interface-defaults'
@@ -17,7 +22,12 @@ import * as editorInterfaceDefaults from './constants/editor-interface-defaults'
 export type { ClientAPI } from './create-contentful-api'
 export { asIterator } from './plain/as-iterator'
 export { isDraft, isPublished, isUpdated } from './plain/checks'
-export type { PlainClientAPI, AlphaPlainClientAPI } from './plain/common-types'
+export type {
+  PlainClientAPI,
+  AlphaPlainClientAPI,
+  PlainClientAPIWithAdapter,
+  AlphaPlainClientAPIWithAdapter,
+} from './plain/common-types'
 export { createClient }
 export { RestAdapter } from './adapters/REST/rest-adapter'
 export { editorInterfaceDefaults }
@@ -42,6 +52,7 @@ interface UserAgentParams {
  */
 export type ClientParams = RestAdapterParams & UserAgentParams
 type ClientOptions = (RestAdapterParams | AdapterParams) & UserAgentParams
+type ClientOptionsWithAdapter = AdapterParams & Partial<RestAdapterParams & UserAgentParams>
 
 /**
  * Create a client instance
@@ -53,6 +64,14 @@ type ClientOptions = (RestAdapterParams | AdapterParams) & UserAgentParams
  * })
  * ```
  */
+function createClient(
+  params: ClientOptionsWithAdapter,
+  opts: {
+    type: 'plain'
+    alphaFeatures?: string[]
+    defaults?: DefaultParams
+  }
+): PlainClientAPIWithAdapter
 function createClient(params: ClientOptions): ClientAPI
 function createClient(
   params: ClientOptions,
@@ -66,6 +85,14 @@ function createClient<
   T extends (ReadonlyArray<string> | readonly ['workflows']) &
     { [K in keyof T]: { [P in K]: 'workflows' } }[number]
 >(
+  params: ClientOptionsWithAdapter,
+  opts: {
+    type: 'plain'
+    alphaFeatures: T
+    defaults?: DefaultParams
+  }
+): AlphaPlainClientAPIWithAdapter
+function createClient<T extends ['workflows']>(
   params: ClientOptions,
   opts: {
     type: 'plain'
@@ -73,6 +100,14 @@ function createClient<
     defaults?: DefaultParams
   }
 ): AlphaPlainClientAPI
+function createClient(
+  params: ClientOptionsWithAdapter,
+  opts: {
+    type: 'plain'
+    alphaFeatures: string[]
+    defaults?: DefaultParams
+  }
+): PlainClientAPIWithAdapter
 function createClient(
   params: ClientOptions,
   opts: {
@@ -88,7 +123,12 @@ function createClient(
     alphaFeatures?: string[]
     defaults?: DefaultParams
   } = {}
-): ClientAPI | PlainClientAPI | AlphaPlainClientAPI {
+):
+  | ClientAPI
+  | PlainClientAPI
+  | AlphaPlainClientAPI
+  | PlainClientAPIWithAdapter
+  | AlphaPlainClientAPIWithAdapter {
   const sdkMain =
     opts.type === 'plain' ? 'contentful-management-plain.js' : 'contentful-management.js'
   const userAgent = getUserAgentHeader(

--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -10,10 +10,10 @@ import type { MakeRequest } from './common-types'
 import { AdapterParams, createAdapter } from './create-adapter'
 import createContentfulApi, { ClientAPI } from './create-contentful-api'
 import type {
-  AlphaPlainClientAPI,
-  AlphaPlainClientAPIWithAdapter,
   PlainClientAPI,
   PlainClientAPIWithAdapter,
+  AlphaPlainClientAPI,
+  AlphaPlainClientAPIWithAdapter,
 } from './plain/common-types'
 import type { DefaultParams } from './plain/plain-client'
 import { createPlainClient } from './plain/plain-client'
@@ -24,8 +24,8 @@ export { asIterator } from './plain/as-iterator'
 export { isDraft, isPublished, isUpdated } from './plain/checks'
 export type {
   PlainClientAPI,
-  AlphaPlainClientAPI,
   PlainClientAPIWithAdapter,
+  AlphaPlainClientAPI,
   AlphaPlainClientAPIWithAdapter,
 } from './plain/common-types'
 export { createClient }

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -926,6 +926,37 @@ export type PlainClientAPI = {
   }
 }
 
+export type PlainClientAPIWithAdapter = {
+  appAction: Pick<PlainClientAPI['appAction'], 'get' | 'getMany' | 'getManyForEnvironment'>
+  appDefinition: Pick<PlainClientAPI['appDefinition'], 'get' | 'getInstallationsForOrg'>
+  appInstallation: Pick<PlainClientAPI['appInstallation'], 'getForOrganization'>
+  asset: PlainClientAPI['asset']
+  assetKey: PlainClientAPI['assetKey']
+  appSignedRequest: Pick<PlainClientAPI['appSignedRequest'], 'create'>
+  bulkAction: PlainClientAPI['bulkAction']
+  comment: PlainClientAPI['comment']
+  contentType: PlainClientAPI['contentType']
+  editorInterface: PlainClientAPI['editorInterface']
+  environment: Pick<PlainClientAPI['environment'], 'get'>
+  environmentAlias: Pick<PlainClientAPI['environmentAlias'], 'get'>
+  entry: PlainClientAPI['entry']
+  locale: PlainClientAPI['locale']
+  release: PlainClientAPI['release']
+  releaseAction: PlainClientAPI['releaseAction']
+  role: Pick<PlainClientAPI['role'], 'get' | 'getMany'>
+  scheduledActions: PlainClientAPI['scheduledActions']
+  snapshot: PlainClientAPI['snapshot']
+  space: Pick<PlainClientAPI['space'], 'get'>
+  upload: PlainClientAPI['upload']
+  user: Pick<PlainClientAPI['user'], 'getManyForSpace' | 'getForSpace'>
+  usage: Pick<PlainClientAPI['usage'], 'getManyForSpace'>
+  team: Pick<PlainClientAPI['team'], 'getManyForSpace'>
+  task: PlainClientAPI['task']
+  tag: PlainClientAPI['tag']
+  uiConfig: PlainClientAPI['uiConfig']
+  userUIConfig: PlainClientAPI['userUIConfig']
+}
+
 export type AlphaWorkflowExtension = {
   workflowDefinition: {
     get(
@@ -990,3 +1021,5 @@ export type AlphaWorkflowExtension = {
 export type AlphaExtensions = AlphaWorkflowExtension
 
 export type AlphaPlainClientAPI = PlainClientAPI & AlphaWorkflowExtension
+
+export type AlphaPlainClientAPIWithAdapter = PlainClientAPIWithAdapter & AlphaWorkflowExtension


### PR DESCRIPTION
## Summary
Not all cma client methods are available from inside of an app. Thus we're syncing types with cma adapter possibilities.
## Approach
We are introducing new return type for a plain client, which removes all methods that doesn't work inside of an app. At `lib/contentful-management.ts` we check whether adapter has been passed as a param and override return types in such cases.