### PR TITLE
[EXT-4732] docs: add tsdocs for plainClient Editor Interface APIs

### DIFF
--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -7,7 +7,6 @@ import {
   GetAppInstallationParams,
   GetCommentParams,
   GetContentTypeParams,
-  GetEditorInterfaceParams,
   GetOrganizationMembershipParams,
   GetOrganizationParams,
   GetSnapshotForContentTypeParams,
@@ -67,7 +66,6 @@ import {
   PlainTextBodyFormat,
 } from '../entities/comment'
 import { ContentTypeProps, CreateContentTypeProps } from '../entities/content-type'
-import { EditorInterfaceProps } from '../entities/editor-interface'
 import { CreateEntryProps, EntryProps, EntryReferenceProps } from '../entities/entry'
 import { CreateEnvironmentProps, EnvironmentProps } from '../entities/environment'
 import { CreateEnvironmentAliasProps, EnvironmentAliasProps } from '../entities/environment-alias'
@@ -176,6 +174,7 @@ import {
 } from '../entities/environment-template-installation'
 import { AppActionPlainClientAPI } from './entities/app-action'
 import { AppActionCallPlainClientAPI } from './entities/app-action-call'
+import { EditorInterfacePlainClientAPI } from './entities/editor-interface'
 
 export type PlainClientAPI = {
   raw: {
@@ -227,17 +226,7 @@ export type PlainClientAPI = {
       params: OptionalDefaults<GetAppDefinitionParams & QueryParams>
     ): Promise<CollectionProp<DeliveryFunctionProps>>
   }
-  editorInterface: {
-    get(params: OptionalDefaults<GetEditorInterfaceParams>): Promise<EditorInterfaceProps>
-    getMany(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>
-    ): Promise<CollectionProp<EditorInterfaceProps>>
-    update(
-      params: OptionalDefaults<GetEditorInterfaceParams>,
-      rawData: EditorInterfaceProps,
-      headers?: RawAxiosRequestHeaders
-    ): Promise<EditorInterfaceProps>
-  }
+  editorInterface: EditorInterfacePlainClientAPI
   space: {
     get(params: OptionalDefaults<GetSpaceParams>): Promise<SpaceProps>
     getMany(params: OptionalDefaults<QueryParams>): Promise<CollectionProp<SpaceProps>>

--- a/lib/plain/entities/editor-interface.ts
+++ b/lib/plain/entities/editor-interface.ts
@@ -1,0 +1,79 @@
+import { RawAxiosRequestHeaders } from 'axios'
+import {
+  CollectionProp,
+  GetEditorInterfaceParams,
+  GetSpaceEnvironmentParams,
+  QueryParams,
+} from '../../common-types'
+import { EditorInterfaceProps } from '../../entities/editor-interface'
+import { OptionalDefaults } from '../wrappers/wrap'
+
+export type EditorInterfacePlainClientAPI = {
+  /**
+   * Fetch an Editor Interface
+   * @param params entity IDs to identify the Editor Interface
+   * @returns the Editor Interface config
+   * @throws if the request fails, or the Editor Interface is not found
+   * @example
+   * ```javascript
+   * const editorInterface = await contentfulClient.editorInterface.get({
+   *   spaceId: "<space_id>",
+   *   environmentId: "<environment_id>",
+   *   contentTypeId: "<content_type_id>",
+   * });
+   * ```
+   */
+  get(params: OptionalDefaults<GetEditorInterfaceParams>): Promise<EditorInterfaceProps>
+  /**
+   * Fetch all Editor Interfaces for the given Space and Environment
+   * @param params entity IDs to identify the Environment from which to fetch Editor Interfaces
+   * @returns an object containing an array of Editor Interfaces
+   * @throws if the request fails, or the Space/Environment is not found
+   * @example
+   * ```javascript
+   * const results = await contentfulClient.editorInterface.getMany({
+   *   spaceId: "<space_id>",
+   *   environmentId: "<environment_id>"
+   * });
+   * ```
+   */
+  getMany(
+    params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>
+  ): Promise<CollectionProp<EditorInterfaceProps>>
+  /**
+   * Update an Editor Interface
+   * @param params entity IDs to identify the Editor Interface
+   * @param rawData the updated Editor Iterface config
+   * @returns the updated Editor Interface config
+   * @throws if the request fails, the Editor Interface is not found, or the update payload is malformed
+   * @example
+   * ```javascript
+   * const updatedEditorInterface =
+   *   await contentfulClient.editorInterface.update(
+   *     {
+   *       spaceId: "<space_id>",
+   *       environmentId: "<environment_id>",
+   *       contentTypeId: "<content_type_id>",
+   *     },
+   *     {
+   *       ...existingEditorInterface,
+   *       sidebar: [
+   *         ...(existingEditorInterface.sidebar ?? []),
+   *         {
+   *           widgetId: "translation-widget",
+   *           widgetNamespace: "sidebar-builtin",
+   *           settings: {
+   *             defaultLocale: "en-US",
+   *           },
+   *         },
+   *       ],
+   *     }
+   *   );
+   * ```
+   */
+  update(
+    params: OptionalDefaults<GetEditorInterfaceParams>,
+    rawData: EditorInterfaceProps,
+    headers?: RawAxiosRequestHeaders
+  ): Promise<EditorInterfaceProps>
+}


### PR DESCRIPTION
## Summary

adds inline documentation for plain client APIs for working with Editor Interfaces

stacks on https://github.com/contentful/contentful-management.js/pull/1942

## Motivation and Context

we want the plain client to become the default way developers consume this SDK, so we need to provide examples for how to do that


## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation
