### PR TITLE
fix: declare the depricated definition first to fix the import issue [HOMER-1556]

### DIFF
--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -44,6 +44,17 @@ export type ClientParams = RestAdapterParams & UserAgentParams
 type ClientOptions = (RestAdapterParams | AdapterParams) & UserAgentParams
 
 /**
+ * @deprecated the alphaFeatures option is not longer supported
+ */
+function createClient(
+  params: ClientOptions,
+  opts: {
+    type?: 'plain'
+    alphaFeatures: string[]
+    defaults?: DefaultParams
+  }
+): ClientAPI | PlainClientAPI
+/**
  * Create a client instance
  * @param params - Client initialization parameters
  *
@@ -61,17 +72,6 @@ function createClient(
     defaults?: DefaultParams
   }
 ): PlainClientAPI
-/**
- * @deprecated the alphaFeatures option is not longer supported
- */
-function createClient(
-  params: ClientOptions,
-  opts: {
-    type?: 'plain'
-    alphaFeatures: string[]
-    defaults?: DefaultParams
-  }
-): ClientAPI | PlainClientAPI
 function createClient(
   params: ClientOptions,
   opts: {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Changing the declaration order with having the deprecation on top fixes the issue in https://github.com/contentful/user_interface/pull/13691

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
