### PR TITLE
fix(types): environment template adapter [MONET-1248]

### DIFF
--- a/lib/adapters/REST/endpoints/environment-template.ts
+++ b/lib/adapters/REST/endpoints/environment-template.ts
@@ -12,7 +12,9 @@ export const get: RestEndpoint<'EnvironmentTemplate', 'get'> = (
   { organizationId, environmentTemplateId, version, query = {} }
 ) =>
   version
-    ? raw.get(http, apiPath(organizationId, environmentTemplateId, 'versions', version), { params: query })
+    ? raw.get(http, apiPath(organizationId, environmentTemplateId, 'versions', version), {
+        params: query,
+      })
     : raw.get(http, apiPath(organizationId, environmentTemplateId), { params: query })
 
 export const getMany: RestEndpoint<'EnvironmentTemplate', 'getMany'> = (

--- a/lib/adapters/REST/endpoints/environment-template.ts
+++ b/lib/adapters/REST/endpoints/environment-template.ts
@@ -9,11 +9,11 @@ const apiPath = (organizationId: string, ...pathSegments: (number | string)[]) =
 
 export const get: RestEndpoint<'EnvironmentTemplate', 'get'> = (
   http,
-  { organizationId, environmentTemplateId, version }
+  { organizationId, environmentTemplateId, version, query = {} }
 ) =>
   version
-    ? raw.get(http, apiPath(organizationId, environmentTemplateId, 'versions', version))
-    : raw.get(http, apiPath(organizationId, environmentTemplateId))
+    ? raw.get(http, apiPath(organizationId, environmentTemplateId, 'versions', version), { params: query })
+    : raw.get(http, apiPath(organizationId, environmentTemplateId), { params: query })
 
 export const getMany: RestEndpoint<'EnvironmentTemplate', 'getMany'> = (
   http,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1095,7 +1095,7 @@ export type MRActions = {
     get: {
       params: GetEnvironmentTemplateParams & {
         version?: number
-        query?: BasicCursorPaginationOptions & { select?: string }
+        query?: { select?: string }
       }
       return: EnvironmentTemplateProps
     }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1095,11 +1095,14 @@ export type MRActions = {
     get: {
       params: GetEnvironmentTemplateParams & {
         version?: number
+        query?: BasicCursorPaginationOptions & { select?: string }
       }
       return: EnvironmentTemplateProps
     }
     getMany: {
-      params: BasicCursorPaginationOptions & GetOrganizationParams
+      params: GetOrganizationParams & {
+        query?: BasicCursorPaginationOptions & { select?: string }
+      }
       return: CursorPaginatedCollectionProp<EnvironmentTemplateProps>
     }
     create: {
@@ -1127,7 +1130,9 @@ export type MRActions = {
       return: void
     }
     versions: {
-      params: GetEnvironmentTemplateParams & BasicCursorPaginationOptions
+      params: GetEnvironmentTemplateParams & {
+        query?: BasicCursorPaginationOptions & { select?: string }
+      }
       return: CursorPaginatedCollectionProp<EnvironmentTemplateProps>
     }
     validate: {

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -6,9 +6,9 @@ import {
   QueryOptions,
   QueryParams,
   GetAppDefinitionParams,
-  PaginationQueryOptions,
   CursorPaginatedCollection,
   GetEnvironmentTemplateParams,
+  BasicCursorPaginationOptions,
 } from './common-types'
 import entities from './entities'
 import { Organization, OrganizationProp } from './entities/organization'
@@ -61,7 +61,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      */
     getEnvironmentTemplates: function getEnvironmentTemplates(
       organizationId: string,
-      query: PaginationQueryOptions = {}
+      query: BasicCursorPaginationOptions & { select?: string } = {}
     ): Promise<CursorPaginatedCollection<EnvironmentTemplate, EnvironmentTemplateProps>> {
       return makeRequest({
         entityType: 'EnvironmentTemplate',
@@ -95,13 +95,20 @@ export default function createClientApi(makeRequest: MakeRequest) {
       organizationId,
       environmentTemplateId,
       version,
+      query = {},
     }: GetEnvironmentTemplateParams & {
       version?: number
+      query?: { select?: string }
     }): Promise<EnvironmentTemplate> {
       return makeRequest({
         entityType: 'EnvironmentTemplate',
         action: 'get',
-        params: { organizationId, environmentTemplateId, version },
+        params: {
+          organizationId,
+          environmentTemplateId,
+          version,
+          query: createRequestConfig({ query }).params,
+        },
       }).then((data) => wrapEnvironmentTemplate(makeRequest, data, organizationId))
     },
     /**

--- a/lib/entities/content-type-fields.ts
+++ b/lib/entities/content-type-fields.ts
@@ -46,7 +46,7 @@ interface NodesValidation {
 }
 
 export interface ContentTypeFieldValidation {
-  linkContentType?: string[]
+  linkContentType?: string | string[]
   in?: (string | number)[]
   linkMimetypeGroup?: string[]
   enabledNodeTypes?: (`${BLOCKS}` | `${INLINES}`)[]

--- a/test/integration/environment-template-integration.ts
+++ b/test/integration/environment-template-integration.ts
@@ -51,6 +51,23 @@ describe('Environment template Api', () => {
       expect(sys).not.to.be.undefined
     })
 
+    test('gets an environment template with select filter applied', async () => {
+      const draftTemplate = createDraftTemplate()
+      const {
+        sys: { id: templateId },
+      } = await client.createEnvironmentTemplate(orgId, draftTemplate)
+
+      const response = await client.getEnvironmentTemplate({
+        organizationId: orgId,
+        environmentTemplateId: templateId,
+        query: {
+          select: 'name',
+        },
+      })
+
+      expect(response).to.be.eql({ name: draftTemplate.name })
+    })
+
     test('gets a collection of environment templates', async () => {
       const draftTemplate = createDraftTemplate()
       await client.createEnvironmentTemplate(orgId, draftTemplate)
@@ -63,6 +80,21 @@ describe('Environment template Api', () => {
       const [{ sys, ...template }] = templates
       expect(template).to.be.eql(draftTemplate)
       expect(sys).not.to.be.undefined
+    })
+
+    test('gets a collection of environment templates with select filter applied', async () => {
+      const draftTemplate = createDraftTemplate()
+      await client.createEnvironmentTemplate(orgId, draftTemplate)
+      const { items: templates } = await client.getEnvironmentTemplates(orgId, {
+        select: 'description',
+      })
+
+      expect(
+        templates.filter(({ description }) => description === templateDescription)
+      ).to.have.length(1)
+
+      const [firstTemplate] = templates
+      expect(firstTemplate).to.be.eql({ description: templateDescription })
     })
 
     test('updates an environment template', async () => {

--- a/test/unit/create-contentful-api-test.js
+++ b/test/unit/create-contentful-api-test.js
@@ -311,7 +311,7 @@ describe('A createContentfulApi', () => {
         makeRequest.calledOnceWith({
           entityType: 'EnvironmentTemplate',
           action: 'get',
-          params: { organizationId, environmentTemplateId, version },
+          params: { organizationId, environmentTemplateId, version, query: {} },
         })
       ).to.be.ok
     })


### PR DESCRIPTION
## Summary
- Extends environment template `get` to accept query parameters.
- Fixes environment template `getMany` and `versions` to correctly pass cursor based pagination options as part of query params (along with including `select` in the query params).