### PR TITLE
feat: add new annotation type [MONET-1301]

### DIFF
--- a/lib/entities/content-type.ts
+++ b/lib/entities/content-type.ts
@@ -28,7 +28,9 @@ export type ContentTypeMetadata = {
   >
 }
 
-export type AnnotationAssignment = Link<'Annotation'> & { parameters?: Record<string, string | number | boolean> }
+export type AnnotationAssignment = Link<'Annotation'> & {
+  parameters?: Record<string, string | number | boolean>
+}
 
 export type ContentTypeProps = {
   sys: BasicMetaSysProps & {

--- a/lib/entities/content-type.ts
+++ b/lib/entities/content-type.ts
@@ -21,12 +21,14 @@ import { omitAndDeleteField } from '../methods/content-type'
 export type ContentTypeMetadata = {
   annotations?: RequireAtLeastOne<
     {
-      ContentType?: Link<'Annotation'>[]
+      ContentType?: AnnotationAssignment[]
       ContentTypeField?: Record<string, Link<'Annotation'>[]>
     },
     'ContentType' | 'ContentTypeField'
   >
 }
+
+export type AnnotationAssignment = Link<'Annotation'> & { parameters?: Record<string, string | number | boolean> }
 
 export type ContentTypeProps = {
   sys: BasicMetaSysProps & {

--- a/lib/entities/content-type.ts
+++ b/lib/entities/content-type.ts
@@ -22,7 +22,7 @@ export type ContentTypeMetadata = {
   annotations?: RequireAtLeastOne<
     {
       ContentType?: AnnotationAssignment[]
-      ContentTypeField?: Record<string, Link<'Annotation'>[]>
+      ContentTypeField?: Record<string, AnnotationAssignment[]>
     },
     'ContentType' | 'ContentTypeField'
   >

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -77,6 +77,7 @@ export type {
   GetManyCommentsParams,
 } from './entities/comment'
 export type {
+  AnnotationAssignment,
   ContentType,
   ContentTypeMetadata,
   ContentTypeProps,


### PR DESCRIPTION
## Summary

This PR changes the typing for `ContentfulMetaData` in order to align with new Annotations.

## Description

`AnnotationAssignment` type is added to `ContentfulMetaData`.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
