### PR TITLE
[EXT-4731] docs: add tsdocs for plainClient app action APIs

### DIFF
--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -27,8 +27,6 @@ import {
   PaginationQueryParams,
   QueryParams,
   GetAppUploadParams,
-  GetAppActionParams,
-  GetAppActionCallParams,
   GetAppBundleParams,
   GetBulkActionParams,
   GetReleaseParams,
@@ -36,13 +34,11 @@ import {
   GetEntryParams,
   CursorPaginatedCollectionProp,
   GetWorkflowDefinitionParams,
-  GetAppActionsForEnvParams,
   GetUserUIConfigParams,
   GetUIConfigParams,
   GetEnvironmentTemplateParams,
   BasicCursorPaginationOptions,
   EnvironmentTemplateParams,
-  GetAppActionCallDetailsParams,
 } from '../common-types'
 import { ApiKeyProps, CreateApiKeyProps } from '../entities/api-key'
 import {
@@ -116,12 +112,6 @@ import {
 import { DefaultParams, OptionalDefaults } from './wrappers/wrap'
 import { AssetKeyProps, CreateAssetKeyProps } from '../entities/asset-key'
 import { AppUploadProps } from '../entities/app-upload'
-import { AppActionProps, CreateAppActionProps } from '../entities/app-action'
-import {
-  AppActionCallProps,
-  AppActionCallResponse,
-  CreateAppActionCallProps,
-} from '../entities/app-action-call'
 import { AppBundleProps, CreateAppBundleProps } from '../entities/app-bundle'
 import { AppDetailsProps, CreateAppDetailsProps } from '../entities/app-details'
 import { AppSignedRequestProps, CreateAppSignedRequestProps } from '../entities/app-signed-request'
@@ -185,6 +175,7 @@ import {
   ValidateEnvironmentTemplateInstallationProps,
 } from '../entities/environment-template-installation'
 import { AppActionPlainClientAPI } from './entities/app-action'
+import { AppActionCallPlainClientAPI } from './entities/app-action-call'
 
 export type PlainClientAPI = {
   raw: {
@@ -197,19 +188,7 @@ export type PlainClientAPI = {
     http<T = unknown>(url: string, config?: RawAxiosRequestConfig): Promise<T>
   }
   appAction: AppActionPlainClientAPI
-  appActionCall: {
-    create(
-      params: OptionalDefaults<GetAppActionCallParams>,
-      payload: CreateAppActionCallProps
-    ): Promise<AppActionCallProps>
-    getCallDetails(
-      params: OptionalDefaults<GetAppActionCallDetailsParams>
-    ): Promise<AppActionCallResponse>
-    createWithResponse(
-      params: OptionalDefaults<GetAppActionCallParams>,
-      payload: CreateAppActionCallProps
-    ): Promise<AppActionCallResponse>
-  }
+  appActionCall: AppActionCallPlainClientAPI
   appBundle: {
     get(params: OptionalDefaults<GetAppBundleParams>): Promise<AppBundleProps>
     getMany(

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -184,6 +184,7 @@ import {
   EnvironmentTemplateValidationProps,
   ValidateEnvironmentTemplateInstallationProps,
 } from '../entities/environment-template-installation'
+import { AppActionPlainClientAPI } from './entities/app-action'
 
 export type PlainClientAPI = {
   raw: {
@@ -195,24 +196,7 @@ export type PlainClientAPI = {
     delete<T = unknown>(url: string, config?: RawAxiosRequestConfig): Promise<T>
     http<T = unknown>(url: string, config?: RawAxiosRequestConfig): Promise<T>
   }
-  appAction: {
-    get(params: OptionalDefaults<GetAppActionParams>): Promise<AppActionProps>
-    getMany(
-      params: OptionalDefaults<GetAppDefinitionParams & QueryParams>
-    ): Promise<CollectionProp<AppActionProps>>
-    getManyForEnvironment(
-      params: OptionalDefaults<GetAppActionsForEnvParams & QueryParams>
-    ): Promise<CollectionProp<AppActionProps>>
-    delete(params: OptionalDefaults<GetAppActionParams>): Promise<void>
-    create(
-      params: OptionalDefaults<GetAppDefinitionParams>,
-      payload: CreateAppActionProps
-    ): Promise<AppActionProps>
-    update(
-      params: OptionalDefaults<GetAppActionParams>,
-      payload: CreateAppActionProps
-    ): Promise<AppActionProps>
-  }
+  appAction: AppActionPlainClientAPI
   appActionCall: {
     create(
       params: OptionalDefaults<GetAppActionCallParams>,

--- a/lib/plain/entities/app-action-call.ts
+++ b/lib/plain/entities/app-action-call.ts
@@ -1,0 +1,78 @@
+import { GetAppActionCallDetailsParams, GetAppActionCallParams } from '../../common-types'
+import {
+  AppActionCallProps,
+  AppActionCallResponse,
+  CreateAppActionCallProps,
+} from '../../entities/app-action-call'
+import { OptionalDefaults } from '../wrappers/wrap'
+
+export type AppActionCallPlainClientAPI = {
+  /**
+   * Calls (triggers) an App Action
+   * @param params entity IDs to identify the App Action to call
+   * @param payload the payload to be sent to the App Action
+   * @returns basic metadata about the App Action Call
+   * @throws if the request fails, or the App Action is not found
+   * @example
+   * ```javascript
+   * await client.appActionCall.create(
+   *   {
+   *     spaceId: "<space_id>",
+   *     environmentId: "<environement_id>",
+   *     appDefinitionId: "<app_definition_id>",
+   *     appActionId: "<app_action_id>",
+   *   },
+   *   {
+   *     parameters: { // ... },
+   *   }
+   * );
+   * ```
+   */
+  create(
+    params: OptionalDefaults<GetAppActionCallParams>,
+    payload: CreateAppActionCallProps
+  ): Promise<AppActionCallProps>
+  /**
+   * Fetches the details of an App Action Call
+   * @param params entity IDs to identify the App Action Call
+   * @returns detailed metadata about the App Action Call
+   * @throws if the request fails, or the App Action is not found
+   * @example
+   * ```javascript
+   * const appActionCall = await client.appActionCall.getCallDetails({
+   *   spaceId: "<space_id>",
+   *   environmentId: "<environement_id>",
+   *   appDefinitionId: "<app_definition_id>",
+   *   appActionId: "<app_action_id>",
+   * });
+   * ```
+   */
+  getCallDetails(
+    params: OptionalDefaults<GetAppActionCallDetailsParams>
+  ): Promise<AppActionCallResponse>
+  /**
+   * Calls (triggers) an App Action
+   * @param params entity IDs to identify the App Action to call
+   * @param payload the payload to be sent to the App Action
+   * @returns detailed metadata about the App Action Call
+   * @throws if the request fails, or the App Action is not found
+   * @example
+   * ```javascript
+   * const appActionCall = await client.appActionCall.createWithResponse(
+   *   {
+   *     spaceId: "<space_id>",
+   *     environmentId: "<environement_id>",
+   *     appDefinitionId: "<app_definition_id>",
+   *     appActionId: "<app_action_id>",
+   *   },
+   *   {
+   *     parameters: { // ... },
+   *   }
+   * );
+   * ```
+   */
+  createWithResponse(
+    params: OptionalDefaults<GetAppActionCallParams>,
+    payload: CreateAppActionCallProps
+  ): Promise<AppActionCallResponse>
+}

--- a/lib/plain/entities/app-action.ts
+++ b/lib/plain/entities/app-action.ts
@@ -1,0 +1,128 @@
+import {
+  CollectionProp,
+  GetAppActionParams,
+  GetAppActionsForEnvParams,
+  GetAppDefinitionParams,
+  QueryParams,
+} from '../../common-types'
+import { AppActionProps, CreateAppActionProps } from '../../entities/app-action'
+import { OptionalDefaults } from '../wrappers/wrap'
+
+export type AppActionPlainClientAPI = {
+  /**
+   * Fetches the given App Action.
+   * @param params entity IDs to identify the App Action
+   * @returns the App Action
+   * @throws if the request fails, or the App Action is not found
+   * @example
+   * ```javascript
+   * const appAction = await client.appAction.get({
+   *   organizationId: "<org_id>",
+   *   appDefinitionId: "<app_definition_id>",
+   *   appActionId: "<app_action_id>",
+   * });
+   * ```
+   */
+  get(params: OptionalDefaults<GetAppActionParams>): Promise<AppActionProps>
+  /**
+   * Fetches all App Actions for the given App
+   * @param params entity IDs to identify the App
+   * @returns an object containing an array of App Actions
+   * @throws if the request fails, or the App is not found
+   * @example
+   * ```javascript
+   * const appActions = await client.appAction.getMany({
+   *   organizationId: "<org_id>",
+   *   appDefinitionId: "<app_definition_id>",
+   * });
+   * ```
+   */
+  getMany(
+    params: OptionalDefaults<GetAppDefinitionParams & QueryParams>
+  ): Promise<CollectionProp<AppActionProps>>
+  /**
+   * Fetches all App Actions for the given environment
+   * @param params entity IDs to identify the Environment
+   * @returns an object containing an array of App Actions
+   * @throws if the request fails, or the Environment is not found
+   * @example
+   * ```javascript
+   * const appActions = await client.appAction.getManyForEnvironment({
+   *   spaceId: "<space_id>",
+   *   environmentId: "<environment_id>",
+   * });
+   * ```
+   */
+  getManyForEnvironment(
+    params: OptionalDefaults<GetAppActionsForEnvParams & QueryParams>
+  ): Promise<CollectionProp<AppActionProps>>
+  /**
+   * Deletes the given App Action
+   * @param params entity IDs to identify the App Action to delete
+   * @returns void
+   * @throws if the request fails, or the App Action is not found
+   * @example
+   * ```javascript
+   * await client.appAction.delete({
+   *   organizationId: "<org_id>",
+   *   appDefinitionId: "<app_definition_id>",
+   *   appActionId: "<app_action_id>",
+   * });
+   * ```
+   */
+  delete(params: OptionalDefaults<GetAppActionParams>): Promise<void>
+  /**
+   * Creates an App Action
+   * @param params entity IDs to scope where to create the App Action
+   * @param payload the App Action details
+   * @returns the created App Action and its metadata
+   * @throws if the request fails, an entity is not found, or the payload is malformed
+   * @example
+   * ```javascript
+   * const appAction = await client.appAction.create(
+   *   {
+   *     organizationId: "<org_id>",
+   *     appDefinitionId: "<app_definition_id>",
+   *     appActionId: "<app_action_id>",
+   *   },
+   *   {
+   *     category: "Notification.v1.0",
+   *     url: "https://www.somewhere-else.com/action",
+   *     description: "sends a notification",
+   *     name: "My Notification",
+   *   }
+   * );
+   * ```
+   */
+  create(
+    params: OptionalDefaults<GetAppDefinitionParams>,
+    payload: CreateAppActionProps
+  ): Promise<AppActionProps>
+  /**
+   * Updates an App Action
+   * @param params entity IDs to identify the App Action
+   * @param payload the App Action update
+   * @returns the updated App Action and its metadata
+   * @throws if the request fails, the App Action is not found, or the payload is malformed
+   * @example
+   * ```javascript
+   * const appAction = await client.appAction.update(
+   *   {
+   *     organizationId: "<org_id>",
+   *     appDefinitionId: "<app_definition_id>",
+   *     appActionId: "<app_action_id>",
+   *   },
+   *   {
+   *     category: "Notification.v1.0",
+   *     url: "https://www.somewhere-else.com/action",
+   *     description: "sends a notification",
+   *     name: "My Notification",
+   *   }
+   * );
+   * ```
+   */
+  update(
+    params: OptionalDefaults<GetAppActionParams>,
+    payload: CreateAppActionProps
+  ): Promise<AppActionProps>
+}


### PR DESCRIPTION
## Summary

adds inline documentation for plain client APIs for working with App Actions and App Action Calls
<img width="760" alt="Screenshot 2023-09-01 at 8 36 27 AM" src="https://github.com/contentful/contentful-management.js/assets/104802020/aca500b2-4223-45e7-9fa2-54ba7e8ccc7b">

## Motivation and Context

we want the plain client to become the default way developers consume this SDK, so we need to provide examples for how to do that

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

