### PR TITLE
fix(app-actions): shape of appActionCall response [NONE]

### DIFF
--- a/lib/entities/app-action-call.ts
+++ b/lib/entities/app-action-call.ts
@@ -3,11 +3,13 @@ import { toPlainObject } from 'contentful-sdk-core'
 import { Except } from 'type-fest'
 import { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '../common-types'
 
-type AppActionCallSys = Except<BasicMetaSysProps, 'version' | 'id'> & {
+type AppActionCallSys = Except<BasicMetaSysProps, 'version'> & {
+  type: 'AppActionCall'
   appDefinition: SysLink
   space: SysLink
   environment: SysLink
   action: SysLink
+  category: SysLink
 }
 
 export type AppActionCallProps = {


### PR DESCRIPTION
## Description

Adding the missing props for the `AppActionCall` response shape
 
## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
