### PR TITLE
feat: allow asset.getMany to accept extra headers

### DIFF
--- a/lib/adapters/REST/endpoints/asset.ts
+++ b/lib/adapters/REST/endpoints/asset.ts
@@ -27,20 +27,23 @@ export const get: RestEndpoint<'Asset', 'get'> = (
     `/spaces/${params.spaceId}/environments/${params.environmentId}/assets/${params.assetId}`,
     {
       params: normalizeSelect(params.query),
-      headers: { ...headers },
+      headers: headers ? { ...headers } : undefined,
     }
   )
 }
 
 export const getMany: RestEndpoint<'Asset', 'getMany'> = (
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & QueryParams
+  params: GetSpaceEnvironmentParams & QueryParams,
+  rawData?: unknown,
+  headers?: AxiosRequestHeaders
 ) => {
   return raw.get<CollectionProp<AssetProps>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/assets`,
     {
       params: normalizeSelect(params.query),
+      headers: headers ? { ...headers } : undefined,
     }
   )
 }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -827,9 +827,14 @@ export type MRActions = {
     }
   }
   Asset: {
-    getMany: { params: GetSpaceEnvironmentParams & QueryParams; return: CollectionProp<AssetProps> }
+    getMany: {
+      params: GetSpaceEnvironmentParams & QueryParams
+      headers?: AxiosRequestHeaders
+      return: CollectionProp<AssetProps>
+    }
     get: {
       params: GetSpaceEnvironmentParams & { assetId: string } & QueryParams
+      headers?: AxiosRequestHeaders
       return: AssetProps
     }
     update: {

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -508,7 +508,9 @@ export type PlainClientAPI = {
   }
   asset: {
     getMany(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>
+      params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>,
+      rawData?: unknown,
+      headers?: AxiosRequestHeaders
     ): Promise<CollectionProp<AssetProps>>
     get(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string } & QueryParams>,


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Allow asset.getMany method to accept extra headers.

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
