### PR TITLE
fix: exclude `metadata` field from types related to SnapshotAPI

### DIFF
--- a/lib/adapters/REST/endpoints/snapshot.ts
+++ b/lib/adapters/REST/endpoints/snapshot.ts
@@ -25,9 +25,13 @@ export const getManyForEntry: RestEndpoint<'Snapshot', 'getManyForEntry'> = <
   http: AxiosInstance,
   params: GetSnapshotForEntryParams & QueryParams
 ) => {
-  return raw.get<CollectionProp<SnapshotProps<EntryProps<T>>>>(http, getBaseEntryUrl(params), {
-    params: normalizeSelect(params.query),
-  })
+  return raw.get<CollectionProp<SnapshotProps<Omit<EntryProps<T>, 'metadata'>>>>(
+    http,
+    getBaseEntryUrl(params),
+    {
+      params: normalizeSelect(params.query),
+    }
+  )
 }
 
 export const getForEntry: RestEndpoint<'Snapshot', 'getForEntry'> = <
@@ -36,7 +40,7 @@ export const getForEntry: RestEndpoint<'Snapshot', 'getForEntry'> = <
   http: AxiosInstance,
   params: GetSnapshotForEntryParams & { snapshotId: string }
 ) => {
-  return raw.get<SnapshotProps<EntryProps<T>>>(http, getEntryUrl(params))
+  return raw.get<SnapshotProps<Omit<EntryProps<T>, 'metadata'>>>(http, getEntryUrl(params))
 }
 
 const getBaseContentTypeUrl = (params: GetSnapshotForContentTypeParams) =>

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1341,11 +1341,11 @@ export type MRActions = {
   Snapshot: {
     getManyForEntry: {
       params: GetSnapshotForEntryParams & QueryParams
-      return: CollectionProp<SnapshotProps<EntryProps<any>>>
+      return: CollectionProp<SnapshotProps<Omit<EntryProps<any>, 'metadata'>>>
     }
     getForEntry: {
       params: GetSnapshotForEntryParams & { snapshotId: string }
-      return: SnapshotProps<EntryProps<any>>
+      return: SnapshotProps<Omit<EntryProps<any>, 'metadata'>>
     }
     getManyForContentType: {
       params: GetSnapshotForContentTypeParams & QueryParams

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -820,10 +820,10 @@ export type PlainClientAPI = {
   snapshot: {
     getManyForEntry<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSnapshotForEntryParams & QueryParams>
-    ): Promise<CollectionProp<SnapshotProps<EntryProps<T>>>>
+    ): Promise<CollectionProp<SnapshotProps<Omit<EntryProps<T>, 'metadata'>>>>
     getForEntry<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSnapshotForEntryParams & { snapshotId: string }>
-    ): Promise<SnapshotProps<EntryProps<T>>>
+    ): Promise<SnapshotProps<Omit<EntryProps<T>, 'metadata'>>>
     getManyForContentType(
       params: OptionalDefaults<GetSnapshotForContentTypeParams & QueryParams>
     ): Promise<CollectionProp<SnapshotProps<ContentTypeProps>>>


### PR DESCRIPTION
## Summary

As SnapshotsAPI returns instead of three entity fields `sys`, `fields` and `metadata`  only two (except `metadata`), we need to adjust TypeScript types.

Only type changes involved, no actual behavioural changes.

