### PR TITLE
fix: forbid combining REST and App adapter types in ClientOptions

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -649,6 +649,16 @@ export type MakeRequestWithUserAgent = MRInternal<true>
  */
 export type MakeRequest = MRInternal<false>
 
+/**
+ * @private
+ */
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never }
+
+/**
+ * @private
+ */
+export type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U
+
 export interface Adapter {
   makeRequest: MakeRequestWithUserAgent
 }

--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -41,10 +41,7 @@ interface UserAgentParams {
  * @deprecated
  */
 export type ClientParams = RestAdapterParams & UserAgentParams
-
-type ClientOptions = UserAgentParams &
-  (RestAdapterParams | AdapterParams) &
-  XOR<RestAdapterParams, AdapterParams>
+type ClientOptions = UserAgentParams & XOR<RestAdapterParams, AdapterParams>
 
 /**
  * @deprecated the alphaFeatures option is not longer supported

--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -6,7 +6,7 @@
 
 import { getUserAgentHeader } from 'contentful-sdk-core'
 import type { RestAdapterParams } from './adapters/REST/rest-adapter'
-import type { MakeRequest } from './common-types'
+import type { MakeRequest, XOR } from './common-types'
 import { AdapterParams, createAdapter } from './create-adapter'
 import createContentfulApi, { ClientAPI } from './create-contentful-api'
 import type { PlainClientAPI } from './plain/common-types'
@@ -41,9 +41,6 @@ interface UserAgentParams {
  * @deprecated
  */
 export type ClientParams = RestAdapterParams & UserAgentParams
-
-type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never }
-type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U
 
 type ClientOptions = UserAgentParams &
   (RestAdapterParams | AdapterParams) &

--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -41,7 +41,13 @@ interface UserAgentParams {
  * @deprecated
  */
 export type ClientParams = RestAdapterParams & UserAgentParams
-type ClientOptions = (RestAdapterParams | AdapterParams) & UserAgentParams
+
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never }
+type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U
+
+type ClientOptions = UserAgentParams &
+  (RestAdapterParams | AdapterParams) &
+  XOR<RestAdapterParams, AdapterParams>
 
 /**
  * @deprecated the alphaFeatures option is not longer supported


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

We are currently streamlining adapter types by removing unnecessary parameters. Although the code below was previously valid, passing { apiAdapter: sdk.cmaAdapter } negates the need for additional parameters to be passed. Therefore, if you pass apiAdapter, no further parameters are required. Now the below code will give error.
```
const client = contentful.createClient(
  { apiAdapter: sdk.cmaAdapter, accessToken: 'YOUR_ACCESS_TOKEN' },
  { type: "plain" }
);

```

## Description

Change the `ClientOptions` to accept only one of the either `RestAdapterParams` / `AdapterParams`