### PR TITLE
fix: remove `sys.id` from `AppInstallationProps`

### DIFF
--- a/lib/entities/app-installation.ts
+++ b/lib/entities/app-installation.ts
@@ -7,7 +7,7 @@ import { Except } from 'type-fest'
 import { FreeFormParameters } from './widget-parameters'
 
 export type AppInstallationProps = {
-  sys: BasicMetaSysProps & {
+  sys: Omit<BasicMetaSysProps, 'id'> & {
     appDefinition: SysLink
     environment: SysLink
     space: SysLink


### PR DESCRIPTION
title

AppInstallations don't have an id