### PR TITLE
feat: add types for nodes validations

### DIFF
--- a/lib/entities/content-type-fields.ts
+++ b/lib/entities/content-type-fields.ts
@@ -1,4 +1,5 @@
 import { KeyValueMap } from '../common-types'
+import { INLINES, BLOCKS } from '@contentful/rich-text-types'
 
 interface NumRange {
   min?: number
@@ -15,11 +16,32 @@ interface RegExp {
   flags: string
 }
 
+interface NodesValidation {
+  [BLOCKS.EMBEDDED_ENTRY]?: Pick<
+    ContentTypeFieldValidation,
+    'size' | 'linkContentType' | 'message'
+  >[]
+  [INLINES.EMBEDDED_ENTRY]?: Pick<
+    ContentTypeFieldValidation,
+    'size' | 'linkContentType' | 'message'
+  >[]
+  [INLINES.ENTRY_HYPERLINK]?: Pick<
+    ContentTypeFieldValidation,
+    'size' | 'linkContentType' | 'message'
+  >[]
+  [BLOCKS.EMBEDDED_ASSET]?: Pick<ContentTypeFieldValidation, 'size' | 'message'>[]
+  [INLINES.ASSET_HYPERLINK]?: Pick<ContentTypeFieldValidation, 'size' | 'message'>[]
+  [BLOCKS.EMBEDDED_RESOURCE]?: {
+    validations: Pick<ContentTypeFieldValidation, 'size' | 'message'>[]
+    allowedResources: ContentTypeAllowedResources[]
+  }
+}
+
 export interface ContentTypeFieldValidation {
   linkContentType?: string[]
   in?: (string | number)[]
   linkMimetypeGroup?: string[]
-  enabledNodeTypes?: string[]
+  enabledNodeTypes?: (`${BLOCKS}` | `${INLINES}`)[]
   enabledMarks?: string[]
   unique?: boolean
   size?: NumRange
@@ -33,6 +55,7 @@ export interface ContentTypeFieldValidation {
     height?: NumRange
   }
   assetFileSize?: NumRange
+  nodes?: NodesValidation
 }
 
 interface Item {


### PR DESCRIPTION
## Summary

Adds types for `nodes` validation object in `ContentFields.validations`

## Description

* Changes `enabledNodeTypes` validation to only accept valid string values
* Creates a new interface NodesValidation which includes the available types for Rich Text nodes
* Adds validation type for the new `embedded-resource-block` node
* Add nodes key to the ContentTypeFieldValidation interface

## Motivation and Context

The lack of a defined type makes it hard to work with RichText field validations while using Typescript and will not autocomplete the property while using javascript.

This PR supersedes #1829 and #1854 as this PR has somewhat stricter types defined and also includes the type for the `embedded-resource-block` node.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
