### PR TITLE
feat(deliveryFunctions): Allow CCA to upload delivery functions [MONET-1336]

### DIFF
--- a/lib/adapters/REST/endpoints/app-bundle.ts
+++ b/lib/adapters/REST/endpoints/app-bundle.ts
@@ -44,7 +44,7 @@ export const create: RestEndpoint<'AppBundle', 'create'> = (
   params: GetAppDefinitionParams,
   payload: CreateAppBundleProps
 ) => {
-  const { appUploadId, comment, actions } = payload
+  const { appUploadId, comment, actions, deliveryFunctions } = payload
 
   const data = {
     upload: {
@@ -56,6 +56,7 @@ export const create: RestEndpoint<'AppBundle', 'create'> = (
     },
     comment,
     actions,
+    deliveryFunctions,
   }
 
   return raw.post<AppBundleProps>(http, getBaseUrl(params), data)

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -16,6 +16,7 @@ interface ActionManifestProps {
   description: string
   category: string
   path: string
+  allowNetworks?: string[]
 }
 
 interface DeliveryFunctionManifestProps {
@@ -23,7 +24,7 @@ interface DeliveryFunctionManifestProps {
   name: string
   description: string
   path: string
-  allowNetworks: string
+  allowNetworks?: string[]
 }
 
 export type AppBundleFile = {

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -18,6 +18,14 @@ interface ActionManifestProps {
   path: string
 }
 
+interface DeliveryFunctionManifestProps {
+  id: string
+  name: string
+  description: string
+  path: string
+  allowNetworks: string
+}
+
 export type AppBundleFile = {
   name: string
   size: number
@@ -28,6 +36,7 @@ export type CreateAppBundleProps = {
   appUploadId: string
   comment?: string
   actions?: ActionManifestProps[]
+  deliveryFunctions?: DeliveryFunctionManifestProps[]
 }
 
 export type AppBundleProps = {

--- a/test/unit/create-app-definition-api-test.js
+++ b/test/unit/create-app-definition-api-test.js
@@ -125,6 +125,27 @@ describe('createAppDefinitionApi', () => {
     })
   })
 
+  test('API call createAppBundle with delivery functions', async () => {
+    const { api, entitiesMock } = setup(Promise.resolve({}))
+    const appBundleWithDeliveryFns = {
+      ...appBundleMock,
+      deliveryFunctions: [
+        {
+          id: 'myCustomId',
+          name: 'My Action',
+          description: 'Action uploaded with bundle',
+          path: 'functions/test.js',
+        },
+      ],
+    }
+
+    entitiesMock['appBundle']['wrapAppBundle'].returns(appBundleWithDeliveryFns)
+
+    return api['createAppBundle']({ appBundleId: 'id' }).then((result) => {
+      expect(result).equals(appBundleWithDeliveryFns)
+    })
+  })
+
   test('API call createAppBundle fails', async () => {
     return makeEntityMethodFailingTest(setup, {
       methodToTest: 'createAppBundle',

--- a/test/unit/create-app-definition-api-test.js
+++ b/test/unit/create-app-definition-api-test.js
@@ -132,8 +132,8 @@ describe('createAppDefinitionApi', () => {
       deliveryFunctions: [
         {
           id: 'myCustomId',
-          name: 'My Action',
-          description: 'Action uploaded with bundle',
+          name: 'My Delivery function',
+          description: 'Delivery function uploaded with bundle',
           path: 'functions/test.js',
         },
       ],


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

New EAP property for allow delivery functions upload.


## Motivation and Context

App bundles will now support an extra feature - delivery functions. Sibling PR: https://github.com/contentful/create-contentful-app/pull/1641

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes

