### PR TITLE
docs: add inline docs for the plain client App Details interface [EXT-4724]

### DIFF
--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -105,7 +105,6 @@ import {
 } from '../entities/webhook'
 import { DefaultParams, OptionalDefaults } from './wrappers/wrap'
 import { AssetKeyProps, CreateAssetKeyProps } from '../entities/asset-key'
-import { AppDetailsProps, CreateAppDetailsProps } from '../entities/app-details'
 import { AppSignedRequestProps, CreateAppSignedRequestProps } from '../entities/app-signed-request'
 import { AppSigningSecretProps, CreateAppSigningSecretProps } from '../entities/app-signing-secret'
 import { DeliveryFunctionProps } from '../entities/delivery-function'
@@ -172,6 +171,7 @@ import { UserUIConfigPlainClientAPI } from './entities/user-ui-config'
 import { AppDefinitionPlainClientAPI } from './entities/app-definition'
 import { AppUploadPlainClientAPI } from './entities/app-upload'
 import { AppBundlePlainClientAPI } from './entities/app-bundle'
+import { AppDetailsPlainClientAPI } from './entities/app-details'
 
 export type PlainClientAPI = {
   raw: {
@@ -186,14 +186,7 @@ export type PlainClientAPI = {
   appAction: AppActionPlainClientAPI
   appActionCall: AppActionCallPlainClientAPI
   appBundle: AppBundlePlainClientAPI
-  appDetails: {
-    upsert(
-      params: OptionalDefaults<GetAppDefinitionParams>,
-      payload: CreateAppDetailsProps
-    ): Promise<AppDetailsProps>
-    get(params: OptionalDefaults<GetAppDefinitionParams>): Promise<AppDetailsProps>
-    delete(params: OptionalDefaults<GetAppDefinitionParams>): Promise<void>
-  }
+  appDetails: AppDetailsPlainClientAPI
   appSignedRequest: {
     create(
       params: OptionalDefaults<GetAppInstallationParams>,

--- a/lib/plain/entities/app-details.ts
+++ b/lib/plain/entities/app-details.ts
@@ -1,0 +1,60 @@
+import { GetAppDefinitionParams } from '../../common-types'
+import { AppDetailsProps, CreateAppDetailsProps } from '../../entities/app-details'
+import { OptionalDefaults } from '../wrappers/wrap'
+
+export type AppDetailsPlainClientAPI = {
+  /**
+   * Upserts an App Detail
+   * @param params entity IDs to identify the App Definition or App Details
+   * @param payload the App Detail upsert
+   * @returns the updated App Detail and its metadata
+   * @throws if the request fails, an entity is not found, or the payload is malformed
+   * @example
+   * ```javascript
+   * const appDetails = await client.appDetails.upsert(
+   *   {
+   *     spaceId: '<space_id>',
+   *     environmentId: '<environment_id>',
+   *     appDefinitionId: '<app_definition_id>',
+   *   },
+   *   {
+   *     icon: {
+   *       type: 'base64',
+   *       value: 'base-64-value'
+   *     }
+   *   }
+   * );
+   * ```
+   */
+  upsert(
+    params: OptionalDefaults<GetAppDefinitionParams>,
+    payload: CreateAppDetailsProps
+  ): Promise<AppDetailsProps>
+  /**
+   * Fetches the requested App Detail
+   * @param params entity IDs to identify the App Detail
+   * @returns the App Detail
+   * @throws if the request fails, or the App Detail is not found
+   * @example
+   * ```javascript
+   * const appDetails = await client.appDetails.get({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * });
+   * ```
+   */
+  get(params: OptionalDefaults<GetAppDefinitionParams>): Promise<AppDetailsProps>
+  /**
+   * Fetches the given App Detail
+   * @param params entity IDs to identify the App Detail
+   * @throws if the request fails, or the App Detail is not found
+   * @example
+   * ```javascript
+   * await client.appDetails.delete({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * });
+   * ```
+   */
+  delete(params: OptionalDefaults<GetAppDefinitionParams>): Promise<void>
+}


### PR DESCRIPTION
## Summary

adds inline documentation for the App Details plain client interface

## Motivation and Context

we want the `plain` client to be the default use of this SDK, so we're providing inline docs for how to use that

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation