### PR TITLE
feat: support optional expiresIn param in token creation [AHOY-2470]

### DIFF
--- a/lib/entities/personal-access-token.ts
+++ b/lib/entities/personal-access-token.ts
@@ -5,7 +5,7 @@ import { wrapCollection } from '../common-utils'
 import { MetaSysProps, DefaultElements, MakeRequest } from '../common-types'
 
 export type PersonalAccessTokenProp = {
-  sys: MetaSysProps & { expiresAt?: number }
+  sys: MetaSysProps & { expiresAt?: string }
   name: string
   scopes: 'content_management_manage'[]
   revokedAt: null | string

--- a/lib/entities/personal-access-token.ts
+++ b/lib/entities/personal-access-token.ts
@@ -5,14 +5,16 @@ import { wrapCollection } from '../common-utils'
 import { MetaSysProps, DefaultElements, MakeRequest } from '../common-types'
 
 export type PersonalAccessTokenProp = {
-  sys: MetaSysProps
+  sys: MetaSysProps & { expiresAt?: number }
   name: string
   scopes: 'content_management_manage'[]
   revokedAt: null | string
   token?: string
 }
 
-export type CreatePersonalAccessTokenProps = Pick<PersonalAccessToken, 'name' | 'scopes'>
+export type CreatePersonalAccessTokenProps = Pick<PersonalAccessToken, 'name' | 'scopes'> & {
+  expiresIn?: number
+}
 
 export interface PersonalAccessToken
   extends PersonalAccessTokenProp,


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

- Support optional `expiresIn` parameter in `CreatePersonalAccessTokenProps`.
- Support optional `expiresAt` parameter in `PersonalAccessTokenProp.sys`.

## Description

- Update 2 out-of-sync types to support new CMA access tokens TTL features.
- Test `personalAccessToken.create` and `personalAccessToken.get` methods on the plain client
- Test `createPersonalAccessToken` and `getPersonalAccessToken` methods on the default client

## Motivation and Context

We are updating the client types to reflect the API changes.
In the follow up pull requests, additional changes will be introduced, moving away from Personal Access Tokens (PATs) and using new entity of unified Access Tokens (PAT, CLI, OAuth) will be introduced.
For now, though, we are just updating PAT types.

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
