### PR TITLE
docs: add inline docs for the plain client App Signed Request and Signing Secret interface [EXT-4726]

### DIFF
--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -660,7 +660,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
     },
 
     /**
-     * Deletes an Entry of this environement
+     * Deletes an Entry of this environment
      * @param id - Entry ID
      * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
      * @example ```javascript

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -109,7 +109,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * })
      *
      * client.getSpace('<space_id>')
-     * .then((space) => space.getEnvironment('<environement_id>'))
+     * .then((space) => space.getEnvironment('<environment_id>'))
      * .then((environment) => console.log(environment))
      * .catch(console.error)
      * ```
@@ -150,7 +150,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
     },
 
     /**
-     * Creates an Environement
+     * Creates an environment
      * @param data - Object representation of the Environment to be created
      * @return Promise for the newly created Environment
      * @example ```javascript

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -4,7 +4,6 @@ import { Stream } from 'stream'
 import {
   CollectionProp,
   GetAppDefinitionParams,
-  GetAppInstallationParams,
   GetCommentParams,
   GetContentTypeParams,
   GetOrganizationMembershipParams,
@@ -94,8 +93,6 @@ import { UsageProps } from '../entities/usage'
 import { UserProps } from '../entities/user'
 import { DefaultParams, OptionalDefaults } from './wrappers/wrap'
 import { AssetKeyProps, CreateAssetKeyProps } from '../entities/asset-key'
-import { AppSignedRequestProps, CreateAppSignedRequestProps } from '../entities/app-signed-request'
-import { AppSigningSecretProps, CreateAppSigningSecretProps } from '../entities/app-signing-secret'
 import { DeliveryFunctionProps } from '../entities/delivery-function'
 import {
   BulkActionPayload,
@@ -163,6 +160,8 @@ import { AppBundlePlainClientAPI } from './entities/app-bundle'
 import { AppDetailsPlainClientAPI } from './entities/app-details'
 import { AppInstallationPlainClientAPI } from './entities/app-installation'
 import { WebhookPlainClientAPI } from './entities/webhook'
+import { AppSignedRequestPlainClientAPI } from './entities/app-signed-request'
+import { AppSigningSecretPlainClientAPI } from './entities/app-signing-secret'
 
 export type PlainClientAPI = {
   raw: {
@@ -178,20 +177,8 @@ export type PlainClientAPI = {
   appActionCall: AppActionCallPlainClientAPI
   appBundle: AppBundlePlainClientAPI
   appDetails: AppDetailsPlainClientAPI
-  appSignedRequest: {
-    create(
-      params: OptionalDefaults<GetAppInstallationParams>,
-      payload: CreateAppSignedRequestProps
-    ): Promise<AppSignedRequestProps>
-  }
-  appSigningSecret: {
-    upsert(
-      params: OptionalDefaults<GetAppDefinitionParams>,
-      payload: CreateAppSigningSecretProps
-    ): Promise<AppSigningSecretProps>
-    get(params: OptionalDefaults<GetAppDefinitionParams>): Promise<AppSigningSecretProps>
-    delete(params: OptionalDefaults<GetAppDefinitionParams>): Promise<void>
-  }
+  appSignedRequest: AppSignedRequestPlainClientAPI
+  appSigningSecret: AppSigningSecretPlainClientAPI
   deliveryFunction: {
     getMany(
       params: OptionalDefaults<GetAppDefinitionParams & QueryParams>

--- a/lib/plain/entities/app-action-call.ts
+++ b/lib/plain/entities/app-action-call.ts
@@ -18,7 +18,7 @@ export type AppActionCallPlainClientAPI = {
    * await client.appActionCall.create(
    *   {
    *     spaceId: "<space_id>",
-   *     environmentId: "<environement_id>",
+   *     environmentId: "<environment_id>",
    *     appDefinitionId: "<app_definition_id>",
    *     appActionId: "<app_action_id>",
    *   },
@@ -41,7 +41,7 @@ export type AppActionCallPlainClientAPI = {
    * ```javascript
    * const appActionCall = await client.appActionCall.getCallDetails({
    *   spaceId: "<space_id>",
-   *   environmentId: "<environement_id>",
+   *   environmentId: "<environment_id>",
    *   appDefinitionId: "<app_definition_id>",
    *   appActionId: "<app_action_id>",
    * });
@@ -61,7 +61,7 @@ export type AppActionCallPlainClientAPI = {
    * const appActionCall = await client.appActionCall.createWithResponse(
    *   {
    *     spaceId: "<space_id>",
-   *     environmentId: "<environement_id>",
+   *     environmentId: "<environment_id>",
    *     appDefinitionId: "<app_definition_id>",
    *     appActionId: "<app_action_id>",
    *   },

--- a/lib/plain/entities/app-signed-request.ts
+++ b/lib/plain/entities/app-signed-request.ts
@@ -1,0 +1,41 @@
+import { GetAppInstallationParams } from '../../common-types'
+import {
+  AppSignedRequestProps,
+  CreateAppSignedRequestProps,
+} from '../../entities/app-signed-request'
+import { OptionalDefaults } from '../wrappers/wrap'
+
+export type AppSignedRequestPlainClientAPI = {
+  /**
+   * Creates a Signed Request for an App
+   * @param params entity IDs to identify the App to make a signed request to
+   * @param payload the Signed Request payload
+   * @returns metadata about the Signed Request
+   * @throws if the request fails, the App is not found, or the payload is malformed
+   * @example
+   * ```javascript
+   * const signedRequest = await client.appSignedRequest.create(
+   *   {
+   *     spaceId: '<space_id>',
+   *     organizationId: '<organization_id>',
+   *     appDefinitionId: '<app_definition_id>',
+   *   },
+   *   {
+   *     method: 'POST',
+   *     path: 'https://your-app-backend.com/event-handler',
+   *     headers: {
+   *       'Content-Type': 'application/json',
+   *       'X-some-header': 'some-value',
+   *     },
+   *     body: JSON.stringify({
+   *       // ...
+   *     }),
+   *   }
+   * );
+   * ```
+   */
+  create(
+    params: OptionalDefaults<GetAppInstallationParams>,
+    payload: CreateAppSignedRequestProps
+  ): Promise<AppSignedRequestProps>
+}

