### PR TITLE
docs: add inline code docs for the plain client App Definition interface [EXT-4721]

### DIFF
--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -38,11 +38,7 @@ import {
   EnvironmentTemplateParams,
 } from '../common-types'
 import { ApiKeyProps, CreateApiKeyProps } from '../entities/api-key'
-import {
-  AppDefinitionProps,
-  AppInstallationsForOrganizationProps,
-  CreateAppDefinitionProps,
-} from '../entities/app-definition'
+import { AppInstallationsForOrganizationProps } from '../entities/app-definition'
 import { AppInstallationProps, CreateAppInstallationProps } from '../entities/app-installation'
 import {
   AssetFileProp,
@@ -177,6 +173,7 @@ import { AppActionCallPlainClientAPI } from './entities/app-action-call'
 import { EditorInterfacePlainClientAPI } from './entities/editor-interface'
 import { UIConfigPlainClientAPI } from './entities/ui-config'
 import { UserUIConfigPlainClientAPI } from './entities/user-ui-config'
+import { AppDefinitionPlainClientAPI } from './entities/app-definition'
 
 export type PlainClientAPI = {
   raw: {
@@ -732,31 +729,7 @@ export type PlainClientAPI = {
     ): Promise<ApiKeyProps>
     delete(params: OptionalDefaults<GetSpaceParams & { apiKeyId: string }>): Promise<any>
   }
-  appDefinition: {
-    get(
-      params: OptionalDefaults<GetOrganizationParams & { appDefinitionId: string } & QueryParams>
-    ): Promise<AppDefinitionProps>
-    getMany(
-      params: OptionalDefaults<GetOrganizationParams & QueryParams>
-    ): Promise<CollectionProp<AppDefinitionProps>>
-    create(
-      params: OptionalDefaults<GetOrganizationParams>,
-      rawData: CreateAppDefinitionProps
-    ): Promise<AppDefinitionProps>
-    update(
-      params: OptionalDefaults<GetAppDefinitionParams>,
-      rawData: AppDefinitionProps,
-      headers?: RawAxiosRequestHeaders
-    ): Promise<AppDefinitionProps>
-    delete(params: OptionalDefaults<GetAppDefinitionParams>): Promise<any>
-    /**
-     * @deprecated
-     * Please use please use appInstallations.getForOrganization instead
-     */
-    getInstallationsForOrg(
-      params: OptionalDefaults<GetAppDefinitionParams>
-    ): Promise<AppInstallationsForOrganizationProps>
-  }
+  appDefinition: AppDefinitionPlainClientAPI
   appInstallation: {
     get(params: OptionalDefaults<GetAppInstallationParams>): Promise<AppInstallationProps>
     getMany(

--- a/lib/plain/entities/app-definition.ts
+++ b/lib/plain/entities/app-definition.ts
@@ -1,0 +1,121 @@
+import { RawAxiosRequestHeaders } from 'axios'
+import {
+  CollectionProp,
+  GetAppDefinitionParams,
+  GetOrganizationParams,
+  QueryParams,
+} from '../../common-types'
+import {
+  AppDefinitionProps,
+  AppInstallationsForOrganizationProps,
+  CreateAppDefinitionProps,
+} from '../../entities/app-definition'
+import { OptionalDefaults } from '../wrappers/wrap'
+
+export type AppDefinitionPlainClientAPI = {
+  /**
+   * Fetch an App Definition
+   * @param params entity IDs to identify the App Definition
+   * @returns the App Definition config
+   * @throws if the request fails, or the App Definition is not found
+   * @example
+   * ```javascript
+   * const appDefinition = await client.appDefinition.get({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * });
+   * ```
+   */
+  get(
+    params: OptionalDefaults<GetOrganizationParams & { appDefinitionId: string } & QueryParams>
+  ): Promise<AppDefinitionProps>
+  /**
+   * Fetch all App Definitions for the given Organization
+   * @param params entity IDs to identify the Organization from which to fetch App Definitions
+   * @returns an object containing an array of App Definitions
+   * @throws if the request fails, or the Organization is not found
+   * @example
+   * ```javascript
+   * const results = await client.appDefinition.getMany({
+   *   organizationId: '<organization_id>',
+   * });
+   * ```
+   */
+  getMany(
+    params: OptionalDefaults<GetOrganizationParams & QueryParams>
+  ): Promise<CollectionProp<AppDefinitionProps>>
+  /**
+   * Create an App Definition
+   * @param params entity IDs to identify the Organization where the App Definition will be created
+   * @param rawData the new App Definition
+   * @returns the new App Definition
+   * @throws if the request fails, the Organization is not found, or the update payload is malformed
+   * @example
+   * ```javascript
+   * const appDefinition = await client.appDefinition.create(
+   *   {
+   *     organizationId: '<organization_id>',
+   *   },
+   *   {
+   *     name: "Hello world!",
+   *     parameters: {},
+   *     src: "https://example.com/app.html",
+   *     locations: [
+   *       {
+   *         location: "entry-sidebar",
+   *       },
+   *     ],
+   *   }
+   * );
+   * ```
+   */
+  create(
+    params: OptionalDefaults<GetOrganizationParams>,
+    rawData: CreateAppDefinitionProps
+  ): Promise<AppDefinitionProps>
+  /**
+   * Update an App Definition
+   * @param params entity IDs to identify the App Definition
+   * @param rawData the updated App Definition config
+   * @returns the updated App Definition config
+   * @throws if the request fails, the App Definition is not found, or the update payload is malformed
+   * @example
+   * ```javascript
+   * const updatedAppDefinition = await client.appDefinition.update(
+   *   {
+   *     organizationId: '<organization_id>',
+   *     appDefinitionId: '<app_definition_id>',
+   *   },
+   *   {
+   *     ...currentAppDefinition,
+   *     name: "New App Definition name",
+   *   }
+   * );
+   * ```
+   */
+  update(
+    params: OptionalDefaults<GetAppDefinitionParams>,
+    rawData: AppDefinitionProps,
+    headers?: RawAxiosRequestHeaders
+  ): Promise<AppDefinitionProps>
+  /**
+   * Delete an App Definition
+   * @param params entity IDs to identify the App Definition
+   * @throws if the request fails, or the App Definition is not found
+   * @example
+   * ```javascript
+   * await client.appDefinition.delete({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * });
+   * ```
+   */
+  delete(params: OptionalDefaults<GetAppDefinitionParams>): Promise<any>
+  /**
+   * @deprecated
+   * Please use please use appInstallations.getForOrganization instead
+   */
+  getInstallationsForOrg(
+    params: OptionalDefaults<GetAppDefinitionParams>
+  ): Promise<AppInstallationsForOrganizationProps>
+}

--- a/lib/plain/entities/editor-interface.ts
+++ b/lib/plain/entities/editor-interface.ts
@@ -16,7 +16,7 @@ export type EditorInterfacePlainClientAPI = {
    * @throws if the request fails, or the Editor Interface is not found
    * @example
    * ```javascript
-   * const editorInterface = await contentfulClient.editorInterface.get({
+   * const editorInterface = await client.editorInterface.get({
    *   spaceId: "<space_id>",
    *   environmentId: "<environment_id>",
    *   contentTypeId: "<content_type_id>",
@@ -31,7 +31,7 @@ export type EditorInterfacePlainClientAPI = {
    * @throws if the request fails, or the Space/Environment is not found
    * @example
    * ```javascript
-   * const results = await contentfulClient.editorInterface.getMany({
+   * const results = await client.editorInterface.getMany({
    *   spaceId: "<space_id>",
    *   environmentId: "<environment_id>"
    * });
@@ -43,22 +43,22 @@ export type EditorInterfacePlainClientAPI = {
   /**
    * Update an Editor Interface
    * @param params entity IDs to identify the Editor Interface
-   * @param rawData the updated Editor Iterface config
+   * @param rawData the updated Editor Interface config
    * @returns the updated Editor Interface config
    * @throws if the request fails, the Editor Interface is not found, or the update payload is malformed
    * @example
    * ```javascript
    * const updatedEditorInterface =
-   *   await contentfulClient.editorInterface.update(
+   *   await client.editorInterface.update(
    *     {
    *       spaceId: "<space_id>",
    *       environmentId: "<environment_id>",
    *       contentTypeId: "<content_type_id>",
    *     },
    *     {
-   *       ...existingEditorInterface,
+   *       ...currentEditorInterface,
    *       sidebar: [
-   *         ...(existingEditorInterface.sidebar ?? []),
+   *         ...(currentEditorInterface.sidebar ?? []),
    *         {
    *           widgetId: "translation-widget",
    *           widgetNamespace: "sidebar-builtin",

--- a/lib/plain/entities/ui-config.ts
+++ b/lib/plain/entities/ui-config.ts
@@ -29,9 +29,9 @@ export type UIConfigPlainClientAPI = {
    *   spaceId: "<space_id>",
    *   environmentId: "<environment_id>",
    * }, {
-   *   ...existingUIConfig,
+   *   ...currentUIConfig,
    *   entryListViews: [
-   *     ...existingUIConfig.entryListViews,
+   *     ...currentUIConfig.entryListViews,
    *     {
    *       id: 'newFolder',
    *       title: 'New Folder',

--- a/lib/plain/entities/user-ui-config.ts
+++ b/lib/plain/entities/user-ui-config.ts
@@ -29,9 +29,9 @@ export type UserUIConfigPlainClientAPI = {
    *   spaceId: "<space_id>",
    *   environmentId: "<environment_id>",
    * }, {
-   *   ...existingUIConfig,
+   *   ...currentUIConfig,
    *   entryListViews: [
-   *     ...existingUIConfig.entryListViews,
+   *     ...currentUIConfig.entryListViews,
    *     {
    *       id: 'newFolder',
    *       title: 'New Folder',


### PR DESCRIPTION
## Summary

adds inline documentation for the App Definition plain client interface

## Motivation and Context

we want the `plain` client to be the default use of this SDK, so we're providing inline docs for how to use that

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation