### PR TITLE
fix: move type-fest from dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "axios": "^0.27.1",
     "contentful-sdk-core": "^7.0.1",
     "fast-copy": "^3.0.0",
-    "lodash.isplainobject": "^4.0.6"
+    "lodash.isplainobject": "^4.0.6",
+    "type-fest": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.7",
@@ -124,7 +125,6 @@
     "rimraf": "^4.1.1",
     "semantic-release": "^19.0.5",
     "sinon": "^15.0.0",
-    "type-fest": "^3.0.0",
     "typedoc": "^0.23.24",
     "typescript": "^4.9.4",
     "webpack": "^4.46.0",


### PR DESCRIPTION
## Summary

Move type-fest from dev-dependencies
it fixes https://github.com/contentful/contentful-management.js/issues/1410

