### PR TITLE
feat: make workflow.sys.id optional to find all past workflows [HOMER-2006]

### DIFF
--- a/lib/entities/workflows-changelog-entry.ts
+++ b/lib/entities/workflows-changelog-entry.ts
@@ -18,6 +18,8 @@ export type WorkflowsChangelogQueryOptions = Omit<PaginationQueryOptions, 'order
   'entity.sys.id': string
   /** workflow.sys.id is optional so all past workflows can be found */
   'workflow.sys.id'?: string
+  'eventAt[lte]'?: string
+  'eventAt[gte]'?: string
 }
 
 export type WorkflowsChangelogEntryProps = {

--- a/lib/entities/workflows-changelog-entry.ts
+++ b/lib/entities/workflows-changelog-entry.ts
@@ -16,7 +16,8 @@ export type WorkflowsChangelogQueryOptions = Omit<PaginationQueryOptions, 'order
   'entity.sys.linkType': string
   /** Find workflows changelog entries containing the specified, comma-separated entities. Requires `sys.entity.sys.linkType` */
   'entity.sys.id': string
-  'workflow.sys.id': string
+  /** workflow.sys.id is optional so all past workflows can be found */
+  'workflow.sys.id'?: string
 }
 
 export type WorkflowsChangelogEntryProps = {


### PR DESCRIPTION
## Summary

workflow.sys.id is going to be optional for the request parameters, in order to be able to retrieve all past workflows.