### PR TITLE
fix(types): content type validation [NONE]

### DIFF
--- a/lib/entities/content-type-fields.ts
+++ b/lib/entities/content-type-fields.ts
@@ -46,7 +46,7 @@ interface NodesValidation {
 }
 
 export interface ContentTypeFieldValidation {
-  linkContentType?: string[]
+  linkContentType?: string | string[]
   in?: (string | number)[]
   linkMimetypeGroup?: string[]
   enabledNodeTypes?: (`${BLOCKS}` | `${INLINES}`)[]


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary
We need to respect the legacy shape of content type validations where the field `linkContentType` can also just by a string. 

