### PR TITLE
fix: allow null type for validation message []

### DIFF
--- a/lib/entities/content-type-fields.ts
+++ b/lib/entities/content-type-fields.ts
@@ -48,7 +48,7 @@ export interface ContentTypeFieldValidation {
   range?: NumRange
   dateRange?: DateRange
   regexp?: RegExp
-  message?: string
+  message?: string | null
   prohibitRegexp?: RegExp
   assetImageDimensions?: {
     width?: NumRange


### PR DESCRIPTION
## Summary

Allow `null` value for validation `message`

## Description

It turns out the `message` value for validations can be set to `null`. This PR updates the Typescript type to reflect this.

## Motivation and Context

The Typescript type is not correct for the possible value set for `message`

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
