### PR TITLE
fix: release metadata types []

### DIFF
--- a/lib/entities/release.ts
+++ b/lib/entities/release.ts
@@ -82,15 +82,15 @@ export type ReleaseSysProps = {
   lastAction?: Link<'ReleaseAction'>
 }
 export type ReleaseReferenceFilters = ScheduledActionReferenceFilters
+export const ReleaseReferenceFilters = ScheduledActionReferenceFilters
 
 export type ReleaseMetadata = {
-  withReferences: [
-    {
-      entity: Link<'Entry'>
-      filter: Record<ReleaseReferenceFilters, string[]>[]
-    }
-  ]
+  withReferences: {
+    entity: Link<'Entry'>
+    filter: Record<ReleaseReferenceFilters, string[]>
+  }[]
 }
+
 /** The object returned by the Releases API */
 export interface ReleaseProps {
   title: string

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -145,6 +145,8 @@ export type {
   ReleaseQueryOptions,
   ReleaseSysProps,
   ReleaseValidateOptions,
+  ReleaseMetadata,
+  ReleaseReferenceFilters,
 } from './entities/release'
 export type {
   ReleaseAction,


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->
The previous implementation in #1624 is not defining the `release.metadata.withReferences` type as an array properly which causes errors when trying to use the type. Here I am fixing this.

The new types were also not exported from `./lib/export-types.ts`, so I am doing that here.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