--- a/lib/plain/entities/app-signing-secret.ts
+++ b/lib/plain/entities/app-signing-secret.ts
@@ -1,0 +1,56 @@
+import { GetAppDefinitionParams } from '../../common-types'
+import {
+  AppSigningSecretProps,
+  CreateAppSigningSecretProps,
+} from '../../entities/app-signing-secret'
+import { OptionalDefaults } from '../wrappers/wrap'
+
+export type AppSigningSecretPlainClientAPI = {
+  /**
+   * Creates or updates an App Signing Secret
+   * @param params entity IDs to identify the App that the Signing Secret belongs to
+   * @param payload the new or updated Signing Secret
+   * @returns the App Signing Secret and its metadata
+   * @throws if the request fails, the App or Signing Secret is not found, or the payload is malformed
+   * @example
+   * ```javascript
+   * const signingSecret = await client.appSigningSecret.upsert({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * }, {
+   *   value: '<value>'
+   * })
+   * ```
+   */
+  upsert(
+    params: OptionalDefaults<GetAppDefinitionParams>,
+    payload: CreateAppSigningSecretProps
+  ): Promise<AppSigningSecretProps>
+  /**
+   * Fetches the current App Signing Secret for the given App
+   * @param params entity IDs to identify the App that the Signing Secret belongs to
+   * @returns the App Signing Secret
+   * @throws if the request fails, or the App or the Signing Secret is not found
+   * @example
+   * ```javascript
+   * const signingSecret = await client.appSigningSecret.get({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * })
+   * ```
+   */
+  get(params: OptionalDefaults<GetAppDefinitionParams>): Promise<AppSigningSecretProps>
+  /**
+   * Removes the current App Signing Secret for the given App
+   * @param params entity IDs to identify the App that the Signing Secret belongs to
+   * @throws if the request fails, or the App or the Signing Secret is not found
+   * @example
+   * ```javascript
+   * await client.appSigningSecret.delete({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * })
+   * ```
+   */
+  delete(params: OptionalDefaults<GetAppDefinitionParams>): Promise<void>
+}


### PR DESCRIPTION
## Summary

adds inline documentation for the App Signing Secret and Signed Request plain client interfaces

## Motivation and Context

we want the `plain` client to be the default use of this SDK, so we're providing inline docs for how to use that

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation