### PR TITLE
docs: add inline docs for the plain client App Bundle interface [EXT-4723]

### DIFF
--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -25,7 +25,6 @@ import {
   KeyValueMap,
   PaginationQueryParams,
   QueryParams,
-  GetAppBundleParams,
   GetBulkActionParams,
   GetReleaseParams,
   GetTaskParams,
@@ -106,7 +105,6 @@ import {
 } from '../entities/webhook'
 import { DefaultParams, OptionalDefaults } from './wrappers/wrap'
 import { AssetKeyProps, CreateAssetKeyProps } from '../entities/asset-key'
-import { AppBundleProps, CreateAppBundleProps } from '../entities/app-bundle'
 import { AppDetailsProps, CreateAppDetailsProps } from '../entities/app-details'
 import { AppSignedRequestProps, CreateAppSignedRequestProps } from '../entities/app-signed-request'
 import { AppSigningSecretProps, CreateAppSigningSecretProps } from '../entities/app-signing-secret'
@@ -173,6 +171,7 @@ import { UIConfigPlainClientAPI } from './entities/ui-config'
 import { UserUIConfigPlainClientAPI } from './entities/user-ui-config'
 import { AppDefinitionPlainClientAPI } from './entities/app-definition'
 import { AppUploadPlainClientAPI } from './entities/app-upload'
+import { AppBundlePlainClientAPI } from './entities/app-bundle'
 
 export type PlainClientAPI = {
   raw: {
@@ -186,17 +185,7 @@ export type PlainClientAPI = {
   }
   appAction: AppActionPlainClientAPI
   appActionCall: AppActionCallPlainClientAPI
-  appBundle: {
-    get(params: OptionalDefaults<GetAppBundleParams>): Promise<AppBundleProps>
-    getMany(
-      params: OptionalDefaults<GetAppDefinitionParams & QueryParams>
-    ): Promise<CollectionProp<AppBundleProps>>
-    delete(params: OptionalDefaults<GetAppBundleParams>): Promise<void>
-    create(
-      params: OptionalDefaults<GetAppDefinitionParams>,
-      payload: CreateAppBundleProps
-    ): Promise<AppBundleProps>
-  }
+  appBundle: AppBundlePlainClientAPI
   appDetails: {
     upsert(
       params: OptionalDefaults<GetAppDefinitionParams>,

--- a/lib/plain/entities/app-bundle.ts
+++ b/lib/plain/entities/app-bundle.ts
@@ -1,0 +1,78 @@
+import {
+  CollectionProp,
+  GetAppBundleParams,
+  GetAppDefinitionParams,
+  QueryParams,
+} from '../../common-types'
+import { AppBundleProps, CreateAppBundleProps } from '../../entities/app-bundle'
+import { OptionalDefaults } from '../wrappers/wrap'
+
+export type AppBundlePlainClientAPI = {
+  /**
+   * Fetches the given App Bundle
+   * @param params entity IDs to identify the App Bundle
+   * @returns the App Bundle
+   * @throws if the request fails, or the App Bundle is not found
+   * @example
+   * ```javascript
+   * const appBundle = await client.appBundle.get({
+   *   appDefinitionId: '<app_definition_id>',
+   *   appBundleId: '<app_bundle_id>',
+   * });
+   * ```
+   */
+  get(params: OptionalDefaults<GetAppBundleParams>): Promise<AppBundleProps>
+  /**
+   * Fetches all App Bundles for the given App
+   * @param params entity IDs to identify the App
+   * @returns an object containing an array of App Bundles
+   * @throws if the request fails, or the App is not found
+   * @example
+   * ```javascript
+   * const results = await client.appBundle.getMany({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * });
+   * ```
+   */
+  getMany(
+    params: OptionalDefaults<GetAppDefinitionParams & QueryParams>
+  ): Promise<CollectionProp<AppBundleProps>>
+  /**
+   * Deletes the given App Bundle
+   * @param params entity IDs to identify the App Bundle
+   * @throws if the request fails, or the App Bundle is not found
+   * @example
+   * ```javascript
+   * await client.appBundle.delete({
+   *   appDefinitionId: '<app_definition_id>',
+   *   appBundleId: '<app_bundle_id>',
+   * });
+   * ```
+   */
+  delete(params: OptionalDefaults<GetAppBundleParams>): Promise<void>
+  /**
+   * Creates an App Bundle
+   * @param params entity IDs to scope where to create the App Bundle
+   * @param payload the App Bundle details
+   * @returns the created App Bundle and its metadata
+   * @throws if the request fails, the associated App is not found, or the payload is malformed
+   * @example
+   * ```javascript
+   * const appBundle = await client.appBundle.create(
+   *   {
+   *     appDefinitionId: '<app_definition_id>',
+   *     appBundleId: '<app_bundle_id>',
+   *   },
+   *   {
+   *     appUploadId: '<app_upload_id>',
+   *     comment: 'a bundle comment',
+   *   }
+   * );
+   * ```
+   */
+  create(
+    params: OptionalDefaults<GetAppDefinitionParams>,
+    payload: CreateAppBundleProps
+  ): Promise<AppBundleProps>
+}


### PR DESCRIPTION
## Summary

adds inline documentation for the App Bundle plain client interface

## Motivation and Context

we want the `plain` client to be the default use of this SDK, so we're providing inline docs for how to use that

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation