### PR TITLE
feat: extend type CommentProps for new status marker

### DIFF
--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -38,7 +38,10 @@ export type RichTextBodyProperty = 'rich-text'
 export type RichTextBodyFormat = { bodyFormat: RichTextBodyProperty }
 export type PlainTextBodyFormat = { bodyFormat?: PlainTextBodyProperty }
 
-export enum CommentStatus {'active', 'resolved'}
+export enum CommentStatus {
+  'active',
+  'resolved',
+}
 
 export type CommentProps = {
   sys: CommentSysProps

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -38,9 +38,12 @@ export type RichTextBodyProperty = 'rich-text'
 export type RichTextBodyFormat = { bodyFormat: RichTextBodyProperty }
 export type PlainTextBodyFormat = { bodyFormat?: PlainTextBodyProperty }
 
+export enum CommentStatus {'active', 'resolved'}
+
 export type CommentProps = {
   sys: CommentSysProps
   body: string
+  status?: CommentStatus
 }
 
 export type CreateCommentProps = Omit<CommentProps, 'sys'>

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -49,9 +49,13 @@ export type CommentProps = {
   status: CommentStatus
 }
 
-export type CreateCommentProps = Omit<CommentProps, 'sys'>
-export type UpdateCommentProps = Omit<CommentProps, 'sys'> & {
+export type CreateCommentProps = Omit<CommentProps, 'sys' | 'status'> & {
+  status?: CommentStatus
+}
+
+export type UpdateCommentProps = Omit<CommentProps, 'sys' | 'status'> & {
   sys: Pick<CommentSysProps, 'version'>
+  status?: CommentStatus
 }
 
 // Remove and replace with BLOCKS as soon as rich-text-types supports mentions

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -46,7 +46,7 @@ export enum CommentStatus {
 export type CommentProps = {
   sys: CommentSysProps
   body: string
-  status?: CommentStatus
+  status: CommentStatus
 }
 
 export type CreateCommentProps = Omit<CommentProps, 'sys'>


### PR DESCRIPTION
## Summary
The comments api got extended and delivers now a status field. This field is meant to represent the comment-thread status. Comments can now be marked as resolved, in order to help organize conversations in comments. The currently available states are 'active' and 'resolved'
