### PR TITLE
feat(app-action-call): add get details function [NONE]

### DIFF
--- a/lib/adapters/REST/endpoints/app-action-call.ts
+++ b/lib/adapters/REST/endpoints/app-action-call.ts
@@ -1,8 +1,9 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { CreateAppActionCallProps, AppActionCallProps } from '../../../entities/app-action-call'
+import { WebhookCallDetailsProps } from '../../../entities/webhook'
 import * as raw from './raw'
 import { RestEndpoint } from '../types'
-import { GetAppActionCallParams } from '../../../common-types'
+import { GetAppActionCallDetailsParams, GetAppActionCallParams } from '../../../common-types'
 
 export const create: RestEndpoint<'AppActionCall', 'create'> = (
   http: AxiosInstance,
@@ -13,5 +14,15 @@ export const create: RestEndpoint<'AppActionCall', 'create'> = (
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/app_installations/${params.appDefinitionId}/actions/${params.appActionId}/calls`,
     data
+  )
+}
+
+export const getCallDetails: RestEndpoint<'AppActionCall', 'getCallDetails'> = (
+  http: AxiosInstance,
+  params: GetAppActionCallDetailsParams
+) => {
+  return raw.get<WebhookCallDetailsProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/actions/${params.appActionId}/calls/${params.callId}`
   )
 }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -685,6 +685,10 @@ export type MRActions = {
       payload: CreateAppActionCallProps
       return: AppActionCallProps
     }
+    getCallDetails: {
+      params: GetAppActionCallDetailsParams
+      return: WebhookCallDetailsProps
+    }
   }
   AppBundle: {
     get: { params: GetAppBundleParams; return: AppBundleProps }
@@ -1681,6 +1685,10 @@ export type EnvironmentTemplateParams = {
 export type GetAppActionParams = GetAppDefinitionParams & { appActionId: string }
 export type GetAppActionsForEnvParams = GetSpaceParams & { environmentId?: string }
 export type GetAppActionCallParams = GetAppInstallationParams & { appActionId: string }
+export type GetAppActionCallDetailsParams = GetSpaceEnvironmentParams & {
+  appActionId: string
+  callId: string
+}
 export type GetAppBundleParams = GetAppDefinitionParams & { appBundleId: string }
 export type GetAppDefinitionParams = GetOrganizationParams & { appDefinitionId: string }
 export type GetAppInstallationsForOrgParams = GetOrganizationParams & {

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -42,6 +42,7 @@ import {
   GetEnvironmentTemplateParams,
   BasicCursorPaginationOptions,
   EnvironmentTemplateParams,
+  GetAppActionCallDetailsParams,
 } from '../common-types'
 import { ApiKeyProps, CreateApiKeyProps } from '../entities/api-key'
 import {
@@ -208,6 +209,9 @@ export type PlainClientAPI = {
       params: OptionalDefaults<GetAppActionCallParams>,
       payload: CreateAppActionCallProps
     ): Promise<AppActionCallProps>
+    getCallDetails(
+      params: OptionalDefaults<GetAppActionCallDetailsParams>
+    ): Promise<WebhookCallDetailsProps>
   }
   appBundle: {
     get(params: OptionalDefaults<GetAppBundleParams>): Promise<AppBundleProps>

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -69,6 +69,7 @@ export const createPlainClient = (
     },
     appActionCall: {
       create: wrap(wrapParams, 'AppActionCall', 'create'),
+      getCallDetails: wrap(wrapParams, 'AppActionCall', 'getCallDetails'),
     },
     appBundle: {
       get: wrap(wrapParams, 'AppBundle', 'get'),


### PR DESCRIPTION
## Summary
Introduce a new function to receive `AppActionCall` details.

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
