### PR TITLE
fix: improve exported types for rich text comments [HOMER-1764]

### DIFF
--- a/lib/adapters/REST/endpoints/comment.ts
+++ b/lib/adapters/REST/endpoints/comment.ts
@@ -17,7 +17,7 @@ import {
   GetManyCommentsParams,
   PlainTextBodyFormat,
   RichTextBodyFormat,
-  RichCommentBodyPayload,
+  RichTextCommentBodyPayload,
 } from '../../../entities/comment'
 import { RestEndpoint } from '../types'
 import * as raw from './raw'
@@ -80,7 +80,7 @@ export const getMany: RestEndpoint<'Comment', 'getMany'> = (
 export const create: RestEndpoint<'Comment', 'create'> = (
   http: AxiosInstance,
   params: CreateCommentParams,
-  rawData: CreateCommentProps | RichCommentBodyPayload
+  rawData: CreateCommentProps | RichTextCommentBodyPayload
 ) => {
   const data = copy(rawData)
   return raw.post<CommentProps>(http, getEntityBaseUrl(params), data, {
@@ -96,7 +96,7 @@ export const create: RestEndpoint<'Comment', 'create'> = (
 export const update: RestEndpoint<'Comment', 'update'> = (
   http: AxiosInstance,
   params: GetCommentParams,
-  rawData: UpdateCommentProps | (Omit<UpdateCommentProps, 'body'> & RichCommentBodyPayload),
+  rawData: UpdateCommentProps | (Omit<UpdateCommentProps, 'body'> & RichTextCommentBodyPayload),
   headers?: AxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -23,9 +23,9 @@ import {
   UpdateCommentProps,
   GetManyCommentsParams,
   RichTextBodyFormat,
-  RichCommentProps,
+  RichTextCommentProps,
   PlainTextBodyFormat,
-  RichCommentBodyPayload,
+  RichTextCommentBodyPayload,
 } from './entities/comment'
 import { EditorInterfaceProps } from './entities/editor-interface'
 import { CreateEntryProps, EntryProps, EntryReferenceProps } from './entities/entry'
@@ -914,7 +914,7 @@ export type MRActions = {
   Comment: {
     get:
       | { params: GetCommentParams & PlainTextBodyFormat; return: CommentProps }
-      | { params: GetCommentParams & RichTextBodyFormat; return: RichCommentProps }
+      | { params: GetCommentParams & RichTextBodyFormat; return: RichTextCommentProps }
     getMany:
       | {
           params: GetManyCommentsParams & PlainTextBodyFormat & QueryParams
@@ -922,7 +922,7 @@ export type MRActions = {
         }
       | {
           params: GetManyCommentsParams & QueryParams & RichTextBodyFormat
-          return: CollectionProp<RichCommentProps>
+          return: CollectionProp<RichTextCommentProps>
         }
     getAll:
       | {
@@ -931,7 +931,7 @@ export type MRActions = {
         }
       | {
           params: GetManyCommentsParams & QueryParams & RichTextBodyFormat
-          return: CollectionProp<RichCommentProps>
+          return: CollectionProp<RichTextCommentProps>
         }
     create:
       | {
@@ -941,8 +941,8 @@ export type MRActions = {
         }
       | {
           params: CreateCommentParams & RichTextBodyFormat
-          payload: RichCommentBodyPayload
-          return: RichCommentProps
+          payload: RichTextCommentBodyPayload
+          return: RichTextCommentProps
         }
     update:
       | {
@@ -953,9 +953,9 @@ export type MRActions = {
         }
       | {
           params: UpdateCommentParams
-          payload: Omit<UpdateCommentProps, 'body'> & RichCommentBodyPayload
+          payload: Omit<UpdateCommentProps, 'body'> & RichTextCommentBodyPayload
           headers?: AxiosRequestHeaders
-          return: RichCommentProps
+          return: RichTextCommentProps
         }
     delete: { params: DeleteCommentParams; return: void }
   }

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -62,12 +62,12 @@ export interface RootParagraph extends Node {
 }
 
 // Add "extends Document" as soon as rich-text-types supports mentions.
-export interface RichTextDocument extends Node {
+export interface RichTextCommentDocument extends Node {
   nodeType: CommentNode.Document
   content: RootParagraph[]
 }
 
-export type RichTextCommentBodyPayload = { body: RichTextDocument }
+export type RichTextCommentBodyPayload = { body: RichTextCommentDocument }
 
 export type RichTextCommentProps = Omit<CommentProps, 'body'> & RichTextCommentBodyPayload
 

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -66,9 +66,9 @@ export interface RichTextDocument extends Node {
   content: RootParagraph[]
 }
 
-export type RichCommentBodyPayload = { body: RichTextDocument }
+export type RichTextCommentBodyPayload = { body: RichTextDocument }
 
-export type RichCommentProps = Omit<CommentProps, 'body'> & RichCommentBodyPayload
+export type RichTextCommentProps = Omit<CommentProps, 'body'> & RichTextCommentBodyPayload
 
 // We keep this type as explicit as possible until we open up the comments entity further
 export type GetCommentParentEntityParams = GetSpaceEnvironmentParams &
@@ -97,7 +97,7 @@ export interface Comment extends CommentProps, DefaultElements<CommentProps>, Co
 
 export interface RichTextComment
   extends Omit<CommentProps, 'body'>,
-    RichCommentProps,
+    RichTextCommentProps,
     DefaultElements<CommentProps>,
     CommentApi {}
 
@@ -146,7 +146,7 @@ export default function createCommentApi(makeRequest: MakeRequest): CommentApi {
  */
 export function wrapComment(
   makeRequest: MakeRequest,
-  data: CommentProps | RichCommentProps
+  data: CommentProps | RichTextCommentProps
 ): Comment | RichTextComment {
   const comment = toPlainObject(copy(data))
   const commentWithMethods = enhanceWithMethods(comment, createCommentApi(makeRequest))

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -1,5 +1,5 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
-import { Node, Text, Mark } from '@contentful/rich-text-types'
+import { Node, Text } from '@contentful/rich-text-types'
 import copy from 'fast-copy'
 import {
   BasicMetaSysProps,
@@ -41,12 +41,14 @@ export type UpdateCommentProps = Omit<CommentProps, 'sys'> & {
   sys: Pick<CommentSysProps, 'version'>
 }
 
+// Remove and replace with BLOCKS as soon as rich-text-types supports mentions
 export enum CommentNode {
   Document = 'document',
   Paragraph = 'paragraph',
   Mention = 'mention',
 }
 
+// Add "extends Block" as soon as rich-text-types supports mentions
 export interface Mention {
   nodeType: CommentNode.Mention
   data: { target: Link<'User'> }
@@ -58,6 +60,7 @@ export interface RootParagraph extends Node {
   content: (Text | Mention)[]
 }
 
+// Add "extends Document" as soon as rich-text-types supports mentions.
 export interface RichTextDocument extends Node {
   nodeType: CommentNode.Document
   content: RootParagraph[]

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -23,6 +23,7 @@ export type CommentSysProps = Pick<
   space: SysLink
   environment: SysLink
   parentEntity: Link<'Entry'> | VersionedLink<'Workflow'>
+  parent: Link<'Comment'> | null
 }
 
 export type PlainTextBodyProperty = 'plain-text'

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -66,7 +66,7 @@ export type {
 } from './entities/bulk-action'
 export type {
   RichTextDocument,
-  RichCommentProps,
+  RichTextCommentProps,
   Comment,
   CommentProps,
   CreateCommentProps,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -65,7 +65,7 @@ export type {
   BulkActionValidatePayload,
 } from './entities/bulk-action'
 export type {
-  RichTextDocument,
+  RichTextCommentDocument,
   RichTextCommentProps,
   Comment,
   CommentProps,

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -66,8 +66,8 @@ import {
   UpdateCommentProps,
   GetManyCommentsParams,
   RichTextBodyFormat,
-  RichCommentProps,
-  RichCommentBodyPayload,
+  RichTextCommentProps,
+  RichTextCommentBodyPayload,
   PlainTextBodyFormat,
 } from '../entities/comment'
 import { ContentTypeProps, CreateContentTypeProps } from '../entities/content-type'
@@ -393,13 +393,15 @@ export type PlainClientAPI = {
   }
   comment: {
     get(params: OptionalDefaults<GetCommentParams> & PlainTextBodyFormat): Promise<CommentProps>
-    get(params: OptionalDefaults<GetCommentParams> & RichTextBodyFormat): Promise<RichCommentProps>
+    get(
+      params: OptionalDefaults<GetCommentParams> & RichTextBodyFormat
+    ): Promise<RichTextCommentProps>
     getMany(
       params: OptionalDefaults<GetManyCommentsParams & PlainTextBodyFormat & QueryParams>
     ): Promise<CollectionProp<CommentProps>>
     getMany(
       params: OptionalDefaults<GetManyCommentsParams & QueryParams & RichTextBodyFormat>
-    ): Promise<CollectionProp<RichCommentProps>>
+    ): Promise<CollectionProp<RichTextCommentProps>>
     create(
       params: OptionalDefaults<CreateCommentParams>,
       rawData: CreateCommentProps,
@@ -407,9 +409,9 @@ export type PlainClientAPI = {
     ): Promise<CommentProps>
     create(
       params: OptionalDefaults<CreateCommentParams>,
-      rawData: RichCommentBodyPayload,
+      rawData: RichTextCommentBodyPayload,
       headers?: AxiosRequestHeaders
-    ): Promise<RichCommentProps>
+    ): Promise<RichTextCommentProps>
     update(
       params: OptionalDefaults<UpdateCommentParams>,
       rawData: UpdateCommentProps,
@@ -417,9 +419,9 @@ export type PlainClientAPI = {
     ): Promise<CommentProps>
     update(
       params: OptionalDefaults<UpdateCommentParams>,
-      rawData: Omit<UpdateCommentProps, 'body'> & RichCommentBodyPayload,
+      rawData: Omit<UpdateCommentProps, 'body'> & RichTextCommentBodyPayload,
       headers?: AxiosRequestHeaders
-    ): Promise<RichCommentProps>
+    ): Promise<RichTextCommentProps>
     delete(params: OptionalDefaults<DeleteCommentParams>): Promise<void>
   }
   contentType: {

--- a/lib/plain/plain-client-test.ts
+++ b/lib/plain/plain-client-test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha'
 import Sinon from 'sinon'
 import { Adapter, createClient } from '../contentful-management'
 import sinonChai from 'sinon-chai'
-import { CommentNode, RichTextDocument } from '../entities/comment'
+import { CommentNode, RichTextCommentDocument } from '../entities/comment'
 
 chai.should()
 chai.use(sinonChai)
@@ -87,7 +87,7 @@ describe('Plain Client', () => {
     })
 
     describe('when body is rich text', () => {
-      const richTextBody: RichTextDocument = {
+      const richTextBody: RichTextCommentDocument = {
         data: {},
         nodeType: CommentNode.Document,
         content: [


### PR DESCRIPTION
## Summary

- chore: add comments about future refactoring (we're currently having typing issues in web app since `Document` and `RichTextDocument` collide.
- refactor: rename RichComment to RichTextComment (use the same prefix in all types)
- feat: add parent to comment type (very old "bug" that just surfaced in web app when adding types)
- refactpr: rename RichTextDocument to RichTextCommentDocument (this type is only usable for comments, so better make it clear that this is not about normal rich text fields)