### PR TITLE
feat: increase retries for app actions to 20 for ai image generator app

### DIFF
--- a/lib/adapters/REST/endpoints/app-action-call.ts
+++ b/lib/adapters/REST/endpoints/app-action-call.ts
@@ -32,7 +32,7 @@ export const getCallDetails: RestEndpoint<'AppActionCall', 'getCallDetails'> = (
 }
 
 const APP_ACTION_CALL_RETRY_INTERVAL = 2000
-const APP_ACTION_CALL_RETRIES = 10
+const APP_ACTION_CALL_RETRIES = 20
 
 async function callAppActionResult(
   http: AxiosInstance,


### PR DESCRIPTION
## Summary
DALL-E by OpenAI is powering our AI Image Generator app. However, the response times are long enough such that we require more polling retries. 20 is sufficient for the AIIG app to respond with the edited image the app requires.

## Description
Increase number of retries

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
