### PR TITLE
[EXT-4733] docs: add inline TSDocs for the plain client UI Config & User UI Config APIs

### DIFF
--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -977,13 +977,7 @@ export type PlainClientAPI = {
     ): Promise<TeamSpaceMembershipProps>
     delete(params: OptionalDefaults<GetTeamSpaceMembershipParams>): Promise<any>
   }
-  uiConfig: {
-    get(params: OptionalDefaults<GetUIConfigParams>): Promise<UIConfigProps>
-    update(
-      params: OptionalDefaults<GetUIConfigParams>,
-      rawData: UIConfigProps
-    ): Promise<UIConfigProps>
-  }
+  uiConfig: UIConfigPlainClientAPI
   userUIConfig: {
     get(params: OptionalDefaults<GetUserUIConfigParams>): Promise<UserUIConfigProps>
     update(

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -33,8 +33,6 @@ import {
   GetEntryParams,
   CursorPaginatedCollectionProp,
   GetWorkflowDefinitionParams,
-  GetUserUIConfigParams,
-  GetUIConfigParams,
   GetEnvironmentTemplateParams,
   BasicCursorPaginationOptions,
   EnvironmentTemplateParams,
@@ -160,8 +158,6 @@ import {
   WorkflowsChangelogEntryProps,
   WorkflowsChangelogQueryOptions,
 } from '../entities/workflows-changelog-entry'
-import { UserUIConfigProps } from '../entities/user-ui-config'
-import { UIConfigProps } from '../entities/ui-config'
 import {
   CreateEnvironmentTemplateProps,
   EnvironmentTemplateProps,
@@ -175,6 +171,8 @@ import {
 import { AppActionPlainClientAPI } from './entities/app-action'
 import { AppActionCallPlainClientAPI } from './entities/app-action-call'
 import { EditorInterfacePlainClientAPI } from './entities/editor-interface'
+import { UIConfigPlainClientAPI } from './entities/ui-config'
+import { UserUIConfigPlainClientAPI } from './entities/user-ui-config'
 
 export type PlainClientAPI = {
   raw: {
@@ -978,13 +976,7 @@ export type PlainClientAPI = {
     delete(params: OptionalDefaults<GetTeamSpaceMembershipParams>): Promise<any>
   }
   uiConfig: UIConfigPlainClientAPI
-  userUIConfig: {
-    get(params: OptionalDefaults<GetUserUIConfigParams>): Promise<UserUIConfigProps>
-    update(
-      params: OptionalDefaults<GetUserUIConfigParams>,
-      rawData: UserUIConfigProps
-    ): Promise<UserUIConfigProps>
-  }
+  userUIConfig: UserUIConfigPlainClientAPI
   workflowDefinition: {
     get(
       params: OptionalDefaults<GetWorkflowDefinitionParams>,

--- a/lib/plain/entities/ui-config.ts
+++ b/lib/plain/entities/ui-config.ts
@@ -1,0 +1,48 @@
+import { GetUIConfigParams } from '../../common-types'
+import { UIConfigProps } from '../../entities/ui-config'
+import { OptionalDefaults } from '../wrappers/wrap'
+
+export type UIConfigPlainClientAPI = {
+  /**
+   * Fetch the UI Config for a given Space and Environment
+   * @param params entity IDs to identify the UI Config
+   * @returns the UI Config
+   * @throws if the request fails, or the UI Config is not found
+   * @example
+   * ```javascript
+   * const uiConfig = await client.uiConfig.get({
+   *   spaceId: "<space_id>",
+   *   environmentId: "<environment_id>",
+   * });
+   * ```
+   */
+  get(params: OptionalDefaults<GetUIConfigParams>): Promise<UIConfigProps>
+  /**
+   * Update the UI Config for a given Space and Environment
+   * @param params entity IDs to identify the UI Config
+   * @param rawData the UI Config update
+   * @returns the updated UI Config
+   * @throws if the request fails, the UI Config is not found, or the update payload is malformed
+   * @example
+   * ```javascript
+   * await client.uiConfig.update({
+   *   spaceId: "<space_id>",
+   *   environmentId: "<environment_id>",
+   * }, {
+   *   ...existingUIConfig,
+   *   entryListViews: [
+   *     ...existingUIConfig.entryListViews,
+   *     {
+   *       id: 'newFolder',
+   *       title: 'New Folder',
+   *       views: []
+   *     }
+   *   ],
+   * });
+   * ```
+   */
+  update(
+    params: OptionalDefaults<GetUIConfigParams>,
+    rawData: UIConfigProps
+  ): Promise<UIConfigProps>
+}

--- a/lib/plain/entities/user-ui-config.ts
+++ b/lib/plain/entities/user-ui-config.ts
@@ -1,0 +1,48 @@
+import { GetUserUIConfigParams } from '../../common-types'
+import { UserUIConfigProps } from '../../entities/user-ui-config'
+import { OptionalDefaults } from '../wrappers/wrap'
+
+export type UserUIConfigPlainClientAPI = {
+  /**
+   * Fetch the UI Config for the current user in a given Space and Environment
+   * @param params entity IDs to identify the UI Config
+   * @returns the UI Config
+   * @throws if the request fails, or the UI Config is not found
+   * @example
+   * ```javascript
+   * const uiConfig = await client.userUIConfig.get({
+   *   spaceId: "<space_id>",
+   *   environmentId: "<environment_id>",
+   * });
+   * ```
+   */
+  get(params: OptionalDefaults<GetUserUIConfigParams>): Promise<UserUIConfigProps>
+  /**
+   * Update the UI Config for for the current user in a given Space and Environment
+   * @param params entity IDs to identify the UI Config
+   * @param rawData the UI Config update
+   * @returns the updated UI Config
+   * @throws if the request fails, the UI Config is not found, or the update payload is malformed
+   * @example
+   * ```javascript
+   * await client.userUIConfig.update({
+   *   spaceId: "<space_id>",
+   *   environmentId: "<environment_id>",
+   * }, {
+   *   ...existingUIConfig,
+   *   entryListViews: [
+   *     ...existingUIConfig.entryListViews,
+   *     {
+   *       id: 'newFolder',
+   *       title: 'New Folder',
+   *       views: []
+   *     }
+   *   ],
+   * });
+   * ```
+   */
+  update(
+    params: OptionalDefaults<GetUserUIConfigParams>,
+    rawData: UserUIConfigProps
+  ): Promise<UserUIConfigProps>
+}


### PR DESCRIPTION
## Summary

adds inline documentation for plain client APIs for working with UI Configs and User UI Configs

stacked on https://github.com/contentful/contentful-management.js/pull/1942

## Motivation and Context

we want the plain client to become the default way developers consume this SDK, so we need to provide examples for how to do that

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation