### PR TITLE
fix: move status to sys properties in OrganizationMembership []

### DIFF
--- a/lib/entities/organization-membership.ts
+++ b/lib/entities/organization-membership.ts
@@ -8,17 +8,12 @@ export type OrganizationMembershipProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { user: { sys: MetaLinkProps } }
+  sys: MetaSysProps & { user: { sys: MetaLinkProps }; status: 'active' | 'pending' }
 
   /**
    * Role
    */
   role: string
-
-  /**
-   * status
-   */
-  status: boolean
 }
 
 export interface OrganizationMembership


### PR DESCRIPTION
Fixes the types for OrganizationMemberShip, status is a sys property and not a boolean but an enum "active" | "pending", see. https://github.com/contentful/gatekeeper/blob/ba6c9dba8da0bf9f4e8058b58c358eb4371b9dd7/app/models/organization_membership.rb#L11

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation
