### PR TITLE
fix: retry AppActionCall for up to 30s [INTEG-1208]

### DIFF
--- a/lib/adapters/REST/endpoints/app-action-call.ts
+++ b/lib/adapters/REST/endpoints/app-action-call.ts
@@ -36,7 +36,7 @@ export const getCallDetails: RestEndpoint<'AppActionCall', 'getCallDetails'> = (
 }
 
 const APP_ACTION_CALL_RETRY_INTERVAL = 2000
-const APP_ACTION_CALL_RETRIES = 10
+const APP_ACTION_CALL_RETRIES = 15
 
 async function callAppActionResult(
   http: AxiosInstance,

--- a/test/unit/adapters/REST/endpoints/app-action-call-test.ts
+++ b/test/unit/adapters/REST/endpoints/app-action-call-test.ts
@@ -81,7 +81,7 @@ describe('Rest App Action Call', () => {
       httpMock.get.withArgs(
         `/spaces/space-id/environments/environment-id/actions/app-action-id/calls/call-id`
       ),
-      10
+      15
     )
   })
 
@@ -142,7 +142,7 @@ describe('Rest App Action Call', () => {
       httpMock.get.withArgs(
         `/spaces/space-id/environments/environment-id/actions/app-action-id/calls/call-id`
       ),
-      10
+      15
     )
   })
 
@@ -172,7 +172,7 @@ describe('Rest App Action Call', () => {
       httpMock.get.withArgs(
         `/spaces/space-id/environments/environment-id/actions/app-action-id/calls/call-id`
       ),
-      10
+      15
     )
   })
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Extends the retry duration when using `AppActionCall.createWithResponse` to 30 seconds (15 retries with a 2 second retry interval.

## Description

Today, createWithResponse retries only 10 times with a 2s interval, which works out to about 20 seconds. We just extend the polling here to 30 seconds.

## Motivation and Context

Long running hosted app actions can take longer than 20 seconds. We are discovering that AI image manipulation frequently takes 20-25 seconds.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
