### PR TITLE
chore/bump node version on CircleCI [NONE]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,29 +1,31 @@
 version: 2.1
 orbs:
+  node: circleci/node@5.0.2
   vault: contentful/vault@1
-
+  
 jobs:
   lint:
     docker:
-      - image: cimg/node:16.19.0
+      - image: cimg/base:stable
     steps:
       - checkout
+      - node/install
       - run: node --version
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: npm ci
+      - run: npm install
       - run: npm run prettier:check
       - run: npm run lint
       - run: npm run check-types
   unit:
     docker:
-      - image: cimg/node:16.19.0
+      - image: cimg/base:stable
     steps:
       - checkout
       - node/install
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: npm ci
+      - run: npm install
       - run: npm run build
       - run: npm run test:cover-unit
       - store_test_results:
@@ -32,13 +34,13 @@ jobs:
           path: ./reports/unit-results.xml
   integration:
     docker:
-      - image: cimg/node:16.19.0
+      - image: cimg/base:stable
     steps:
       - checkout
       - node/install
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: npm ci
+      - run: npm install
       - run: npm run build
       - run: npm run test:cover-integration
       - store_test_results:
@@ -47,13 +49,13 @@ jobs:
           path: ./reports/integration-results.xml
   release:
     docker:
-      - image: cimg/node:16.19.0
+      - image: cimg/base:stable
     steps:
       - checkout
       - vault/get-secrets: # Loads vault secrets
           template-preset: 'semantic-release-ecosystem'
       - node/install
-      - run: npm ci
+      - run: npm install
       - run: npm run semantic-release
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,29 @@
 version: 2.1
 orbs:
-  node: circleci/node@5.0.2
   vault: contentful/vault@1
-  
+
 jobs:
   lint:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/node:16.19.0
     steps:
       - checkout
-      - node/install
       - run: node --version
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: npm install
+      - run: npm ci
       - run: npm run prettier:check
       - run: npm run lint
       - run: npm run check-types
   unit:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/node:16.19.0
     steps:
       - checkout
       - node/install
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - run: npm run test:cover-unit
       - store_test_results:
@@ -34,13 +32,13 @@ jobs:
           path: ./reports/unit-results.xml
   integration:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/node:16.19.0
     steps:
       - checkout
       - node/install
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - run: npm run test:cover-integration
       - store_test_results:
@@ -49,13 +47,13 @@ jobs:
           path: ./reports/integration-results.xml
   release:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/node:16.19.0
     steps:
       - checkout
       - vault/get-secrets: # Loads vault secrets
           template-preset: 'semantic-release-ecosystem'
       - node/install
-      - run: npm install
+      - run: npm ci
       - run: npm run semantic-release
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,28 @@
 version: 2.1
 orbs:
-  node: circleci/node@5.0.2
   vault: contentful/vault@1
-  
+
 jobs:
   lint:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/node:16.19.0
     steps:
       - checkout
-      - node/install
       - run: node --version
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: npm install
+      - run: npm ci
       - run: npm run prettier:check
       - run: npm run lint
       - run: npm run check-types
   unit:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/node:16.19.0
     steps:
       - checkout
-      - node/install
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - run: npm run test:cover-unit
       - store_test_results:
@@ -34,13 +31,12 @@ jobs:
           path: ./reports/unit-results.xml
   integration:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/node:16.19.0
     steps:
       - checkout
-      - node/install
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - run: npm run test:cover-integration
       - store_test_results:
@@ -49,13 +45,12 @@ jobs:
           path: ./reports/integration-results.xml
   release:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/node:16.19.0
     steps:
       - checkout
       - vault/get-secrets: # Loads vault secrets
           template-preset: 'semantic-release-ecosystem'
-      - node/install
-      - run: npm install
+      - run: npm ci
       - run: npm run semantic-release
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,14 @@ version: 2.1
 orbs:
   vault: contentful/vault@1
 
-jobs:
-  lint:
+executors:
+  docker-with-node:
     docker:
       - image: cimg/node:16.19.0
+
+jobs:
+  lint:
+    executor: docker-with-node
     steps:
       - checkout
       - run: node --version
@@ -16,36 +20,31 @@ jobs:
       - run: npm run lint
       - run: npm run check-types
   unit:
-    docker:
-      - image: cimg/node:16.19.0
+    executor: docker-with-node
     steps:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: npm ci
-      - run: npm run build
       - run: npm run test:cover-unit
       - store_test_results:
           path: reports
       - store_artifacts:
           path: ./reports/unit-results.xml
   integration:
-    docker:
-      - image: cimg/node:16.19.0
+    executor: docker-with-node
     steps:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: npm ci
-      - run: npm run build
       - run: npm run test:cover-integration
       - store_test_results:
           path: reports
       - store_artifacts:
           path: ./reports/integration-results.xml
   release:
-    docker:
-      - image: cimg/node:16.19.0
+    executor: docker-with-node
     steps:
       - checkout
       - vault/get-secrets: # Loads vault secrets


### PR DESCRIPTION
We should at least build with node `16.x`, and we should only use `npm ci`