### PR TITLE
chore: bump axios to 1.x [PHX-2741]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,5 @@ yarn.lock
 
 
 reports
+
+.tool-versions

--- a/lib/adapters/REST/endpoints/api-key.ts
+++ b/lib/adapters/REST/endpoints/api-key.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -27,7 +27,7 @@ export const create: RestEndpoint<'ApiKey', 'create'> = (
   http: AxiosInstance,
   params: GetSpaceParams,
   data: CreateApiKeyProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.post<ApiKeyProps>(http, `/spaces/${params.spaceId}/api_keys`, data, { headers })
 }
@@ -36,7 +36,7 @@ export const createWithId: RestEndpoint<'ApiKey', 'createWithId'> = (
   http: AxiosInstance,
   params: GetSpaceParams & { apiKeyId: string },
   data: CreateApiKeyProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.put<ApiKeyProps>(http, `/spaces/${params.spaceId}/api_keys/${params.apiKeyId}`, data, {
     headers,
@@ -47,7 +47,7 @@ export const update: RestEndpoint<'ApiKey', 'update'> = (
   http: AxiosInstance,
   params: GetSpaceParams & { apiKeyId: string },
   rawData: ApiKeyProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'accessToken' | 'preview_api_key' | 'policies' | 'sys'> =
     copy(rawData)

--- a/lib/adapters/REST/endpoints/app-definition.ts
+++ b/lib/adapters/REST/endpoints/app-definition.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import * as raw from './raw'
 import copy from 'fast-copy'
@@ -59,7 +59,7 @@ export const update: RestEndpoint<'AppDefinition', 'update'> = (
   http: AxiosInstance,
   params: GetAppDefinitionParams,
   rawData: AppDefinitionProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
 

--- a/lib/adapters/REST/endpoints/app-installation.ts
+++ b/lib/adapters/REST/endpoints/app-installation.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import * as raw from './raw'
 import { normalizeSelect, normalizeSpaceId } from './utils'
@@ -49,7 +49,7 @@ export const upsert: RestEndpoint<'AppInstallation', 'upsert'> = (
   http: AxiosInstance,
   params: GetAppInstallationParams & { acceptAllTerms?: boolean },
   rawData: CreateAppInstallationProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data = copy(rawData)
 

--- a/lib/adapters/REST/endpoints/asset.ts
+++ b/lib/adapters/REST/endpoints/asset.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { errorHandler } from 'contentful-sdk-core'
 import copy from 'fast-copy'
@@ -20,7 +20,7 @@ export const get: RestEndpoint<'Asset', 'get'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { assetId: string } & QueryParams,
   rawData?: unknown,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.get<AssetProps>(
     http,
@@ -36,7 +36,7 @@ export const getMany: RestEndpoint<'Asset', 'getMany'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & QueryParams,
   rawData?: unknown,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.get<CollectionProp<AssetProps>>(
     http,
@@ -52,7 +52,7 @@ export const update: RestEndpoint<'Asset', 'update'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { assetId: string },
   rawData: AssetProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/comment.ts
+++ b/lib/adapters/REST/endpoints/comment.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance, AxiosRequestHeaders } from 'axios'
+import { AxiosInstance, RawAxiosRequestHeaders } from 'axios'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
 import {
@@ -97,7 +97,7 @@ export const update: RestEndpoint<'Comment', 'update'> = (
   http: AxiosInstance,
   params: GetCommentParams,
   rawData: UpdateCommentProps | (Omit<UpdateCommentProps, 'body'> & RichTextCommentBodyPayload),
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/content-type.ts
+++ b/lib/adapters/REST/endpoints/content-type.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -22,7 +22,7 @@ const getContentTypeUrl = (params: GetContentTypeParams) =>
 export const get: RestEndpoint<'ContentType', 'get'> = (
   http: AxiosInstance,
   params: GetContentTypeParams & QueryParams,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.get<ContentTypeProps>(http, getContentTypeUrl(params), {
     params: normalizeSelect(params.query),
@@ -33,7 +33,7 @@ export const get: RestEndpoint<'ContentType', 'get'> = (
 export const getMany: RestEndpoint<'ContentType', 'getMany'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & QueryParams,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.get<CollectionProp<ContentTypeProps>>(http, getBaseUrl(params), {
     params: params.query,
@@ -45,7 +45,7 @@ export const create: RestEndpoint<'ContentType', 'create'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams,
   rawData: CreateContentTypeProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data = copy(rawData)
 
@@ -56,7 +56,7 @@ export const createWithId: RestEndpoint<'ContentType', 'createWithId'> = (
   http: AxiosInstance,
   params: GetContentTypeParams,
   rawData: CreateContentTypeProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data = copy(rawData)
 
@@ -67,7 +67,7 @@ export const update: RestEndpoint<'ContentType', 'update'> = (
   http: AxiosInstance,
   params: GetContentTypeParams,
   rawData: ContentTypeProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys
@@ -82,7 +82,7 @@ export const update: RestEndpoint<'ContentType', 'update'> = (
 export const del: RestEndpoint<'ContentType', 'delete'> = (
   http: AxiosInstance,
   params: GetContentTypeParams,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.del(http, getContentTypeUrl(params), { headers })
 }
@@ -91,7 +91,7 @@ export const publish: RestEndpoint<'ContentType', 'publish'> = (
   http: AxiosInstance,
   params: GetContentTypeParams,
   rawData: ContentTypeProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.put<ContentTypeProps>(http, getContentTypeUrl(params) + '/published', null, {
     headers: {
@@ -104,7 +104,7 @@ export const publish: RestEndpoint<'ContentType', 'publish'> = (
 export const unpublish: RestEndpoint<'ContentType', 'unpublish'> = (
   http: AxiosInstance,
   params: GetContentTypeParams,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.del<ContentTypeProps>(http, getContentTypeUrl(params) + '/published', { headers })
 }

--- a/lib/adapters/REST/endpoints/editor-interface.ts
+++ b/lib/adapters/REST/endpoints/editor-interface.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -36,7 +36,7 @@ export const update: RestEndpoint<'EditorInterface', 'update'> = (
   http: AxiosInstance,
   params: GetEditorInterfaceParams,
   rawData: EditorInterfaceProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { OpPatch } from 'json-patch'
@@ -18,7 +18,7 @@ export const get: RestEndpoint<'Entry', 'get'> = <T extends KeyValueMap = KeyVal
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { entryId: string } & QueryParams,
   rawData?: unknown,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.get<EntryProps<T>>(
     http,
@@ -36,7 +36,7 @@ export const getPublished: RestEndpoint<'Entry', 'getPublished'> = <
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & QueryParams,
   rawData?: unknown,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.get<CollectionProp<EntryProps<T>>>(
     http,
@@ -52,7 +52,7 @@ export const getMany: RestEndpoint<'Entry', 'getMany'> = <T extends KeyValueMap 
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & QueryParams,
   rawData?: unknown,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.get<CollectionProp<EntryProps<T>>>(
     http,
@@ -68,7 +68,7 @@ export const patch: RestEndpoint<'Entry', 'patch'> = <T extends KeyValueMap = Ke
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { entryId: string; version: number },
   data: OpPatch[],
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.patch<EntryProps<T>>(
     http,
@@ -88,7 +88,7 @@ export const update: RestEndpoint<'Entry', 'update'> = <T extends KeyValueMap = 
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { entryId: string },
   rawData: EntryProps<T>,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/environment-alias.ts
+++ b/lib/adapters/REST/endpoints/environment-alias.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -48,7 +48,7 @@ export const createWithId: RestEndpoint<'EnvironmentAlias', 'createWithId'> = (
   http: AxiosInstance,
   params: GetSpaceEnvAliasParams,
   rawData: CreateEnvironmentAliasProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data = copy(rawData)
   return raw.put<EnvironmentAliasProps>(http, getEnvironmentAliasUrl(params), data, {
@@ -60,7 +60,7 @@ export const update: RestEndpoint<'EnvironmentAlias', 'update'> = (
   http: AxiosInstance,
   params: GetSpaceEnvAliasParams,
   rawData: EnvironmentAliasProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/environment.ts
+++ b/lib/adapters/REST/endpoints/environment.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -35,7 +35,7 @@ export const update: RestEndpoint<'Environment', 'update'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams,
   rawData: EnvironmentProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys
@@ -64,7 +64,7 @@ export const create: RestEndpoint<'Environment', 'create'> = (
   http: AxiosInstance,
   params: GetSpaceParams,
   rawData: CreateEnvironmentProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data = copy(rawData)
   return raw.post<EnvironmentProps>(http, `/spaces/${params.spaceId}/environments`, data, {
@@ -76,7 +76,7 @@ export const createWithId: RestEndpoint<'Environment', 'createWithId'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { sourceEnvironmentId?: string },
   rawData: CreateEnvironmentProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data = copy(rawData)
   return raw.put<EnvironmentProps>(

--- a/lib/adapters/REST/endpoints/extension.ts
+++ b/lib/adapters/REST/endpoints/extension.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -41,7 +41,7 @@ export const create: RestEndpoint<'Extension', 'create'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams,
   rawData: CreateExtensionProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.post<ExtensionProps>(http, getBaseUrl(params), rawData, { headers })
 }
@@ -50,7 +50,7 @@ export const createWithId: RestEndpoint<'Extension', 'createWithId'> = (
   http: AxiosInstance,
   params: GetExtensionParams,
   rawData: CreateExtensionProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data = copy(rawData)
 
@@ -61,7 +61,7 @@ export const update: RestEndpoint<'Extension', 'update'> = async (
   http: AxiosInstance,
   params: GetExtensionParams,
   rawData: ExtensionProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
 

--- a/lib/adapters/REST/endpoints/http.ts
+++ b/lib/adapters/REST/endpoints/http.ts
@@ -1,18 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { AxiosInstance, AxiosRequestConfig } from 'axios'
+import { AxiosInstance, RawAxiosRequestConfig } from 'axios'
 import { RestEndpoint } from '../types'
 import * as raw from './raw'
 
 export const get: RestEndpoint<'Http', 'get'> = <T = any>(
   http: AxiosInstance,
-  { url, config }: { url: string; config?: AxiosRequestConfig }
+  { url, config }: { url: string; config?: RawAxiosRequestConfig }
 ) => {
   return raw.get<T>(http, url, config)
 }
 
 export const post: RestEndpoint<'Http', 'post'> = <T = any>(
   http: AxiosInstance,
-  { url, config }: { url: string; config?: AxiosRequestConfig },
+  { url, config }: { url: string; config?: RawAxiosRequestConfig },
   payload?: any
 ) => {
   return raw.post<T>(http, url, payload, config)
@@ -20,7 +20,7 @@ export const post: RestEndpoint<'Http', 'post'> = <T = any>(
 
 export const put: RestEndpoint<'Http', 'put'> = <T = any>(
   http: AxiosInstance,
-  { url, config }: { url: string; config?: AxiosRequestConfig },
+  { url, config }: { url: string; config?: RawAxiosRequestConfig },
   payload?: any
 ) => {
   return raw.put<T>(http, url, payload, config)
@@ -28,7 +28,7 @@ export const put: RestEndpoint<'Http', 'put'> = <T = any>(
 
 export const patch: RestEndpoint<'Http', 'patch'> = <T = any>(
   http: AxiosInstance,
-  { url, config }: { url: string; config?: AxiosRequestConfig },
+  { url, config }: { url: string; config?: RawAxiosRequestConfig },
   payload?: any
 ) => {
   return raw.patch<T>(http, url, payload, config)
@@ -36,14 +36,14 @@ export const patch: RestEndpoint<'Http', 'patch'> = <T = any>(
 
 export const del: RestEndpoint<'Http', 'delete'> = <T = any>(
   http: AxiosInstance,
-  { url, config }: { url: string; config?: AxiosRequestConfig }
+  { url, config }: { url: string; config?: RawAxiosRequestConfig }
 ) => {
   return raw.del<T>(http, url, config)
 }
 
 export const request: RestEndpoint<'Http', 'request'> = <T = any>(
   http: AxiosInstance,
-  { url, config }: { url: string; config?: AxiosRequestConfig }
+  { url, config }: { url: string; config?: RawAxiosRequestConfig }
 ) => {
   return raw.http<T>(http, url, config)
 }

--- a/lib/adapters/REST/endpoints/locale.ts
+++ b/lib/adapters/REST/endpoints/locale.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -35,7 +35,7 @@ export const create: RestEndpoint<'Locale', 'create'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams,
   data: CreateLocaleProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.post<LocaleProps>(
     http,
@@ -51,7 +51,7 @@ export const update: RestEndpoint<'Locale', 'update'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { localeId: string },
   rawData: LocaleProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'default' | 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/organization-invitation.ts
+++ b/lib/adapters/REST/endpoints/organization-invitation.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import {
   CreateOrganizationInvitationProps,
@@ -19,7 +19,7 @@ export const create: RestEndpoint<'OrganizationInvitation', 'create'> = (
   http: AxiosInstance,
   params: { organizationId: string },
   data: CreateOrganizationInvitationProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.post<OrganizationInvitationProps>(
     http,
@@ -37,7 +37,7 @@ export const create: RestEndpoint<'OrganizationInvitation', 'create'> = (
 export const get: RestEndpoint<'OrganizationInvitation', 'get'> = (
   http: AxiosInstance,
   params: { organizationId: string; invitationId: string },
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.get<OrganizationInvitationProps>(
     http,

--- a/lib/adapters/REST/endpoints/organization-membership.ts
+++ b/lib/adapters/REST/endpoints/organization-membership.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -38,7 +38,7 @@ export const update: RestEndpoint<'OrganizationMembership', 'update'> = (
   http: AxiosInstance,
   params: GetOrganizationMembershipParams,
   rawData: OrganizationMembershipProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/personal-access-token.ts
+++ b/lib/adapters/REST/endpoints/personal-access-token.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { CollectionProp, QueryParams } from '../../../common-types'
 import {
@@ -28,7 +28,7 @@ export const create: RestEndpoint<'PersonalAccessToken', 'create'> = (
   http: AxiosInstance,
   _params: {},
   rawData: CreatePersonalAccessTokenProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.post<PersonalAccessTokenProp>(http, '/users/me/access_tokens', rawData, {
     headers,

--- a/lib/adapters/REST/endpoints/raw.ts
+++ b/lib/adapters/REST/endpoints/raw.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { AxiosInstance, AxiosRequestConfig } from 'axios'
+import { AxiosInstance, RawAxiosRequestConfig } from 'axios'
 import { errorHandler } from 'contentful-sdk-core'
 
 function getBaseUrl(http: AxiosInstance) {
   return http.defaults.baseURL?.split('/spaces')[0]
 }
 
-export function get<T = any>(http: AxiosInstance, url: string, config?: AxiosRequestConfig) {
+export function get<T = any>(http: AxiosInstance, url: string, config?: RawAxiosRequestConfig) {
   return http
     .get<T>(url, {
       baseURL: getBaseUrl(http),
@@ -20,7 +20,7 @@ export function patch<T = any>(
   http: AxiosInstance,
   url: string,
   payload?: any,
-  config?: AxiosRequestConfig
+  config?: RawAxiosRequestConfig
 ) {
   return http
     .patch<T>(url, payload, {
@@ -34,7 +34,7 @@ export function post<T = any>(
   http: AxiosInstance,
   url: string,
   payload?: any,
-  config?: AxiosRequestConfig
+  config?: RawAxiosRequestConfig
 ) {
   return http
     .post<T>(url, payload, {
@@ -48,7 +48,7 @@ export function put<T = any>(
   http: AxiosInstance,
   url: string,
   payload?: any,
-  config?: AxiosRequestConfig
+  config?: RawAxiosRequestConfig
 ) {
   return http
     .put<T>(url, payload, {
@@ -58,7 +58,7 @@ export function put<T = any>(
     .then((response) => response.data, errorHandler)
 }
 
-export function del<T = any>(http: AxiosInstance, url: string, config?: AxiosRequestConfig) {
+export function del<T = any>(http: AxiosInstance, url: string, config?: RawAxiosRequestConfig) {
   return http
     .delete<T>(url, {
       baseURL: getBaseUrl(http),
@@ -70,7 +70,7 @@ export function del<T = any>(http: AxiosInstance, url: string, config?: AxiosReq
 export function http<T = any>(
   http: AxiosInstance,
   url: string,
-  config?: Omit<AxiosRequestConfig, 'url'>
+  config?: Omit<RawAxiosRequestConfig, 'url'>
 ) {
   return http(url, {
     baseURL: getBaseUrl(http),

--- a/lib/adapters/REST/endpoints/release.ts
+++ b/lib/adapters/REST/endpoints/release.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { GetReleaseParams, GetSpaceEnvironmentParams } from '../../../common-types'
 import {
@@ -44,7 +44,7 @@ export const update: RestEndpoint<'Release', 'update'> = (
   http: AxiosInstance,
   params: GetReleaseParams & { version: number },
   payload: ReleasePayload,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.put(
     http,
@@ -72,7 +72,7 @@ export const del: RestEndpoint<'Release', 'delete'> = (
 export const publish: RestEndpoint<'Release', 'publish'> = (
   http: AxiosInstance,
   params: GetReleaseParams & { version: number },
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.put(
     http,
@@ -90,7 +90,7 @@ export const publish: RestEndpoint<'Release', 'publish'> = (
 export const unpublish: RestEndpoint<'Release', 'unpublish'> = (
   http: AxiosInstance,
   params: GetReleaseParams & { version: number },
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.del(
     http,

--- a/lib/adapters/REST/endpoints/role.ts
+++ b/lib/adapters/REST/endpoints/role.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -28,7 +28,7 @@ export const create: RestEndpoint<'Role', 'create'> = (
   http: AxiosInstance,
   params: GetSpaceParams,
   data: CreateRoleProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.post<RoleProps>(http, `/spaces/${params.spaceId}/roles`, data, {
     headers,
@@ -39,7 +39,7 @@ export const createWithId: RestEndpoint<'Role', 'createWithId'> = (
   http: AxiosInstance,
   params: GetSpaceParams & { roleId: string },
   data: CreateRoleProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.put<RoleProps>(http, `/spaces/${params.spaceId}/roles/${params.roleId}`, data, {
     headers,
@@ -50,7 +50,7 @@ export const update: RestEndpoint<'Role', 'update'> = (
   http: AxiosInstance,
   params: GetSpaceParams & { roleId: string },
   rawData: RoleProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/space-membership.ts
+++ b/lib/adapters/REST/endpoints/space-membership.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -71,7 +71,7 @@ export const create: RestEndpoint<'SpaceMembership', 'create'> = (
   http: AxiosInstance,
   params: GetSpaceParams,
   data: CreateSpaceMembershipProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   spaceMembershipDeprecationWarning()
   return raw.post<SpaceMembershipProps>(http, getBaseUrl(params), data, {
@@ -83,7 +83,7 @@ export const createWithId: RestEndpoint<'SpaceMembership', 'createWithId'> = (
   http: AxiosInstance,
   params: GetSpaceMembershipProps,
   data: CreateSpaceMembershipProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   spaceMembershipDeprecationWarning()
   return raw.put<SpaceMembershipProps>(http, getEntityUrl(params), data, {
@@ -95,7 +95,7 @@ export const update: RestEndpoint<'SpaceMembership', 'update'> = (
   http: AxiosInstance,
   params: GetSpaceMembershipProps,
   rawData: SpaceMembershipProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/space.ts
+++ b/lib/adapters/REST/endpoints/space.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -22,7 +22,7 @@ export const create: RestEndpoint<'Space', 'create'> = (
   http: AxiosInstance,
   params: { organizationId?: string },
   payload: Omit<SpaceProps, 'sys'>,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.post(http, `/spaces`, payload, {
     headers: params.organizationId
@@ -35,7 +35,7 @@ export const update: RestEndpoint<'Space', 'update'> = (
   http: AxiosInstance,
   params: GetSpaceParams,
   rawData: SpaceProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/tag.ts
+++ b/lib/adapters/REST/endpoints/tag.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -43,7 +43,7 @@ export const update: RestEndpoint<'Tag', 'update'> = (
   http: AxiosInstance,
   params: GetTagParams,
   rawData: UpdateTagProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/task.ts
+++ b/lib/adapters/REST/endpoints/task.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance, AxiosRequestHeaders } from 'axios'
+import { AxiosInstance, RawAxiosRequestHeaders } from 'axios'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
 import {
@@ -52,7 +52,7 @@ export const update: RestEndpoint<'Task', 'update'> = (
   http: AxiosInstance,
   params: GetTaskParams,
   rawData: UpdateTaskProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/team-membership.ts
+++ b/lib/adapters/REST/endpoints/team-membership.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -50,7 +50,7 @@ export const create: RestEndpoint<'TeamMembership', 'create'> = (
   http: AxiosInstance,
   params: GetTeamParams,
   rawData: CreateTeamMembershipProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.post<TeamMembershipProps>(http, getBaseUrl(params), rawData, { headers })
 }
@@ -59,7 +59,7 @@ export const update: RestEndpoint<'TeamMembership', 'update'> = (
   http: AxiosInstance,
   params: GetTeamMembershipParams,
   rawData: TeamMembershipProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/team-space-membership.ts
+++ b/lib/adapters/REST/endpoints/team-space-membership.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -65,7 +65,7 @@ export const create: RestEndpoint<'TeamSpaceMembership', 'create'> = (
   http: AxiosInstance,
   params: GetSpaceParams & { teamId: string },
   rawData: CreateTeamSpaceMembershipProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.post<TeamSpaceMembershipProps>(http, getBaseUrl(params), rawData, {
     headers: {
@@ -79,7 +79,7 @@ export const update: RestEndpoint<'TeamSpaceMembership', 'update'> = (
   http: AxiosInstance,
   params: GetTeamSpaceMembershipParams,
   rawData: TeamSpaceMembershipProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/team.ts
+++ b/lib/adapters/REST/endpoints/team.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -43,7 +43,7 @@ export const create: RestEndpoint<'Team', 'create'> = (
   http: AxiosInstance,
   params: GetOrganizationParams,
   rawData: CreateTeamProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.post(http, getBaseUrl(params), rawData, { headers })
 }
@@ -52,7 +52,7 @@ export const update: RestEndpoint<'Team', 'update'> = (
   http: AxiosInstance,
   params: GetTeamParams,
   rawData: TeamProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys

--- a/lib/adapters/REST/endpoints/webhook.ts
+++ b/lib/adapters/REST/endpoints/webhook.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
@@ -72,7 +72,7 @@ export const create: RestEndpoint<'Webhook', 'create'> = (
   http: AxiosInstance,
   params: GetSpaceParams,
   rawData: CreateWebhooksProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data = copy(rawData)
 
@@ -83,7 +83,7 @@ export const createWithId = (
   http: AxiosInstance,
   params: GetWebhookParams,
   rawData: CreateWebhooksProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data = copy(rawData)
 
@@ -94,7 +94,7 @@ export const update: RestEndpoint<'Webhook', 'update'> = async (
   http: AxiosInstance,
   params: GetWebhookParams,
   rawData: WebhookProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
 

--- a/lib/adapters/REST/endpoints/workflow-definition.ts
+++ b/lib/adapters/REST/endpoints/workflow-definition.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance, AxiosRequestHeaders } from 'axios'
+import { AxiosInstance, RawAxiosRequestHeaders } from 'axios'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
 import {
@@ -25,7 +25,7 @@ const getWorkflowDefinitionUrl = (params: GetWorkflowDefinitionParams) =>
 export const get: RestEndpoint<'WorkflowDefinition', 'get'> = (
   http: AxiosInstance,
   params: GetWorkflowDefinitionParams,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) =>
   raw.get<WorkflowDefinitionProps>(http, getWorkflowDefinitionUrl(params), {
     headers,
@@ -34,7 +34,7 @@ export const get: RestEndpoint<'WorkflowDefinition', 'get'> = (
 export const getMany: RestEndpoint<'WorkflowDefinition', 'getMany'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { query?: WorkflowDefinitionQueryOptions },
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) =>
   raw.get<CollectionProp<WorkflowDefinitionProps>>(http, getBaseUrl(params), {
     headers,
@@ -45,7 +45,7 @@ export const create: RestEndpoint<'WorkflowDefinition', 'create'> = (
   http: AxiosInstance,
   params: CreateWorkflowDefinitionParams,
   rawData: CreateWorkflowDefinitionProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data = copy(rawData)
   return raw.post<WorkflowDefinitionProps>(http, getBaseUrl(params), data, {
@@ -57,7 +57,7 @@ export const update: RestEndpoint<'WorkflowDefinition', 'update'> = (
   http: AxiosInstance,
   params: GetWorkflowDefinitionParams,
   rawData: UpdateWorkflowDefinitionProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys
@@ -73,7 +73,7 @@ export const update: RestEndpoint<'WorkflowDefinition', 'update'> = (
 export const del: RestEndpoint<'WorkflowDefinition', 'delete'> = (
   http: AxiosInstance,
   { version, ...params }: DeleteWorkflowDefinitionParams,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.del(http, getWorkflowDefinitionUrl(params), {
     headers: { 'X-Contentful-Version': version, ...headers },

--- a/lib/adapters/REST/endpoints/workflow.ts
+++ b/lib/adapters/REST/endpoints/workflow.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance, AxiosRequestHeaders } from 'axios'
+import { AxiosInstance, RawAxiosRequestHeaders } from 'axios'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
 import { CollectionProp, GetSpaceEnvironmentParams, GetWorkflowParams } from '../../../common-types'
@@ -25,7 +25,7 @@ const completeWorkflowUrl = (params: GetWorkflowParams) => `${getWorkflowUrl(par
 export const getMany: RestEndpoint<'Workflow', 'getMany'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { query?: WorkflowQueryOptions },
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) =>
   raw.get<CollectionProp<WorkflowProps>>(http, getBaseUrl(params), {
     headers,
@@ -36,7 +36,7 @@ export const create: RestEndpoint<'Workflow', 'create'> = (
   http: AxiosInstance,
   params: CreateWorkflowParams,
   rawData: CreateWorkflowProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data = copy(rawData)
   return raw.post<WorkflowProps>(http, getBaseUrl(params), data, {
@@ -48,7 +48,7 @@ export const update: RestEndpoint<'Workflow', 'update'> = (
   http: AxiosInstance,
   params: UpdateWorkflowParams,
   rawData: UpdateWorkflowProps,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys
@@ -64,7 +64,7 @@ export const update: RestEndpoint<'Workflow', 'update'> = (
 export const del: RestEndpoint<'Workflow', 'delete'> = (
   http: AxiosInstance,
   { version, ...params }: DeleteWorkflowParams,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.del(http, getWorkflowUrl(params), {
     headers: { 'X-Contentful-Version': version, ...headers },
@@ -74,7 +74,7 @@ export const del: RestEndpoint<'Workflow', 'delete'> = (
 export const complete: RestEndpoint<'Workflow', 'complete'> = (
   http: AxiosInstance,
   { version, ...params }: CompleteWorkflowParams,
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) => {
   return raw.put(http, completeWorkflowUrl(params), null, {
     headers: { 'X-Contentful-Version': version, ...headers },

--- a/lib/adapters/REST/endpoints/workflows-changelog.ts
+++ b/lib/adapters/REST/endpoints/workflows-changelog.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance, AxiosRequestHeaders } from 'axios'
+import { AxiosInstance, RawAxiosRequestHeaders } from 'axios'
 import { CollectionProp, GetSpaceEnvironmentParams } from '../../../common-types'
 import {
   WorkflowsChangelogQueryOptions,
@@ -13,7 +13,7 @@ const getBaseUrl = (params: GetSpaceEnvironmentParams) =>
 export const getMany: RestEndpoint<'WorkflowsChangelog', 'getMany'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { query: WorkflowsChangelogQueryOptions },
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
 ) =>
   raw.get<CollectionProp<WorkflowsChangelogEntryProps>>(http, getBaseUrl(params), {
     headers,

--- a/lib/adapters/REST/rest-adapter.ts
+++ b/lib/adapters/REST/rest-adapter.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestHeaders } from 'axios'
+import axios, { RawAxiosRequestHeaders } from 'axios'
 import { AxiosInstance, createHttpClient, CreateHttpClientParams } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { OpPatch } from 'json-patch'
@@ -60,7 +60,7 @@ export class RestAdapter implements Adapter {
       http: AxiosInstance,
       params?: Record<string, unknown>,
       payload?: Record<string, unknown> | OpPatch[] | MakeRequestPayload,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ) => Promise<R> =
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestConfig, AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestConfig, RawAxiosRequestHeaders } from 'axios'
 import { OpPatch } from 'json-patch'
 import { Stream } from 'stream'
 import { AppActionProps, CreateAppActionProps } from './entities/app-action'
@@ -677,12 +677,12 @@ export interface Adapter {
  */
 export type MRActions = {
   Http: {
-    get: { params: { url: string; config?: AxiosRequestConfig }; return: any }
-    patch: { params: { url: string; config?: AxiosRequestConfig }; payload: any; return: any }
-    post: { params: { url: string; config?: AxiosRequestConfig }; payload: any; return: any }
-    put: { params: { url: string; config?: AxiosRequestConfig }; payload: any; return: any }
-    delete: { params: { url: string; config?: AxiosRequestConfig }; return: any }
-    request: { params: { url: string; config?: AxiosRequestConfig }; return: any }
+    get: { params: { url: string; config?: RawAxiosRequestConfig }; return: any }
+    patch: { params: { url: string; config?: RawAxiosRequestConfig }; payload: any; return: any }
+    post: { params: { url: string; config?: RawAxiosRequestConfig }; payload: any; return: any }
+    put: { params: { url: string; config?: RawAxiosRequestConfig }; payload: any; return: any }
+    delete: { params: { url: string; config?: RawAxiosRequestConfig }; return: any }
+    request: { params: { url: string; config?: RawAxiosRequestConfig }; return: any }
   }
   AppAction: {
     get: { params: GetAppActionParams; return: AppActionProps }
@@ -741,19 +741,19 @@ export type MRActions = {
     create: {
       params: GetSpaceParams
       payload: CreateApiKeyProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: ApiKeyProps
     }
     createWithId: {
       params: GetSpaceParams & { apiKeyId: string }
       payload: CreateApiKeyProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: ApiKeyProps
     }
     update: {
       params: GetSpaceParams & { apiKeyId: string }
       payload: ApiKeyProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: ApiKeyProps
     }
     delete: { params: GetSpaceParams & { apiKeyId: string }; return: any }
@@ -775,7 +775,7 @@ export type MRActions = {
     update: {
       params: GetAppDefinitionParams
       payload: AppDefinitionProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: AppDefinitionProps
     }
     delete: { params: GetAppDefinitionParams; return: any }
@@ -793,7 +793,7 @@ export type MRActions = {
     upsert: {
       params: GetAppInstallationParams & { acceptAllTerms?: boolean }
       payload: CreateAppInstallationProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: AppInstallationProps
     }
     delete: { params: GetAppInstallationParams; return: any }
@@ -857,18 +857,18 @@ export type MRActions = {
   Asset: {
     getMany: {
       params: GetSpaceEnvironmentParams & QueryParams
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: CollectionProp<AssetProps>
     }
     get: {
       params: GetSpaceEnvironmentParams & { assetId: string } & QueryParams
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: AssetProps
     }
     update: {
       params: GetSpaceEnvironmentParams & { assetId: string }
       payload: AssetProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: AssetProps
     }
     delete: { params: GetSpaceEnvironmentParams & { assetId: string }; return: any }
@@ -972,13 +972,13 @@ export type MRActions = {
       | {
           params: UpdateCommentParams
           payload: UpdateCommentProps
-          headers?: AxiosRequestHeaders
+          headers?: RawAxiosRequestHeaders
           return: CommentProps
         }
       | {
           params: UpdateCommentParams
           payload: Omit<UpdateCommentProps, 'body'> & RichTextCommentBodyPayload
-          headers?: AxiosRequestHeaders
+          headers?: RawAxiosRequestHeaders
           return: RichTextCommentProps
         }
     delete: { params: DeleteCommentParams; return: void }
@@ -1002,7 +1002,7 @@ export type MRActions = {
     update: {
       params: GetContentTypeParams
       payload: ContentTypeProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: ContentTypeProps
     }
     delete: { params: GetContentTypeParams; return: any }
@@ -1018,7 +1018,7 @@ export type MRActions = {
     update: {
       params: GetEditorInterfaceParams
       payload: EditorInterfaceProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: EditorInterfaceProps
     }
   }
@@ -1031,19 +1031,19 @@ export type MRActions = {
     create: {
       params: GetSpaceParams
       payload: Partial<Pick<EnvironmentProps, 'name'>>
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: EnvironmentProps
     }
     createWithId: {
       params: GetSpaceEnvironmentParams & { sourceEnvironmentId?: string }
       payload: CreateEnvironmentProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: EnvironmentProps
     }
     update: {
       params: GetSpaceEnvironmentParams
       payload: EnvironmentProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: EnvironmentProps
     }
     delete: { params: GetSpaceEnvironmentParams; return: any }
@@ -1057,13 +1057,13 @@ export type MRActions = {
     createWithId: {
       params: GetSpaceEnvAliasParams
       payload: CreateEnvironmentAliasProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: EnvironmentAliasProps
     }
     update: {
       params: GetSpaceEnvAliasParams
       payload: EnvironmentAliasProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: EnvironmentAliasProps
     }
     delete: { params: GetSpaceEnvAliasParams; return: any }
@@ -1158,13 +1158,13 @@ export type MRActions = {
     patch: {
       params: GetSpaceEnvironmentParams & { entryId: string; version: number }
       payload: OpPatch[]
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: EntryProps<any>
     }
     update: {
       params: GetSpaceEnvironmentParams & { entryId: string }
       payload: EntryProps<any>
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: EntryProps<any>
     }
     delete: { params: GetSpaceEnvironmentParams & { entryId: string }; return: any }
@@ -1212,19 +1212,19 @@ export type MRActions = {
     create: {
       params: GetSpaceEnvironmentParams
       payload: CreateExtensionProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: ExtensionProps
     }
     createWithId: {
       params: GetExtensionParams
       payload: CreateExtensionProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: ExtensionProps
     }
     update: {
       params: GetExtensionParams
       payload: ExtensionProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: ExtensionProps
     }
     delete: { params: GetExtensionParams; return: any }
@@ -1239,13 +1239,13 @@ export type MRActions = {
     update: {
       params: GetSpaceEnvironmentParams & { localeId: string }
       payload: LocaleProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: LocaleProps
     }
     create: {
       params: GetSpaceEnvironmentParams
       payload: CreateLocaleProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: LocaleProps
     }
   }
@@ -1256,13 +1256,13 @@ export type MRActions = {
   OrganizationInvitation: {
     get: {
       params: { organizationId: string; invitationId: string }
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: OrganizationInvitationProps
     }
     create: {
       params: { organizationId: string }
       payload: CreateOrganizationInvitationProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: OrganizationInvitationProps
     }
   }
@@ -1275,7 +1275,7 @@ export type MRActions = {
     update: {
       params: GetOrganizationMembershipParams
       payload: OrganizationMembershipProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: OrganizationMembershipProps
     }
     delete: { params: GetOrganizationMembershipParams; return: any }
@@ -1286,7 +1286,7 @@ export type MRActions = {
     create: {
       params: {}
       payload: CreatePersonalAccessTokenProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: PersonalAccessTokenProp
     }
     revoke: { params: { tokenId: string }; return: PersonalAccessTokenProp }
@@ -1360,19 +1360,19 @@ export type MRActions = {
     create: {
       params: GetSpaceParams
       payload: CreateRoleProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: RoleProps
     }
     createWithId: {
       params: GetSpaceParams & { roleId: string }
       payload: CreateRoleProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: RoleProps
     }
     update: {
       params: GetSpaceParams & { roleId: string }
       payload: RoleProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: RoleProps
     }
     delete: { params: GetSpaceParams & { roleId: string }; return: any }
@@ -1419,13 +1419,13 @@ export type MRActions = {
     create: {
       params: { organizationId?: string }
       payload: Omit<SpaceProps, 'sys'>
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: any
     }
     update: {
       params: GetSpaceParams
       payload: SpaceProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: SpaceProps
     }
     delete: { params: GetSpaceParams; return: void }
@@ -1448,19 +1448,19 @@ export type MRActions = {
     create: {
       params: GetSpaceParams
       payload: CreateSpaceMembershipProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: SpaceMembershipProps
     }
     createWithId: {
       params: GetSpaceMembershipProps
       payload: CreateSpaceMembershipProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: SpaceMembershipProps
     }
     update: {
       params: GetSpaceMembershipProps
       payload: SpaceMembershipProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: SpaceMembershipProps
     }
     delete: { params: GetSpaceMembershipProps; return: any }
@@ -1472,7 +1472,7 @@ export type MRActions = {
     update: {
       params: GetTagParams
       payload: UpdateTagProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: TagProps
     }
     delete: { params: DeleteTagParams; return: any }
@@ -1491,7 +1491,7 @@ export type MRActions = {
     update: {
       params: UpdateTaskParams
       payload: UpdateTaskProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: TaskProps
     }
     delete: { params: DeleteTaskParams; return: void }
@@ -1503,13 +1503,13 @@ export type MRActions = {
     create: {
       params: GetOrganizationParams
       payload: CreateTeamProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: any
     }
     update: {
       params: GetTeamParams
       payload: TeamProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: TeamProps
     }
     delete: { params: GetTeamParams; return: any }
@@ -1527,13 +1527,13 @@ export type MRActions = {
     create: {
       params: GetTeamParams
       payload: CreateTeamMembershipProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: TeamMembershipProps
     }
     update: {
       params: GetTeamMembershipParams
       payload: TeamMembershipProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: TeamMembershipProps
     }
     delete: { params: GetTeamMembershipParams; return: any }
@@ -1555,13 +1555,13 @@ export type MRActions = {
     create: {
       params: GetSpaceParams & { teamId: string }
       payload: CreateTeamSpaceMembershipProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: TeamSpaceMembershipProps
     }
     update: {
       params: GetTeamSpaceMembershipParams
       payload: TeamSpaceMembershipProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: TeamSpaceMembershipProps
     }
     delete: { params: GetTeamSpaceMembershipParams; return: any }
@@ -1615,13 +1615,13 @@ export type MRActions = {
     create: {
       params: GetSpaceParams
       payload: CreateWebhooksProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: WebhookProps
     }
     createWithId: {
       params: GetWebhookParams
       payload: CreateWebhooksProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: WebhookProps
     }
     update: { params: GetWebhookParams; payload: WebhookProps; return: WebhookProps }
@@ -1630,65 +1630,65 @@ export type MRActions = {
   WorkflowDefinition: {
     get: {
       params: GetWorkflowDefinitionParams
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: WorkflowDefinitionProps
     }
     getMany: {
       params: GetSpaceEnvironmentParams & { query?: WorkflowDefinitionQueryOptions }
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: CollectionProp<WorkflowDefinitionProps>
     }
     create: {
       params: CreateWorkflowDefinitionParams
       payload: CreateWorkflowDefinitionProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: WorkflowDefinitionProps
     }
     update: {
       params: GetWorkflowDefinitionParams
       payload: WorkflowDefinitionProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: WorkflowDefinitionProps
     }
     delete: {
       params: DeleteWorkflowDefinitionParams
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: void
     }
   }
   Workflow: {
     getMany: {
       params: GetSpaceEnvironmentParams & { query?: WorkflowQueryOptions }
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: CollectionProp<WorkflowProps>
     }
     create: {
       params: CreateWorkflowParams
       payload: CreateWorkflowProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: WorkflowProps
     }
     update: {
       params: GetWorkflowParams
       payload: WorkflowProps
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: WorkflowProps
     }
     delete: {
       params: DeleteWorkflowParams
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: void
     }
     complete: {
       params: CompleteWorkflowParams
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: void
     }
   }
   WorkflowsChangelog: {
     getMany: {
       params: GetSpaceEnvironmentParams & { query: WorkflowsChangelogQueryOptions }
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
       return: CollectionProp<WorkflowsChangelogEntryProps>
     }
   }
@@ -1738,7 +1738,7 @@ export interface MakeRequestOptions {
   action: string
   params?: Record<string, unknown>
   payload?: Record<string, unknown> | OpPatch[] | MakeRequestPayload
-  headers?: AxiosRequestHeaders
+  headers?: RawAxiosRequestHeaders
   userAgent: string
 }
 

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -1,4 +1,3 @@
-import { AxiosRequestConfig } from 'axios'
 import { createRequestConfig } from 'contentful-sdk-core'
 import {
   Collection,
@@ -23,6 +22,7 @@ import {
   EnvironmentTemplate,
   EnvironmentTemplateProps,
 } from './entities/environment-template'
+import { RawAxiosRequestConfig } from 'axios'
 
 export type ClientAPI = ReturnType<typeof createClientApi>
 type CreateSpaceProps = Omit<SpaceProps, 'sys'> & { defaultLocale?: string }
@@ -482,7 +482,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    rawRequest: function rawRequest({ url, ...config }: AxiosRequestConfig & { url: string }) {
+    rawRequest: function rawRequest({ url, ...config }: RawAxiosRequestConfig & { url: string }) {
       return makeRequest({
         entityType: 'Http',
         action: 'request',

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestConfig, AxiosRequestHeaders } from 'axios'
+import { RawAxiosRequestHeaders, RawAxiosRequestConfig } from 'axios'
 import { OpPatch } from 'json-patch'
 import { Stream } from 'stream'
 import {
@@ -187,12 +187,12 @@ import {
 export type PlainClientAPI = {
   raw: {
     getDefaultParams(): DefaultParams | undefined
-    get<T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T>
-    post<T = unknown>(url: string, payload?: any, config?: AxiosRequestConfig): Promise<T>
-    patch<T = unknown>(url: string, payload?: any, config?: AxiosRequestConfig): Promise<T>
-    put<T = unknown>(url: string, payload?: any, config?: AxiosRequestConfig): Promise<T>
-    delete<T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T>
-    http<T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T>
+    get<T = unknown>(url: string, config?: RawAxiosRequestConfig): Promise<T>
+    post<T = unknown>(url: string, payload?: any, config?: RawAxiosRequestConfig): Promise<T>
+    patch<T = unknown>(url: string, payload?: any, config?: RawAxiosRequestConfig): Promise<T>
+    put<T = unknown>(url: string, payload?: any, config?: RawAxiosRequestConfig): Promise<T>
+    delete<T = unknown>(url: string, config?: RawAxiosRequestConfig): Promise<T>
+    http<T = unknown>(url: string, config?: RawAxiosRequestConfig): Promise<T>
   }
   appAction: {
     get(params: OptionalDefaults<GetAppActionParams>): Promise<AppActionProps>
@@ -266,7 +266,7 @@ export type PlainClientAPI = {
     update(
       params: OptionalDefaults<GetEditorInterfaceParams>,
       rawData: EditorInterfaceProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EditorInterfaceProps>
   }
   space: {
@@ -275,12 +275,12 @@ export type PlainClientAPI = {
     create(
       params: OptionalDefaults<{ organizationId?: string }>,
       payload: Omit<SpaceProps, 'sys'>,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<any>
     update(
       params: OptionalDefaults<GetSpaceParams>,
       payload: SpaceProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<SpaceProps>
     delete(params: OptionalDefaults<GetSpaceParams>): Promise<any>
   }
@@ -292,17 +292,17 @@ export type PlainClientAPI = {
     create(
       params: OptionalDefaults<GetSpaceParams>,
       rawData: Partial<Pick<EnvironmentProps, 'name'>>,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EnvironmentProps>
     createWithId(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { sourceEnvironmentId?: string }>,
       rawData: CreateEnvironmentProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EnvironmentProps>
     update(
       params: OptionalDefaults<GetSpaceEnvironmentParams>,
       rawData: EnvironmentProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EnvironmentProps>
     delete(params: OptionalDefaults<GetSpaceEnvironmentParams>): Promise<any>
   }
@@ -314,57 +314,57 @@ export type PlainClientAPI = {
     createWithId(
       params: OptionalDefaults<GetSpaceEnvAliasParams>,
       rawData: CreateEnvironmentAliasProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EnvironmentAliasProps>
     update(
       params: OptionalDefaults<GetSpaceEnvAliasParams>,
       rawData: EnvironmentAliasProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EnvironmentAliasProps>
     delete(params: OptionalDefaults<GetSpaceEnvAliasParams>): Promise<any>
   }
   environmentTemplate: {
     get(
       params: GetEnvironmentTemplateParams & { version?: number },
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EnvironmentTemplateProps>
     getMany(
       params: BasicCursorPaginationOptions & GetOrganizationParams,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<CursorPaginatedCollectionProp<EnvironmentTemplateProps>>
     create(
       params: GetOrganizationParams,
       rawData: CreateEnvironmentTemplateProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EnvironmentTemplateProps>
     versionUpdate(
       params: GetEnvironmentTemplateParams & { version: number },
       rawData: { versionName?: string; versionDescription?: string },
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EnvironmentTemplateProps>
     update(
       params: GetEnvironmentTemplateParams,
       rawData: EnvironmentTemplateProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EnvironmentTemplateProps>
-    delete(params: GetEnvironmentTemplateParams, headers?: AxiosRequestHeaders): Promise<void>
+    delete(params: GetEnvironmentTemplateParams, headers?: RawAxiosRequestHeaders): Promise<void>
     versions(
       params: GetEnvironmentTemplateParams & BasicCursorPaginationOptions,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<CursorPaginatedCollectionProp<EnvironmentTemplateProps>>
     validate(
       params: EnvironmentTemplateParams & {
         version?: number
       },
       rawData: ValidateEnvironmentTemplateInstallationProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EnvironmentTemplateValidationProps>
     install(
       params: EnvironmentTemplateParams,
       rawData: CreateEnvironmentTemplateInstallationProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EnvironmentTemplateInstallationProps>
-    disconnect(params: EnvironmentTemplateParams, headers?: AxiosRequestHeaders): Promise<void>
+    disconnect(params: EnvironmentTemplateParams, headers?: RawAxiosRequestHeaders): Promise<void>
   }
   environmentTemplateInstallation: {
     getMany(
@@ -374,14 +374,14 @@ export type PlainClientAPI = {
         organizationId: string
         spaceId?: string
       },
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<CursorPaginatedCollectionProp<EnvironmentTemplateInstallationProps>>
     getForEnvironment(
       params: BasicCursorPaginationOptions &
         EnvironmentTemplateParams & {
           installationId?: string
         },
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<CursorPaginatedCollectionProp<EnvironmentTemplateInstallationProps>>
   }
   bulkAction: {
@@ -413,22 +413,22 @@ export type PlainClientAPI = {
     create(
       params: OptionalDefaults<CreateCommentParams>,
       rawData: CreateCommentProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<CommentProps>
     create(
       params: OptionalDefaults<CreateCommentParams>,
       rawData: RichTextCommentBodyPayload,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<RichTextCommentProps>
     update(
       params: OptionalDefaults<UpdateCommentParams>,
       rawData: UpdateCommentProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<CommentProps>
     update(
       params: OptionalDefaults<UpdateCommentParams>,
       rawData: Omit<UpdateCommentProps, 'body'> & RichTextCommentBodyPayload,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<RichTextCommentProps>
     delete(params: OptionalDefaults<DeleteCommentParams>): Promise<void>
   }
@@ -440,7 +440,7 @@ export type PlainClientAPI = {
     update(
       params: OptionalDefaults<GetContentTypeParams>,
       rawData: ContentTypeProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<ContentTypeProps>
     delete(params: OptionalDefaults<GetContentTypeParams>): Promise<any>
     publish(
@@ -479,27 +479,27 @@ export type PlainClientAPI = {
     getPublished<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>,
       rawData?: unknown,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<CollectionProp<EntryProps<T>>>
     getMany<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>,
       rawData?: unknown,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<CollectionProp<EntryProps<T>>>
     get<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>,
       rawData?: unknown,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>
     update<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>,
       rawData: EntryProps<T>,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>
     patch<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>,
       rawData: OpPatch[],
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>
     delete(params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>): Promise<any>
     publish<T extends KeyValueMap = KeyValueMap>(
@@ -538,17 +538,17 @@ export type PlainClientAPI = {
     getMany(
       params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>,
       rawData?: unknown,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<CollectionProp<AssetProps>>
     get(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string } & QueryParams>,
       rawData?: unknown,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<AssetProps>
     update(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string }>,
       rawData: AssetProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<AssetProps>
     delete(params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string }>): Promise<any>
     publish(
@@ -621,12 +621,12 @@ export type PlainClientAPI = {
     update(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { localeId: string }>,
       rawData: LocaleProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<LocaleProps>
     create(
       params: OptionalDefaults<GetSpaceEnvironmentParams>,
       data: CreateLocaleProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<LocaleProps>
   }
   personalAccessToken: {
@@ -634,7 +634,7 @@ export type PlainClientAPI = {
     getMany(params: OptionalDefaults<QueryParams>): Promise<CollectionProp<PersonalAccessTokenProp>>
     create(
       rawData: CreatePersonalAccessTokenProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<PersonalAccessTokenProp>
     revoke(params: OptionalDefaults<{ tokenId: string }>): Promise<PersonalAccessTokenProp>
   }
@@ -694,17 +694,17 @@ export type PlainClientAPI = {
     create(
       params: OptionalDefaults<GetSpaceParams>,
       data: CreateRoleProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<RoleProps>
     createWithId(
       params: OptionalDefaults<GetSpaceParams & { roleId: string }>,
       data: CreateRoleProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<RoleProps>
     update(
       params: OptionalDefaults<GetSpaceParams & { roleId: string }>,
       rawData: RoleProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<RoleProps>
     delete(params: OptionalDefaults<GetSpaceParams & { roleId: string }>): Promise<any>
   }
@@ -746,17 +746,17 @@ export type PlainClientAPI = {
     create(
       params: OptionalDefaults<GetSpaceParams>,
       data: CreateApiKeyProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<ApiKeyProps>
     createWithId(
       params: OptionalDefaults<GetSpaceParams & { apiKeyId: string }>,
       data: CreateApiKeyProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<ApiKeyProps>
     update(
       params: OptionalDefaults<GetSpaceParams & { apiKeyId: string }>,
       rawData: ApiKeyProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<ApiKeyProps>
     delete(params: OptionalDefaults<GetSpaceParams & { apiKeyId: string }>): Promise<any>
   }
@@ -774,7 +774,7 @@ export type PlainClientAPI = {
     update(
       params: OptionalDefaults<GetAppDefinitionParams>,
       rawData: AppDefinitionProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<AppDefinitionProps>
     delete(params: OptionalDefaults<GetAppDefinitionParams>): Promise<any>
     /**
@@ -796,7 +796,7 @@ export type PlainClientAPI = {
     upsert(
       params: OptionalDefaults<GetAppInstallationParams>,
       rawData: CreateAppInstallationProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<AppInstallationProps>
     delete(params: OptionalDefaults<GetAppInstallationParams>): Promise<any>
   }
@@ -808,17 +808,17 @@ export type PlainClientAPI = {
     create(
       params: OptionalDefaults<GetSpaceEnvironmentParams>,
       rawData: CreateExtensionProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<ExtensionProps>
     createWithId(
       params: OptionalDefaults<GetExtensionParams>,
       rawData: CreateExtensionProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<ExtensionProps>
     update(
       params: OptionalDefaults<GetExtensionParams>,
       rawData: ExtensionProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<ExtensionProps>
     delete(params: OptionalDefaults<GetExtensionParams>): Promise<any>
   }
@@ -837,7 +837,7 @@ export type PlainClientAPI = {
     create(
       params: OptionalDefaults<GetSpaceParams>,
       rawData: CreateWebhooksProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<WebhookProps>
     update(
       params: OptionalDefaults<GetWebhookParams>,
@@ -868,7 +868,7 @@ export type PlainClientAPI = {
     update(
       params: OptionalDefaults<GetTagParams>,
       rawData: UpdateTagProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<TagProps>
     delete(params: OptionalDefaults<GetTagParams>, version: number): Promise<any>
   }
@@ -881,12 +881,12 @@ export type PlainClientAPI = {
   organizationInvitation: {
     get(
       params: OptionalDefaults<{ organizationId: string; invitationId: string }>,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<OrganizationInvitationProps>
     create(
       params: OptionalDefaults<{ organizationId: string }>,
       data: CreateOrganizationInvitationProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<OrganizationInvitationProps>
   }
   organizationMembership: {
@@ -899,7 +899,7 @@ export type PlainClientAPI = {
     update(
       params: OptionalDefaults<GetOrganizationMembershipParams>,
       rawData: OrganizationMembershipProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<OrganizationMembershipProps>
     delete(params: OptionalDefaults<GetOrganizationMembershipParams>): Promise<any>
   }
@@ -925,17 +925,17 @@ export type PlainClientAPI = {
     create(
       params: OptionalDefaults<GetSpaceParams>,
       data: CreateSpaceMembershipProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<SpaceMembershipProps>
     createWithId(
       params: OptionalDefaults<GetSpaceMembershipProps>,
       data: CreateSpaceMembershipProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<SpaceMembershipProps>
     update(
       params: OptionalDefaults<GetSpaceMembershipProps>,
       rawData: SpaceMembershipProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<SpaceMembershipProps>
     delete(params: OptionalDefaults<GetSpaceMembershipProps>): Promise<any>
   }
@@ -947,12 +947,12 @@ export type PlainClientAPI = {
     create(
       params: OptionalDefaults<CreateTaskParams>,
       rawData: CreateTaskProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<TaskProps>
     update(
       params: OptionalDefaults<UpdateTaskParams>,
       rawData: UpdateTaskProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<TaskProps>
     delete(params: OptionalDefaults<DeleteTaskParams>): Promise<void>
   }
@@ -967,12 +967,12 @@ export type PlainClientAPI = {
     create(
       params: OptionalDefaults<GetOrganizationParams>,
       rawData: CreateTeamProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<any>
     update(
       params: OptionalDefaults<GetTeamParams>,
       rawData: TeamProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<TeamProps>
     delete(params: OptionalDefaults<GetTeamParams>): Promise<any>
   }
@@ -987,12 +987,12 @@ export type PlainClientAPI = {
     create(
       params: OptionalDefaults<GetTeamParams>,
       rawData: CreateTeamMembershipProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<TeamMembershipProps>
     update(
       params: OptionalDefaults<GetTeamMembershipParams>,
       rawData: TeamMembershipProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<TeamMembershipProps>
     delete(params: OptionalDefaults<GetTeamMembershipParams>): Promise<any>
   }
@@ -1010,12 +1010,12 @@ export type PlainClientAPI = {
     create(
       params: OptionalDefaults<GetSpaceParams & { teamId: string }>,
       rawData: CreateTeamSpaceMembershipProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<TeamSpaceMembershipProps>
     update(
       params: OptionalDefaults<GetTeamSpaceMembershipParams>,
       rawData: TeamSpaceMembershipProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<TeamSpaceMembershipProps>
     delete(params: OptionalDefaults<GetTeamSpaceMembershipParams>): Promise<any>
   }
@@ -1036,51 +1036,51 @@ export type PlainClientAPI = {
   workflowDefinition: {
     get(
       params: OptionalDefaults<GetWorkflowDefinitionParams>,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<WorkflowDefinitionProps>
     getMany(
       params: OptionalDefaults<
         GetSpaceEnvironmentParams & { query?: WorkflowDefinitionQueryOptions }
       >,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<CollectionProp<WorkflowDefinitionProps>>
     create(
       params: OptionalDefaults<CreateWorkflowDefinitionParams>,
       rawData: CreateWorkflowDefinitionProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<WorkflowDefinitionProps>
     update(
       params: OptionalDefaults<UpdateWorkflowDefinitionParams>,
       rawData: UpdateWorkflowDefinitionProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<WorkflowDefinitionProps>
     delete(
       params: OptionalDefaults<DeleteWorkflowDefinitionParams>,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<any>
   }
   workflow: {
     getMany(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { query?: WorkflowQueryOptions }>,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<CollectionProp<WorkflowProps>>
     create(
       params: OptionalDefaults<CreateWorkflowParams>,
       rawData: CreateWorkflowProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<WorkflowProps>
     update(
       params: OptionalDefaults<UpdateWorkflowParams>,
       rawData: UpdateWorkflowProps,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<WorkflowProps>
     delete(
       params: OptionalDefaults<DeleteWorkflowParams>,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<void>
     complete(
       params: OptionalDefaults<CompleteWorkflowParams>,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<void>
   }
   workflowsChangelog: {
@@ -1088,7 +1088,7 @@ export type PlainClientAPI = {
       params: OptionalDefaults<
         GetSpaceEnvironmentParams & { query: WorkflowsChangelogQueryOptions }
       >,
-      headers?: AxiosRequestHeaders
+      headers?: RawAxiosRequestHeaders
     ): Promise<CollectionProp<WorkflowsChangelogEntryProps>>
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
         "babel-loader": "^8.2.1",
-        "babel-minify-webpack-plugin": "^0.3.1",
         "babel-plugin-inline-replace-variables": "^1.3.1",
         "babel-plugin-lodash": "^3.3.4",
         "babel-plugin-rewire-ts": "1.4.0",
@@ -5097,60 +5096,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/babel-core": {
-      "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-      "dev": true,
-      "dependencies": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
-      }
-    },
-    "node_modules/babel-core/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/babel-core/node_modules/json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/babel-core/node_modules/slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/babel-generator": {
       "version": "6.26.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
@@ -5174,58 +5119,6 @@
       "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
-      }
-    },
-    "node_modules/babel-helper-evaluate-path": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.3.0.tgz",
-      "integrity": "sha512-dRFlMTqUJRGzx5a2smKxmptDdNCXKSkPcXWzKLwAV72hvIZumrd/0z9RcewHkr7PmAEq+ETtpD1GK6wZ6ZUXzw==",
-      "dev": true
-    },
-    "node_modules/babel-helper-flip-expressions": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.3.0.tgz",
-      "integrity": "sha512-kNGohWmtAG3b7tN1xocRQ5rsKkH/hpvZsMiGOJ1VwGJKhnwzR5KlB3rvKBaBPl5/IGHcopB2JN+r1SUEX1iMAw==",
-      "dev": true
-    },
-    "node_modules/babel-helper-is-nodes-equiv": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
-      "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
-      "dev": true
-    },
-    "node_modules/babel-helper-is-void-0": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.3.0.tgz",
-      "integrity": "sha512-JVqdX8y7Rf/x4NwbqtUI7mdQjL9HWoDnoAEQ8Gv8oxzjvbJv+n75f7l36m9Y8C7sCUltX3V5edndrp7Hp1oSXQ==",
-      "dev": true
-    },
-    "node_modules/babel-helper-mark-eval-scopes": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.3.0.tgz",
-      "integrity": "sha512-nrho5Dg4vl0VUgURVpGpEGiwbst5JX7efIyDHFxmkCx/ocQFnrPt8ze9Kxl6TKjR29bJ7D/XKY1NMlSxOQJRbQ==",
-      "dev": true
-    },
-    "node_modules/babel-helper-remove-or-void": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.3.0.tgz",
-      "integrity": "sha512-D68W1M3ibCcbg0ysh3ww4/O0g10X1CXK720oOuR8kpfY7w0yP4tVcpK7zDmI1JecynycTQYAZ1rhLJo9aVtIKQ==",
-      "dev": true
-    },
-    "node_modules/babel-helper-to-multiple-sequence-expressions": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.3.0.tgz",
-      "integrity": "sha512-1uCrBD+EAaMnAYh7hc944n8Ga19y3daEnoXWPYDvFVsxMCc1l8aDjksApaCEaNSSuewq8BEcff47Cy1PbLg2Gw==",
-      "dev": true
-    },
-    "node_modules/babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
-      "dependencies": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
       }
     },
     "node_modules/babel-loader": {
@@ -5355,23 +5248,6 @@
         "babel-runtime": "^6.22.0"
       }
     },
-    "node_modules/babel-minify-webpack-plugin": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/babel-minify-webpack-plugin/-/babel-minify-webpack-plugin-0.3.1.tgz",
-      "integrity": "sha512-Johg6Ju0Gxevk2R55eutMqnyXwlyUzCtwunBpiyNzoxGnKum+x5nfNuYZYHGd5Bmc1gmhjwzb7GkxHWOtYWmtQ==",
-      "dev": true,
-      "dependencies": {
-        "babel-core": "^6.26.0",
-        "babel-preset-minify": "^0.3.0",
-        "webpack-sources": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 4.3 < 5.0.0 || >= 5.10"
-      },
-      "peerDependencies": {
-        "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
-    },
     "node_modules/babel-plugin-inline-replace-variables": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-inline-replace-variables/-/babel-plugin-inline-replace-variables-1.3.1.tgz",
@@ -5395,101 +5271,6 @@
         "glob": "^7.1.1",
         "lodash": "^4.17.10",
         "require-package-name": "^2.0.1"
-      }
-    },
-    "node_modules/babel-plugin-minify-builtins": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.3.0.tgz",
-      "integrity": "sha512-MqhSHlxkmgURqj3144qPksbZ/qof1JWdumcbucc4tysFcf3P3V3z3munTevQgKEFNMd8F5/ECGnwb63xogLjAg==",
-      "dev": true,
-      "dependencies": {
-        "babel-helper-evaluate-path": "^0.3.0"
-      }
-    },
-    "node_modules/babel-plugin-minify-constant-folding": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.3.0.tgz",
-      "integrity": "sha512-1XeRpx+aY1BuNY6QU/cm6P+FtEi3ar3XceYbmC+4q4W+2Ewq5pL7V68oHg1hKXkBIE0Z4/FjSoHz6vosZLOe/A==",
-      "dev": true,
-      "dependencies": {
-        "babel-helper-evaluate-path": "^0.3.0"
-      }
-    },
-    "node_modules/babel-plugin-minify-dead-code-elimination": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.3.0.tgz",
-      "integrity": "sha512-SjM2Fzg85YZz+q/PNJ/HU4O3W98FKFOiP9K5z3sfonlamGOzvZw3Eup2OTiEBsbbqTeY8yzNCAv3qpJRYCgGmw==",
-      "dev": true,
-      "dependencies": {
-        "babel-helper-evaluate-path": "^0.3.0",
-        "babel-helper-mark-eval-scopes": "^0.3.0",
-        "babel-helper-remove-or-void": "^0.3.0",
-        "lodash.some": "^4.6.0"
-      }
-    },
-    "node_modules/babel-plugin-minify-flip-comparisons": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.3.0.tgz",
-      "integrity": "sha512-B8lK+ekcpSNVH7PZpWDe5nC5zxjRiiT4nTsa6h3QkF3Kk6y9qooIFLemdGlqBq6j0zALEnebvCpw8v7gAdpgnw==",
-      "dev": true,
-      "dependencies": {
-        "babel-helper-is-void-0": "^0.3.0"
-      }
-    },
-    "node_modules/babel-plugin-minify-guarded-expressions": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.3.0.tgz",
-      "integrity": "sha512-O+6CvF5/Ttsth3LMg4/BhyvVZ82GImeKMXGdVRQGK/8jFiP15EjRpdgFlxv3cnqRjqdYxLCS6r28VfLpb9C/kA==",
-      "dev": true,
-      "dependencies": {
-        "babel-helper-flip-expressions": "^0.3.0"
-      }
-    },
-    "node_modules/babel-plugin-minify-infinity": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.3.0.tgz",
-      "integrity": "sha512-Sj8ia3/w9158DWieUxU6/VvnYVy59geeFEkVgLZYBE8EBP+sN48tHtBM/jSgz0ejEdBlcfqJ6TnvPmVXTzR2BQ==",
-      "dev": true
-    },
-    "node_modules/babel-plugin-minify-mangle-names": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.3.0.tgz",
-      "integrity": "sha512-PYTonhFWURsfAN8achDwvR5Xgy6EeTClLz+fSgGRqjAIXb0OyFm3/xfccbQviVi1qDXmlSnt6oJhBg8KE4Fn7Q==",
-      "dev": true,
-      "dependencies": {
-        "babel-helper-mark-eval-scopes": "^0.3.0"
-      }
-    },
-    "node_modules/babel-plugin-minify-numeric-literals": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.3.0.tgz",
-      "integrity": "sha512-TgZj6ay8zDw74AS3yiIfoQ8vRSNJisYO/Du60S8nPV7EW7JM6fDMx5Sar6yVHlVuuwNgvDUBh191K33bVrAhpg==",
-      "dev": true
-    },
-    "node_modules/babel-plugin-minify-replace": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.3.0.tgz",
-      "integrity": "sha512-VR6tTg2Lt0TicHIOw04fsUtpPw7RaRP8PC8YzSFwEixnzvguZjZJoL7TgG7ZyEWQD1cJ96UezswECmFNa815bg==",
-      "dev": true
-    },
-    "node_modules/babel-plugin-minify-simplify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.3.0.tgz",
-      "integrity": "sha512-2M16ytQOCqBi7bYMu4DCWn8e6KyFCA108F6+tVrBJxOmm5u2sOmTFEa8s94tR9RHRRNYmcUf+rgidfnzL3ik9Q==",
-      "dev": true,
-      "dependencies": {
-        "babel-helper-flip-expressions": "^0.3.0",
-        "babel-helper-is-nodes-equiv": "^0.0.1",
-        "babel-helper-to-multiple-sequence-expressions": "^0.3.0"
-      }
-    },
-    "node_modules/babel-plugin-minify-type-constructors": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.3.0.tgz",
-      "integrity": "sha512-XRXpvsUCPeVw9YEUw+9vSiugcSZfow81oIJT0yR9s8H4W7yJ6FHbImi5DJHoL8KcDUjYnL9wYASXk/fOkbyR6Q==",
-      "dev": true,
-      "dependencies": {
-        "babel-helper-is-void-0": "^0.3.0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -5536,133 +5317,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-rewire-ts/-/babel-plugin-rewire-ts-1.4.0.tgz",
       "integrity": "sha512-XVyyWMIx1fNSG42vbUaAro1LANLs/fBW6KurYaeoVjS2U8zLCaow7LKll6zjs1cwcqcbZK2v59zVouPs+JAqxw==",
       "dev": true
-    },
-    "node_modules/babel-plugin-transform-inline-consecutive-adds": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.3.0.tgz",
-      "integrity": "sha512-iZsYAIjYLLfLK0yN5WVT7Xf7Y3wQ9Z75j9A8q/0IglQSpUt2ppTdHlwl/GeaXnxdaSmsxBu861klbTBbv2n+RA==",
-      "dev": true
-    },
-    "node_modules/babel-plugin-transform-member-expression-literals": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
-      "integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8=",
-      "dev": true
-    },
-    "node_modules/babel-plugin-transform-merge-sibling-variables": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
-      "integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4=",
-      "dev": true
-    },
-    "node_modules/babel-plugin-transform-minify-booleans": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
-      "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg=",
-      "dev": true
-    },
-    "node_modules/babel-plugin-transform-property-literals": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
-      "integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      }
-    },
-    "node_modules/babel-plugin-transform-regexp-constructors": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.3.0.tgz",
-      "integrity": "sha512-h92YHzyl042rb0naKO8frTHntpRFwRgKkfWD8602kFHoQingjJNtbvZzvxqHncJ6XmKVyYvfrBpDOSkCTDIIxw==",
-      "dev": true
-    },
-    "node_modules/babel-plugin-transform-remove-console": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
-      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
-      "dev": true
-    },
-    "node_modules/babel-plugin-transform-remove-debugger": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
-      "integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI=",
-      "dev": true
-    },
-    "node_modules/babel-plugin-transform-remove-undefined": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.3.0.tgz",
-      "integrity": "sha512-TYGQucc8iP3LJwN3kDZLEz5aa/2KuFrqpT+s8f8NnHsBU1sAgR3y8Opns0xhC+smyDYWscqFCKM1gbkWQOhhnw==",
-      "dev": true,
-      "dependencies": {
-        "babel-helper-evaluate-path": "^0.3.0"
-      }
-    },
-    "node_modules/babel-plugin-transform-simplify-comparison-operators": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
-      "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk=",
-      "dev": true
-    },
-    "node_modules/babel-plugin-transform-undefined-to-void": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
-      "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=",
-      "dev": true
-    },
-    "node_modules/babel-preset-minify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.3.0.tgz",
-      "integrity": "sha512-+VV2GWEyak3eDOmzT1DDMuqHrw3VbE9nBNkx2LLVs4pH/Me32ND8DRpVDd8IRvk1xX5p75nygyRPtkMh6GIAbQ==",
-      "dev": true,
-      "dependencies": {
-        "babel-plugin-minify-builtins": "^0.3.0",
-        "babel-plugin-minify-constant-folding": "^0.3.0",
-        "babel-plugin-minify-dead-code-elimination": "^0.3.0",
-        "babel-plugin-minify-flip-comparisons": "^0.3.0",
-        "babel-plugin-minify-guarded-expressions": "^0.3.0",
-        "babel-plugin-minify-infinity": "^0.3.0",
-        "babel-plugin-minify-mangle-names": "^0.3.0",
-        "babel-plugin-minify-numeric-literals": "^0.3.0",
-        "babel-plugin-minify-replace": "^0.3.0",
-        "babel-plugin-minify-simplify": "^0.3.0",
-        "babel-plugin-minify-type-constructors": "^0.3.0",
-        "babel-plugin-transform-inline-consecutive-adds": "^0.3.0",
-        "babel-plugin-transform-member-expression-literals": "^6.9.0",
-        "babel-plugin-transform-merge-sibling-variables": "^6.9.0",
-        "babel-plugin-transform-minify-booleans": "^6.9.0",
-        "babel-plugin-transform-property-literals": "^6.9.0",
-        "babel-plugin-transform-regexp-constructors": "^0.3.0",
-        "babel-plugin-transform-remove-console": "^6.9.0",
-        "babel-plugin-transform-remove-debugger": "^6.9.0",
-        "babel-plugin-transform-remove-undefined": "^0.3.0",
-        "babel-plugin-transform-simplify-comparison-operators": "^6.9.0",
-        "babel-plugin-transform-undefined-to-void": "^6.9.0",
-        "lodash.isplainobject": "^4.0.6"
-      }
-    },
-    "node_modules/babel-register": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
-      "dependencies": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
-      }
-    },
-    "node_modules/babel-register/node_modules/source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
-      "dependencies": {
-        "source-map": "^0.5.6"
-      }
     },
     "node_modules/babel-runtime": {
       "version": "6.26.0",
@@ -11485,19 +11139,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "node_modules/home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
-      "dependencies": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -14030,12 +13671,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
-    },
-    "node_modules/lodash.some": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
       "dev": true
     },
     "node_modules/lodash.uniqby": {
@@ -18811,15 +18446,6 @@
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
-    },
-    "node_modules/os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
@@ -27904,56 +27530,6 @@
         }
       }
     },
-    "babel-core": {
-      "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-          "dev": true
-        },
-        "slash": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-          "dev": true
-        }
-      }
-    },
     "babel-generator": {
       "version": "6.26.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
@@ -27976,58 +27552,6 @@
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         }
-      }
-    },
-    "babel-helper-evaluate-path": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.3.0.tgz",
-      "integrity": "sha512-dRFlMTqUJRGzx5a2smKxmptDdNCXKSkPcXWzKLwAV72hvIZumrd/0z9RcewHkr7PmAEq+ETtpD1GK6wZ6ZUXzw==",
-      "dev": true
-    },
-    "babel-helper-flip-expressions": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.3.0.tgz",
-      "integrity": "sha512-kNGohWmtAG3b7tN1xocRQ5rsKkH/hpvZsMiGOJ1VwGJKhnwzR5KlB3rvKBaBPl5/IGHcopB2JN+r1SUEX1iMAw==",
-      "dev": true
-    },
-    "babel-helper-is-nodes-equiv": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
-      "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
-      "dev": true
-    },
-    "babel-helper-is-void-0": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.3.0.tgz",
-      "integrity": "sha512-JVqdX8y7Rf/x4NwbqtUI7mdQjL9HWoDnoAEQ8Gv8oxzjvbJv+n75f7l36m9Y8C7sCUltX3V5edndrp7Hp1oSXQ==",
-      "dev": true
-    },
-    "babel-helper-mark-eval-scopes": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.3.0.tgz",
-      "integrity": "sha512-nrho5Dg4vl0VUgURVpGpEGiwbst5JX7efIyDHFxmkCx/ocQFnrPt8ze9Kxl6TKjR29bJ7D/XKY1NMlSxOQJRbQ==",
-      "dev": true
-    },
-    "babel-helper-remove-or-void": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.3.0.tgz",
-      "integrity": "sha512-D68W1M3ibCcbg0ysh3ww4/O0g10X1CXK720oOuR8kpfY7w0yP4tVcpK7zDmI1JecynycTQYAZ1rhLJo9aVtIKQ==",
-      "dev": true
-    },
-    "babel-helper-to-multiple-sequence-expressions": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.3.0.tgz",
-      "integrity": "sha512-1uCrBD+EAaMnAYh7hc944n8Ga19y3daEnoXWPYDvFVsxMCc1l8aDjksApaCEaNSSuewq8BEcff47Cy1PbLg2Gw==",
-      "dev": true
-    },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
       }
     },
     "babel-loader": {
@@ -28122,17 +27646,6 @@
         "babel-runtime": "^6.22.0"
       }
     },
-    "babel-minify-webpack-plugin": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/babel-minify-webpack-plugin/-/babel-minify-webpack-plugin-0.3.1.tgz",
-      "integrity": "sha512-Johg6Ju0Gxevk2R55eutMqnyXwlyUzCtwunBpiyNzoxGnKum+x5nfNuYZYHGd5Bmc1gmhjwzb7GkxHWOtYWmtQ==",
-      "dev": true,
-      "requires": {
-        "babel-core": "^6.26.0",
-        "babel-preset-minify": "^0.3.0",
-        "webpack-sources": "^1.0.1"
-      }
-    },
     "babel-plugin-inline-replace-variables": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-inline-replace-variables/-/babel-plugin-inline-replace-variables-1.3.1.tgz",
@@ -28153,101 +27666,6 @@
         "glob": "^7.1.1",
         "lodash": "^4.17.10",
         "require-package-name": "^2.0.1"
-      }
-    },
-    "babel-plugin-minify-builtins": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.3.0.tgz",
-      "integrity": "sha512-MqhSHlxkmgURqj3144qPksbZ/qof1JWdumcbucc4tysFcf3P3V3z3munTevQgKEFNMd8F5/ECGnwb63xogLjAg==",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "^0.3.0"
-      }
-    },
-    "babel-plugin-minify-constant-folding": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.3.0.tgz",
-      "integrity": "sha512-1XeRpx+aY1BuNY6QU/cm6P+FtEi3ar3XceYbmC+4q4W+2Ewq5pL7V68oHg1hKXkBIE0Z4/FjSoHz6vosZLOe/A==",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "^0.3.0"
-      }
-    },
-    "babel-plugin-minify-dead-code-elimination": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.3.0.tgz",
-      "integrity": "sha512-SjM2Fzg85YZz+q/PNJ/HU4O3W98FKFOiP9K5z3sfonlamGOzvZw3Eup2OTiEBsbbqTeY8yzNCAv3qpJRYCgGmw==",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "^0.3.0",
-        "babel-helper-mark-eval-scopes": "^0.3.0",
-        "babel-helper-remove-or-void": "^0.3.0",
-        "lodash.some": "^4.6.0"
-      }
-    },
-    "babel-plugin-minify-flip-comparisons": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.3.0.tgz",
-      "integrity": "sha512-B8lK+ekcpSNVH7PZpWDe5nC5zxjRiiT4nTsa6h3QkF3Kk6y9qooIFLemdGlqBq6j0zALEnebvCpw8v7gAdpgnw==",
-      "dev": true,
-      "requires": {
-        "babel-helper-is-void-0": "^0.3.0"
-      }
-    },
-    "babel-plugin-minify-guarded-expressions": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.3.0.tgz",
-      "integrity": "sha512-O+6CvF5/Ttsth3LMg4/BhyvVZ82GImeKMXGdVRQGK/8jFiP15EjRpdgFlxv3cnqRjqdYxLCS6r28VfLpb9C/kA==",
-      "dev": true,
-      "requires": {
-        "babel-helper-flip-expressions": "^0.3.0"
-      }
-    },
-    "babel-plugin-minify-infinity": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.3.0.tgz",
-      "integrity": "sha512-Sj8ia3/w9158DWieUxU6/VvnYVy59geeFEkVgLZYBE8EBP+sN48tHtBM/jSgz0ejEdBlcfqJ6TnvPmVXTzR2BQ==",
-      "dev": true
-    },
-    "babel-plugin-minify-mangle-names": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.3.0.tgz",
-      "integrity": "sha512-PYTonhFWURsfAN8achDwvR5Xgy6EeTClLz+fSgGRqjAIXb0OyFm3/xfccbQviVi1qDXmlSnt6oJhBg8KE4Fn7Q==",
-      "dev": true,
-      "requires": {
-        "babel-helper-mark-eval-scopes": "^0.3.0"
-      }
-    },
-    "babel-plugin-minify-numeric-literals": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.3.0.tgz",
-      "integrity": "sha512-TgZj6ay8zDw74AS3yiIfoQ8vRSNJisYO/Du60S8nPV7EW7JM6fDMx5Sar6yVHlVuuwNgvDUBh191K33bVrAhpg==",
-      "dev": true
-    },
-    "babel-plugin-minify-replace": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.3.0.tgz",
-      "integrity": "sha512-VR6tTg2Lt0TicHIOw04fsUtpPw7RaRP8PC8YzSFwEixnzvguZjZJoL7TgG7ZyEWQD1cJ96UezswECmFNa815bg==",
-      "dev": true
-    },
-    "babel-plugin-minify-simplify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.3.0.tgz",
-      "integrity": "sha512-2M16ytQOCqBi7bYMu4DCWn8e6KyFCA108F6+tVrBJxOmm5u2sOmTFEa8s94tR9RHRRNYmcUf+rgidfnzL3ik9Q==",
-      "dev": true,
-      "requires": {
-        "babel-helper-flip-expressions": "^0.3.0",
-        "babel-helper-is-nodes-equiv": "^0.0.1",
-        "babel-helper-to-multiple-sequence-expressions": "^0.3.0"
-      }
-    },
-    "babel-plugin-minify-type-constructors": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.3.0.tgz",
-      "integrity": "sha512-XRXpvsUCPeVw9YEUw+9vSiugcSZfow81oIJT0yR9s8H4W7yJ6FHbImi5DJHoL8KcDUjYnL9wYASXk/fOkbyR6Q==",
-      "dev": true,
-      "requires": {
-        "babel-helper-is-void-0": "^0.3.0"
       }
     },
     "babel-plugin-polyfill-corejs2": {
@@ -28285,135 +27703,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-rewire-ts/-/babel-plugin-rewire-ts-1.4.0.tgz",
       "integrity": "sha512-XVyyWMIx1fNSG42vbUaAro1LANLs/fBW6KurYaeoVjS2U8zLCaow7LKll6zjs1cwcqcbZK2v59zVouPs+JAqxw==",
       "dev": true
-    },
-    "babel-plugin-transform-inline-consecutive-adds": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.3.0.tgz",
-      "integrity": "sha512-iZsYAIjYLLfLK0yN5WVT7Xf7Y3wQ9Z75j9A8q/0IglQSpUt2ppTdHlwl/GeaXnxdaSmsxBu861klbTBbv2n+RA==",
-      "dev": true
-    },
-    "babel-plugin-transform-member-expression-literals": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
-      "integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8=",
-      "dev": true
-    },
-    "babel-plugin-transform-merge-sibling-variables": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
-      "integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4=",
-      "dev": true
-    },
-    "babel-plugin-transform-minify-booleans": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
-      "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg=",
-      "dev": true
-    },
-    "babel-plugin-transform-property-literals": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
-      "integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
-      "dev": true,
-      "requires": {
-        "esutils": "^2.0.2"
-      }
-    },
-    "babel-plugin-transform-regexp-constructors": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.3.0.tgz",
-      "integrity": "sha512-h92YHzyl042rb0naKO8frTHntpRFwRgKkfWD8602kFHoQingjJNtbvZzvxqHncJ6XmKVyYvfrBpDOSkCTDIIxw==",
-      "dev": true
-    },
-    "babel-plugin-transform-remove-console": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
-      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
-      "dev": true
-    },
-    "babel-plugin-transform-remove-debugger": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
-      "integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI=",
-      "dev": true
-    },
-    "babel-plugin-transform-remove-undefined": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.3.0.tgz",
-      "integrity": "sha512-TYGQucc8iP3LJwN3kDZLEz5aa/2KuFrqpT+s8f8NnHsBU1sAgR3y8Opns0xhC+smyDYWscqFCKM1gbkWQOhhnw==",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "^0.3.0"
-      }
-    },
-    "babel-plugin-transform-simplify-comparison-operators": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
-      "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk=",
-      "dev": true
-    },
-    "babel-plugin-transform-undefined-to-void": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
-      "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=",
-      "dev": true
-    },
-    "babel-preset-minify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.3.0.tgz",
-      "integrity": "sha512-+VV2GWEyak3eDOmzT1DDMuqHrw3VbE9nBNkx2LLVs4pH/Me32ND8DRpVDd8IRvk1xX5p75nygyRPtkMh6GIAbQ==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-minify-builtins": "^0.3.0",
-        "babel-plugin-minify-constant-folding": "^0.3.0",
-        "babel-plugin-minify-dead-code-elimination": "^0.3.0",
-        "babel-plugin-minify-flip-comparisons": "^0.3.0",
-        "babel-plugin-minify-guarded-expressions": "^0.3.0",
-        "babel-plugin-minify-infinity": "^0.3.0",
-        "babel-plugin-minify-mangle-names": "^0.3.0",
-        "babel-plugin-minify-numeric-literals": "^0.3.0",
-        "babel-plugin-minify-replace": "^0.3.0",
-        "babel-plugin-minify-simplify": "^0.3.0",
-        "babel-plugin-minify-type-constructors": "^0.3.0",
-        "babel-plugin-transform-inline-consecutive-adds": "^0.3.0",
-        "babel-plugin-transform-member-expression-literals": "^6.9.0",
-        "babel-plugin-transform-merge-sibling-variables": "^6.9.0",
-        "babel-plugin-transform-minify-booleans": "^6.9.0",
-        "babel-plugin-transform-property-literals": "^6.9.0",
-        "babel-plugin-transform-regexp-constructors": "^0.3.0",
-        "babel-plugin-transform-remove-console": "^6.9.0",
-        "babel-plugin-transform-remove-debugger": "^6.9.0",
-        "babel-plugin-transform-remove-undefined": "^0.3.0",
-        "babel-plugin-transform-simplify-comparison-operators": "^6.9.0",
-        "babel-plugin-transform-undefined-to-void": "^6.9.0",
-        "lodash.isplainobject": "^4.0.6"
-      }
-    },
-    "babel-register": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
-      },
-      "dependencies": {
-        "source-map-support": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "dev": true,
-          "requires": {
-            "source-map": "^0.5.6"
-          }
-        }
-      }
     },
     "babel-runtime": {
       "version": "6.26.0",
@@ -32934,16 +32223,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
-      }
-    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -34827,12 +34106,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
-    },
-    "lodash.some": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
       "dev": true
     },
     "lodash.uniqby": {
@@ -38297,12 +37570,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-      "dev": true
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-tmpdir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@contentful/rich-text-types": "^16.0.3",
         "@types/json-patch": "0.0.30",
-        "axios": "^0.27.1",
-        "contentful-sdk-core": "^7.0.1",
+        "axios": "^1.4.0",
+        "contentful-sdk-core": "^8.1.0",
         "fast-copy": "^3.0.0",
         "lodash.isplainobject": "^4.0.6",
         "type-fest": "^4.0.0"
@@ -4654,6 +4654,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+      "dev": true
+    },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -5031,31 +5037,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-code-frame": {
@@ -6632,6 +6620,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -7963,16 +7952,47 @@
         "node": ">=14"
       }
     },
-    "node_modules/contentful-sdk-core": {
+    "node_modules/contentful-management/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/contentful-management/node_modules/contentful-sdk-core": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.1.0.tgz",
       "integrity": "sha512-RzTPnRsbCdVAhyka3wa9sDsAu9YsxoerNgaMqd63Ljb7qpG2zkdHcP7NTfyIbuHDJNJdAQdifyafxfEEwP+q/w==",
+      "dev": true,
       "dependencies": {
         "fast-copy": "^2.1.7",
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
         "p-throttle": "^4.1.1",
         "qs": "^6.9.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/contentful-management/node_modules/contentful-sdk-core/node_modules/fast-copy": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA==",
+      "dev": true
+    },
+    "node_modules/contentful-sdk-core": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.1.0.tgz",
+      "integrity": "sha512-ZXTtrkrx4OlRcVY0WLihrskF+BSuHe7QZuWA8DNEeTlHmkPXAVch9Og5TJDoyGeqNrArR3Ovd7yfaG+1QYo+ag==",
+      "dependencies": {
+        "fast-copy": "^2.1.7",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "p-throttle": "^4.1.1"
       },
       "engines": {
         "node": ">=12"
@@ -10577,10 +10597,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
-      "dev": true,
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "funding": [
         {
           "type": "individual",
@@ -10770,7 +10789,8 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -10846,6 +10866,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
       "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -11212,6 +11233,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -11277,6 +11299,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -14351,9 +14374,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -18507,6 +18530,7 @@
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
       "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -19476,6 +19500,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -19703,6 +19732,7 @@
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
       "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -21095,11 +21125,12 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.12.1.tgz",
-      "integrity": "sha512-aieaV1m349rZINEBkjxh2QbBvFFQOlgqYTNtCal82hHj4dDZ76oMlQIX+C7ryerBTDiga3e5NfH6smjdJ02BbQ==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.3.tgz",
+      "integrity": "sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==",
       "dev": true,
       "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
         "jsonc-parser": "^3.2.0",
         "vscode-oniguruma": "^1.7.0",
         "vscode-textmate": "^8.0.0"
@@ -21109,6 +21140,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -22710,15 +22742,15 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.23.24",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.24.tgz",
-      "integrity": "sha512-bfmy8lNQh+WrPYcJbtjQ6JEEsVl/ce1ZIXyXhyW+a1vFrjO39t6J8sL/d6FfAGrJTc7McCXgk9AanYBSNvLdIA==",
+      "version": "0.23.28",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
+      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
-        "marked": "^4.2.5",
-        "minimatch": "^5.1.2",
-        "shiki": "^0.12.1"
+        "marked": "^4.2.12",
+        "minimatch": "^7.1.3",
+        "shiki": "^0.14.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -22727,7 +22759,7 @@
         "node": ">= 14.14"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -22740,15 +22772,18 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typescript": {
@@ -27503,6 +27538,12 @@
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
+    "ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+      "dev": true
+    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -27810,19 +27851,13 @@
       "dev": true
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      },
-      "dependencies": {
-        "follow-redirects": {
-          "version": "1.14.9",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-          "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
-        }
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "babel-code-frame": {
@@ -29144,6 +29179,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -30147,18 +30183,50 @@
         "contentful-sdk-core": "^7.0.1",
         "fast-copy": "^3.0.0",
         "lodash.isplainobject": "^4.0.6"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        },
+        "contentful-sdk-core": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.1.0.tgz",
+          "integrity": "sha512-RzTPnRsbCdVAhyka3wa9sDsAu9YsxoerNgaMqd63Ljb7qpG2zkdHcP7NTfyIbuHDJNJdAQdifyafxfEEwP+q/w==",
+          "dev": true,
+          "requires": {
+            "fast-copy": "^2.1.7",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "p-throttle": "^4.1.1",
+            "qs": "^6.9.4"
+          },
+          "dependencies": {
+            "fast-copy": {
+              "version": "2.1.7",
+              "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+              "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA==",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "contentful-sdk-core": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.1.0.tgz",
-      "integrity": "sha512-RzTPnRsbCdVAhyka3wa9sDsAu9YsxoerNgaMqd63Ljb7qpG2zkdHcP7NTfyIbuHDJNJdAQdifyafxfEEwP+q/w==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.1.0.tgz",
+      "integrity": "sha512-ZXTtrkrx4OlRcVY0WLihrskF+BSuHe7QZuWA8DNEeTlHmkPXAVch9Og5TJDoyGeqNrArR3Ovd7yfaG+1QYo+ag==",
       "requires": {
         "fast-copy": "^2.1.7",
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
-        "p-throttle": "^4.1.1",
-        "qs": "^6.9.4"
+        "p-throttle": "^4.1.1"
       },
       "dependencies": {
         "fast-copy": {
@@ -32198,10 +32266,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
-      "dev": true
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -32334,7 +32401,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "function.prototype.name": {
       "version": "1.1.5",
@@ -32392,6 +32460,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
       "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -32684,6 +32753,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -32727,7 +32797,8 @@
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true
     },
     "has-tostringtag": {
       "version": "1.0.0",
@@ -35008,9 +35079,9 @@
       }
     },
     "marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true
     },
     "marked-terminal": {
@@ -38024,7 +38095,8 @@
     "object-inspect": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
@@ -38745,6 +38817,11 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -38966,6 +39043,7 @@
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
       "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
       }
@@ -40047,11 +40125,12 @@
       "dev": true
     },
     "shiki": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.12.1.tgz",
-      "integrity": "sha512-aieaV1m349rZINEBkjxh2QbBvFFQOlgqYTNtCal82hHj4dDZ76oMlQIX+C7ryerBTDiga3e5NfH6smjdJ02BbQ==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.3.tgz",
+      "integrity": "sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==",
       "dev": true,
       "requires": {
+        "ansi-sequence-parser": "^1.1.0",
         "jsonc-parser": "^3.2.0",
         "vscode-oniguruma": "^1.7.0",
         "vscode-textmate": "^8.0.0"
@@ -40061,6 +40140,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -41328,15 +41408,15 @@
       }
     },
     "typedoc": {
-      "version": "0.23.24",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.24.tgz",
-      "integrity": "sha512-bfmy8lNQh+WrPYcJbtjQ6JEEsVl/ce1ZIXyXhyW+a1vFrjO39t6J8sL/d6FfAGrJTc7McCXgk9AanYBSNvLdIA==",
+      "version": "0.23.28",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
+      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
       "dev": true,
       "requires": {
         "lunr": "^2.3.9",
-        "marked": "^4.2.5",
-        "minimatch": "^5.1.2",
-        "shiki": "^0.12.1"
+        "marked": "^4.2.12",
+        "minimatch": "^7.1.3",
+        "shiki": "^0.14.1"
       },
       "dependencies": {
         "brace-expansion": {
@@ -41349,9 +41429,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+          "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
   "dependencies": {
     "@contentful/rich-text-types": "^16.0.3",
     "@types/json-patch": "0.0.30",
-    "axios": "^0.27.1",
-    "contentful-sdk-core": "^7.0.1",
+    "axios": "^1.4.0",
+    "contentful-sdk-core": "^8.1.0",
     "fast-copy": "^3.0.0",
     "lodash.isplainobject": "^4.0.6",
     "type-fest": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",
     "babel-loader": "^8.2.1",
-    "babel-minify-webpack-plugin": "^0.3.1",
     "babel-plugin-inline-replace-variables": "^1.3.1",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-rewire-ts": "1.4.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const webpack = require('webpack')
-// const MinifyPlugin = require('babel-minify-webpack-plugin')
 const clone = require('lodash/cloneDeep')
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin')
 
@@ -20,8 +19,6 @@ const plugins = [
 ]
 
 if (PROD) {
-  //TODO: remove dev dependency
-  //plugins.push(new MinifyPlugin())
   plugins.push(
     new webpack.LoaderOptionsPlugin({
       minimize: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const webpack = require('webpack')
-const MinifyPlugin = require('babel-minify-webpack-plugin')
+// const MinifyPlugin = require('babel-minify-webpack-plugin')
 const clone = require('lodash/cloneDeep')
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin')
 
@@ -20,7 +20,8 @@ const plugins = [
 ]
 
 if (PROD) {
-  plugins.push(new MinifyPlugin())
+  //TODO: remove dev dependency
+  //plugins.push(new MinifyPlugin())
   plugins.push(
     new webpack.LoaderOptionsPlugin({
       minimize: true,


### PR DESCRIPTION
## Summary

Bump `contentful-sdk-core` to the latest major version which also pulls in `axios@1.4.0`

## Description

Bump `contentful-sdk-core` to the latest major version which also pulls in `axios@1.4.0`. 
This requires some adjustment in the codebase: 

### Headers shape
The old shape of `AxiosRequestHeaders` is now represented by `RawAxiosRequestHeaders`.


### Remove webpack plugin
After updating the dependencies, one of the build steps threw an error. This was caused by the babel plugin `babel-minify-webpack-plugin` which we used to minify the bundles. [We still minify through loader options](https://github.com/contentful/contentful-management.js/blob/master/webpack.config.js#L26).


## Motivation and Context

`axios@1.x` is now released for ~10 months and stable. To ensure we can receive updates for all our dependencies, we have to eventually update to the latest major. 

## Checklist (check all before merging)

- [X] Both unit and integration tests are passing
- [X] There are no breaking changes
