### PR TITLE
feat: add nodes validation

### DIFF
--- a/lib/entities/content-type-fields.ts
+++ b/lib/entities/content-type-fields.ts
@@ -15,6 +15,18 @@ interface RegExp {
   flags: string
 }
 
+type RichTextNode =
+  | 'embedded-entry-block'
+  | 'embedded-entry-inline'
+  | 'embedded-asset-inline'
+  | 'entry-hyperlink'
+  | 'asset-hyperlink'
+  | 'hyperlink'
+
+type NodesValidation = {
+  [k in RichTextNode]: [Pick<ContentTypeFieldValidation, 'size' | 'linkContentType' | 'message'>]
+}
+
 export interface ContentTypeFieldValidation {
   linkContentType?: string[]
   in?: (string | number)[]
@@ -33,6 +45,7 @@ export interface ContentTypeFieldValidation {
     height?: NumRange
   }
   assetFileSize?: NumRange
+  nodes?: NodesValidation
 }
 
 interface Item {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

* Add `nodes` validation key in the `ContentTypeFieldValidation` interface.

## Description

<!-- Describe your changes in detail -->

* Creates a new interface `RichTextNode` which includes the available types for Rich Text nodes with embedded resources like hyperlink, asset and entries.
* Add `nodes` key to the `ContentTypeFieldValidation` interface, allowing to add validations for these nodes such as **size**, **linkContentType**, **message**.

## Motivation and Context

This is a valid validation that we can apply to the Content Model but we don't have autocomplete feature for it, making think that this does not exist at all.

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
