### PR TITLE
feat: allow retry and retryInterval to be specified in appActionCall.createWithResponse [INTEG-1208]

### DIFF
--- a/lib/adapters/REST/endpoints/app-action-call.ts
+++ b/lib/adapters/REST/endpoints/app-action-call.ts
@@ -6,7 +6,11 @@ import {
 } from '../../../entities/app-action-call'
 import * as raw from './raw'
 import { RestEndpoint } from '../types'
-import { GetAppActionCallDetailsParams, GetAppActionCallParams } from '../../../common-types'
+import {
+  CreateWithResponseParams,
+  GetAppActionCallDetailsParams,
+  GetAppActionCallParams,
+} from '../../../common-types'
 import { isSuccessful, shouldRePoll, waitFor } from '../../../common-utils'
 
 export const create: RestEndpoint<'AppActionCall', 'create'> = (
@@ -36,7 +40,7 @@ const APP_ACTION_CALL_RETRIES = 10
 
 async function callAppActionResult(
   http: AxiosInstance,
-  params: GetAppActionCallParams,
+  params: CreateWithResponseParams,
   {
     callId,
   }: {
@@ -44,8 +48,8 @@ async function callAppActionResult(
   }
 ): Promise<AppActionCallResponse> {
   let checkCount = 1
-  const retryInterval = APP_ACTION_CALL_RETRY_INTERVAL
-  const retries = APP_ACTION_CALL_RETRIES
+  const retryInterval = params.retryInterval || APP_ACTION_CALL_RETRY_INTERVAL
+  const retries = params.retries || APP_ACTION_CALL_RETRIES
 
   return new Promise((resolve, reject) => {
     const poll = async () => {
@@ -92,7 +96,7 @@ async function callAppActionResult(
 
 export const createWithResponse: RestEndpoint<'AppActionCall', 'createWithResponse'> = async (
   http: AxiosInstance,
-  params: GetAppActionCallParams,
+  params: CreateWithResponseParams,
   data: CreateAppActionCallProps
 ) => {
   const createResponse = await raw.post<AppActionCallProps>(

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1758,6 +1758,10 @@ export type EnvironmentTemplateParams = {
 export type GetAppActionParams = GetAppDefinitionParams & { appActionId: string }
 export type GetAppActionsForEnvParams = GetSpaceParams & { environmentId?: string }
 export type GetAppActionCallParams = GetAppInstallationParams & { appActionId: string }
+export type CreateWithResponseParams = GetAppActionCallParams & {
+  retries?: number
+  retryInterval?: number
+}
 export type GetAppActionCallDetailsParams = GetSpaceEnvironmentParams & {
   appActionId: string
   callId: string


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Allows the caller to specify a `retries` and/or `retryInterval` in calls to `appActionCall.createWithResponse()`

## Motivation and Context

The current `retry` and `retryInterval` values are hard coded to 10 and 2 seconds respectively. But some operations implemented with App Action can take longer than 20 seconds (for example, AI image processing).

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
