### PR TITLE
docs: add inline docs for the plain client Webhook interface [EXT-4720]

### DIFF
--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -20,8 +20,6 @@ import {
   GetTeamParams,
   GetTeamSpaceMembershipParams,
   GetExtensionParams,
-  GetWebhookCallDetailsUrl,
-  GetWebhookParams,
   KeyValueMap,
   PaginationQueryParams,
   QueryParams,
@@ -94,13 +92,6 @@ import {
 import { CreateExtensionProps, ExtensionProps } from '../entities/extension'
 import { UsageProps } from '../entities/usage'
 import { UserProps } from '../entities/user'
-import {
-  CreateWebhooksProps,
-  WebhookCallDetailsProps,
-  WebhookCallOverviewProps,
-  WebhookHealthProps,
-  WebhookProps,
-} from '../entities/webhook'
 import { DefaultParams, OptionalDefaults } from './wrappers/wrap'
 import { AssetKeyProps, CreateAssetKeyProps } from '../entities/asset-key'
 import { AppSignedRequestProps, CreateAppSignedRequestProps } from '../entities/app-signed-request'
@@ -171,6 +162,7 @@ import { AppUploadPlainClientAPI } from './entities/app-upload'
 import { AppBundlePlainClientAPI } from './entities/app-bundle'
 import { AppDetailsPlainClientAPI } from './entities/app-details'
 import { AppInstallationPlainClientAPI } from './entities/app-installation'
+import { WebhookPlainClientAPI } from './entities/webhook'
 
 export type PlainClientAPI = {
   raw: {
@@ -733,29 +725,7 @@ export type PlainClientAPI = {
     ): Promise<ExtensionProps>
     delete(params: OptionalDefaults<GetExtensionParams>): Promise<any>
   }
-  webhook: {
-    get(params: OptionalDefaults<GetWebhookParams>): Promise<WebhookProps>
-    getMany(
-      params: OptionalDefaults<GetSpaceParams & QueryParams>
-    ): Promise<CollectionProp<WebhookProps>>
-    getHealthStatus(params: OptionalDefaults<GetWebhookParams>): Promise<WebhookHealthProps>
-    getCallDetails(
-      params: OptionalDefaults<GetWebhookCallDetailsUrl>
-    ): Promise<WebhookCallDetailsProps>
-    getManyCallDetails(
-      params: OptionalDefaults<GetWebhookParams & QueryParams>
-    ): Promise<CollectionProp<WebhookCallOverviewProps>>
-    create(
-      params: OptionalDefaults<GetSpaceParams>,
-      rawData: CreateWebhooksProps,
-      headers?: RawAxiosRequestHeaders
-    ): Promise<WebhookProps>
-    update(
-      params: OptionalDefaults<GetWebhookParams>,
-      rawData: CreateWebhooksProps
-    ): Promise<WebhookProps>
-    delete(params: OptionalDefaults<GetWebhookParams>): Promise<any>
-  }
+  webhook: WebhookPlainClientAPI
   snapshot: {
     getManyForEntry<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSnapshotForEntryParams & QueryParams>

--- a/lib/plain/entities/webhook.ts
+++ b/lib/plain/entities/webhook.ts
@@ -1,0 +1,157 @@
+import { RawAxiosRequestHeaders } from 'axios'
+import {
+  CollectionProp,
+  GetSpaceParams,
+  GetWebhookCallDetailsUrl,
+  GetWebhookParams,
+  QueryParams,
+} from '../../common-types'
+import {
+  CreateWebhooksProps,
+  WebhookCallDetailsProps,
+  WebhookCallOverviewProps,
+  WebhookHealthProps,
+  WebhookProps,
+} from '../../entities/webhook'
+import { OptionalDefaults } from '../wrappers/wrap'
+
+export type WebhookPlainClientAPI = {
+  /**
+   * Fetches the Webhook
+   * @param params entity IDs to identify the Webhook
+   * @returns the Webhook
+   * @throws if the request fails, or the Webhook is not found
+   * @example
+   * ```javascript
+   * const webhook = await client.webhook.get({
+   *   spaceId: '<space_id>',
+   *   webhookDefinitionId: '<webhook_id>',
+   * });
+   * ```
+   */
+  get(params: OptionalDefaults<GetWebhookParams>): Promise<WebhookProps>
+  /**
+   * Fetches all Webhooks for the given Space
+   * @param params entity IDs to identify the Space
+   * @returns an object containing an array of Webhooks
+   * @throws if the request fails, or the Space is not found
+   * @example
+   * ```javascript
+   * const results = await client.webhook.getMany({
+   *   spaceId: '<space_id>',
+   * });
+   * ```
+   */
+  getMany(
+    params: OptionalDefaults<GetSpaceParams & QueryParams>
+  ): Promise<CollectionProp<WebhookProps>>
+  /**
+   * Fetches an overview of recently successful webhook calls
+   * @param params entity IDs to identify the Webhook
+   * @returns an object containing the Webhook and the health overview of recent calls
+   * @throws if the request fails, or the Webhook is not found
+   * @example
+   * ```javascript
+   * const webhookHealth = await client.webhook.getHealthStatus({
+   *   spaceId: '<space_id>',
+   *   webhookDefinitionId: '<webhook_id>',
+   * });
+   * ```
+   */
+  getHealthStatus(params: OptionalDefaults<GetWebhookParams>): Promise<WebhookHealthProps>
+  /**
+   * Fetches the details a specific Webhook call
+   * @param params entity IDs to identify the Webhook call
+   * @returns details about the outgoing Webhook request and response
+   * @throws if the request fails, or the Webhook call is not found
+   * @example
+   * ```javascript
+   * const webhookCall = await client.webhook.getCallDetails({
+   *   spaceId: '<space_id>',
+   *   webhookDefinitionId: '<webhook_id>',
+   *   callId: '<call_id>',
+   * });
+   * ```
+   */
+  getCallDetails(
+    params: OptionalDefaults<GetWebhookCallDetailsUrl>
+  ): Promise<WebhookCallDetailsProps>
+  /**
+   * Fetches the details the most recent calls for a given Webhook
+   * @param params entity IDs to identify the Webhook
+   * @returns a list of the most recent webhook calls made, their status, possible errors, and the target URL
+   * @throws if the request fails, or the Webhook is not found
+   * @example
+   * ```javascript
+   * const results = await client.webhook.getManyCallDetails({
+   *   spaceId: '<space_id>',
+   *   webhookDefinitionId: '<webhook_id>',
+   * });
+   * ```
+   */
+  getManyCallDetails(
+    params: OptionalDefaults<GetWebhookParams & QueryParams>
+  ): Promise<CollectionProp<WebhookCallOverviewProps>>
+  /**
+   * Creates a Webhook
+   * @param params entity IDs to identify the Space to create the Webhook in
+   * @param rawData the Webhook
+   * @returns the created Webhook and its metadata
+   * @throws if the request fails, the Space is not found, or the payload is malformed
+   * @example
+   * ```javascript
+   * const webhook = await client.webhook.create(
+   *   {
+   *     spaceId: '<space_id>',
+   *   },
+   *   {
+   *     name: 'My webhook',
+   *     url: 'https://www.example.com/test',
+   *     topics: ['Entry.create', 'ContentType.create', '*.publish', 'Asset.*'],
+   *   }
+   * );
+   * ```
+   */
+  create(
+    params: OptionalDefaults<GetSpaceParams>,
+    rawData: CreateWebhooksProps,
+    headers?: RawAxiosRequestHeaders
+  ): Promise<WebhookProps>
+  /**
+   * Creates the Webhook
+   * @param params entity IDs to identify the Webhook to update
+   * @param rawData the new Webhook configuration
+   * @returns the updated Webhook and its metadata
+   * @throws if the request fails, the Webhook is not found, or the payload is malformed
+   * @example
+   * ```javascript
+   * const webhook = await client.webhook.update(
+   *   {
+   *     spaceId: '<space_id>',
+   *     webhookDefinitionId: '<webhook_definition_id>',
+   *   },
+   *   {
+   *     ...currentWebhook,
+   *     name: 'New webhook name',
+   *   }
+   * );
+   * ```
+   */
+  update(
+    params: OptionalDefaults<GetWebhookParams>,
+    rawData: CreateWebhooksProps
+  ): Promise<WebhookProps>
+  /**
+   * Deletes the Webhook
+   * @param params entity IDs to identify the Webhook to delete
+   * @throws if the request fails, or the Webhook is not found
+   * @example
+   * ```javascript
+   * await client.webhook.delete({
+   *   spaceId: '<space_id>',
+   *   webhookDefinitionId: '<webhook_id>',
+   * });
+   * ```
+   */
+  delete(params: OptionalDefaults<GetWebhookParams>): Promise<any>
+}


### PR DESCRIPTION
## Summary

adds inline documentation for the Webhook plain client interface

## Motivation and Context

we want the `plain` client to be the default use of this SDK, so we're providing inline docs for how to use that

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation