### PR TITLE
fix: change overload order to not show the deprecation per default [HOMER-1999]

### DIFF
--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -44,17 +44,6 @@ export type ClientParams = RestAdapterParams & UserAgentParams
 type ClientOptions = UserAgentParams & XOR<RestAdapterParams, AdapterParams>
 
 /**
- * @deprecated the alphaFeatures option is not longer supported
- */
-function createClient(
-  params: ClientOptions,
-  opts: {
-    type?: 'plain'
-    alphaFeatures: string[]
-    defaults?: DefaultParams
-  }
-): ClientAPI | PlainClientAPI
-/**
  * Create a client instance
  * @param params - Client initialization parameters
  *
@@ -72,6 +61,17 @@ function createClient(
     defaults?: DefaultParams
   }
 ): PlainClientAPI
+/**
+ * @deprecated the alphaFeatures option is not longer supported
+ */
+function createClient(
+  params: ClientOptions,
+  opts: {
+    type?: 'plain'
+    alphaFeatures: string[]
+    defaults?: DefaultParams
+  }
+): ClientAPI | PlainClientAPI
 function createClient(
   params: ClientOptions,
   opts: {


### PR DESCRIPTION
## Summary

In some IDEs, it will only pick up the JSDoc of the first overload for a function. By moving the deprecated overload to the end, we hope to mitigate the wrongly shown deprecation warning.

## Description

We need to change the order of function overloads for `createClient`. In some cases, the IDE will pick up only the JSDoc for the first overload and even mark the usage as `deprecated` as shown in [this issue](https://github.com/contentful/contentful-management.js/issues/1701). Weirdly, we can't reproduce this consistently with the same version of VSC & TS. In some cases, it works as expected. In a few other cases, the TS engine appears to pick up only the first overload and render any usage of the function as being deprecated.

This is a reported issue for VSC ([issue](https://github.com/microsoft/TypeScript/issues/407#issuecomment-650266584)) and WebStorm ([issue](https://youtrack.jetbrains.com/issue/WEB-59045)). It appears we can mitigate this scenario by changing the order of overloads.

We also tested this on the TS playground ([see here](https://www.typescriptlang.org/play?ts=5.0.4#code/PQKhCgAIUgBATApgBwE6IMYEMAuj6Q4AWikAlgM4DKArgEYU6pYY5kD2AdpO8m1+QqRO7HJAA2XAOaJUkCjWTJ2qPPAB0kAArjEWCqRoHIWeSizM8kALaJi7AgDMVhIrhOcC6a+wBupYkoePg5uR1R2a1dSRxpOVlDIbHFxdSgQYChY+P5uLHh4ADkaazpZCgAKLAAuYRKy1AAaSDpaznrZZt4cClqAbyhIIcpCxClcMn8Aflq6dnZdLE4AbkHh6npGZgSuWfnFlfAAXwBKNo7ULLidvILi0vKq84emlueGs7qXq5zE-KKLpUal8Gs1WiDOsEev01oJRuM2NM9gs9IdTu9ZD8biY7oCnhDXuD2i9mn04WMJv5mpRaAwmCxcpAjjChut4ZTEDMWvtUatWYJaVsGaEuXMUUtVkdIABeSB9dEEuWwjBcRjyZIWGXkhGTUhTSAAWgAjJBakbYWRHJAKjTNvSbiclfz+egcDRUNwqoaWo6YBQNZd+VLWa73Z7TABqH3QdVYcQWY7gcAqzhquhYABeWv+9walROSZTauc7GzuJelQATM0ACwnVZFlHqSRSColgvJ1VidNyWU5vEADmaADZSQK7dtcrUmDRSKcG6qmy2Kj2O+AgA)) but couldn't reproduce it there as well.