### PR TITLE
fix: add optional 'errors' property to entry reference return type

### DIFF
--- a/lib/entities/entry.ts
+++ b/lib/entities/entry.ts
@@ -22,11 +22,24 @@ export type EntryProps<T = KeyValueMap> = {
 
 export type CreateEntryProps<TFields = KeyValueMap> = Omit<EntryProps<TFields>, 'sys'>
 
+export type EntryReferenceError = {
+  sys: {
+    type: 'error'
+    id: 'notResolvable'
+  }
+  details: {
+    type: 'Link'
+    linkType: 'Entry' | 'Asset'
+    id: string
+  }
+}
+
 export interface EntryReferenceProps extends CollectionProp<EntryProps> {
   includes?: {
     Entry?: EntryProps[]
     Asset?: AssetProps[]
   }
+  errors?: EntryReferenceError[]
 }
 
 export type EntryReferenceOptionsProps = {


### PR DESCRIPTION
When entry references are not resolvable, the return payload contains an `errors` property with some information. 
This was not reflected in the types yet.
