### PR TITLE
Fix: skip x-space reference flaky test [NONE]

### DIFF
--- a/test/integration/entry-integration.js
+++ b/test/integration/entry-integration.js
@@ -431,7 +431,7 @@ describe('Entry Api', () => {
    * entry '4zimQzVMxDsSX607PCfo2u' from the space '6mqcevu5a50r' is deleted
    * Content type with id stored in `TestDefaults.contentType.withCrossSpaceReferenceId` is deleted
    */
-  describe('write with x-space references', () => {
+  describe.skip('write with x-space references', () => {
     let contentTypeData = {
       name: 'testCTXSpace',
       fields: [


### PR DESCRIPTION
Temporarily skip the x-space reference flaky test, to unblock the CI pipeline 