### PR TITLE
fix: remove waitForEnvironmentToBeReady from x-space integration tests

### DIFF
--- a/test/integration/entry-integration.js
+++ b/test/integration/entry-integration.js
@@ -8,7 +8,6 @@ import {
   generateRandomId,
   getDefaultSpace,
   initPlainClient,
-  waitForEnvironmentToBeReady,
 } from '../helpers'
 
 describe('Entry Api', () => {
@@ -310,7 +309,6 @@ describe('Entry Api', () => {
     before(async () => {
       space = await createTestSpace(initClient(), 'Entry')
       environment = await createTestEnvironment(space, 'Testing Environment')
-      await waitForEnvironmentToBeReady(space, environment)
     })
 
     after(async () => {
@@ -488,7 +486,6 @@ describe('Entry Api', () => {
           xSpaceEnabledSpace,
           'Test Cross Space'
         )
-        await waitForEnvironmentToBeReady(xSpaceEnabledSpace, xSpaceEnabledEnvironment)
         xSpaceEnabledContentType = await xSpaceEnabledEnvironment.getContentType(
           TestDefaults.contentType.withCrossSpaceReferenceId
         )


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->
x-space tests were occasionally failing, this is a quick PR to investigate and try to fix this issue.

