### PR TITLE
feat: use a single axios instance [PHX-2863]

### DIFF
--- a/lib/adapters/REST/rest-adapter.ts
+++ b/lib/adapters/REST/rest-adapter.ts
@@ -21,6 +21,8 @@ export type RestAdapterParams = CreateHttpClientParams & {
    * @default upload.contentful.com
    */
   hostUpload?: string
+
+  userAgent?: string | undefined
 }
 
 /**
@@ -35,7 +37,7 @@ export class RestAdapter implements Adapter {
   private readonly params: RestAdapterParams
   private readonly axiosInstance: AxiosInstance
 
-  public constructor(params: RestAdapterParams, userAgent?: string | undefined) {
+  public constructor(params: RestAdapterParams) {
     if (!params.accessToken) {
       throw new TypeError('Expected parameter accessToken')
     }
@@ -49,7 +51,8 @@ export class RestAdapter implements Adapter {
       ...this.params,
       headers: {
         'Content-Type': 'application/vnd.contentful.management.v1+json',
-        ...(userAgent ? { 'X-Contentful-User-Agent': userAgent } : {}),
+        // possibly define a default user agent?
+        ...(params.userAgent ? { 'X-Contentful-User-Agent': params.userAgent } : {}),
         ...this.params.headers,
       },
     })
@@ -82,7 +85,8 @@ export class RestAdapter implements Adapter {
 
     return await endpoint(this.axiosInstance, params, payload, {
       ...headers,
-      'X-Contentful-User-Agent': userAgent,
+      // overwrite the userAgent with the one passed in the request
+      ...(userAgent ? { 'X-Contentful-User-Agent': userAgent } : {}),
     })
   }
 }

--- a/lib/adapters/REST/rest-adapter.ts
+++ b/lib/adapters/REST/rest-adapter.ts
@@ -33,6 +33,7 @@ const defaultHostParameters = {
 
 export class RestAdapter implements Adapter {
   private readonly params: RestAdapterParams
+  private readonly axiosInstance: AxiosInstance
 
   public constructor(params: RestAdapterParams) {
     if (!params.accessToken) {
@@ -43,6 +44,14 @@ export class RestAdapter implements Adapter {
       ...defaultHostParameters,
       ...copy(params),
     }
+
+    this.axiosInstance = createHttpClient(axios, {
+      ...this.params,
+      headers: {
+        'Content-Type': 'application/vnd.contentful.management.v1+json',
+        ...this.params.headers,
+      },
+    })
   }
 
   public async makeRequest<R>({
@@ -70,20 +79,9 @@ export class RestAdapter implements Adapter {
       throw new Error('Unknown endpoint')
     }
 
-    const requiredHeaders = {
-      'Content-Type': 'application/vnd.contentful.management.v1+json',
+    return await endpoint(this.axiosInstance, params, payload, {
+      ...headers,
       'X-Contentful-User-Agent': userAgent,
-    }
-
-    // TODO: maybe we can avoid creating a new axios instance for each request
-    const axiosInstance = createHttpClient(axios, {
-      ...this.params,
-      headers: {
-        ...requiredHeaders,
-        ...this.params.headers,
-      },
     })
-
-    return await endpoint(axiosInstance, params, payload, headers)
   }
 }

--- a/lib/adapters/REST/rest-adapter.ts
+++ b/lib/adapters/REST/rest-adapter.ts
@@ -35,7 +35,7 @@ export class RestAdapter implements Adapter {
   private readonly params: RestAdapterParams
   private readonly axiosInstance: AxiosInstance
 
-  public constructor(params: RestAdapterParams) {
+  public constructor(params: RestAdapterParams, userAgent?: string | undefined) {
     if (!params.accessToken) {
       throw new TypeError('Expected parameter accessToken')
     }
@@ -49,6 +49,7 @@ export class RestAdapter implements Adapter {
       ...this.params,
       headers: {
         'Content-Type': 'application/vnd.contentful.management.v1+json',
+        ...(userAgent ? { 'X-Contentful-User-Agent': userAgent } : {}),
         ...this.params.headers,
       },
     })

--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -90,7 +90,7 @@ function createClient(
     params.feature
   )
 
-  const adapter = createAdapter(params, userAgent)
+  const adapter = createAdapter({ ...params, userAgent })
 
   // Parameters<?> and ReturnType<?> only return the types of the last overload
   // https://github.com/microsoft/TypeScript/issues/26591

--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -90,7 +90,7 @@ function createClient(
     params.feature
   )
 
-  const adapter = createAdapter(params)
+  const adapter = createAdapter(params, userAgent)
 
   // Parameters<?> and ReturnType<?> only return the types of the last overload
   // https://github.com/microsoft/TypeScript/issues/26591

--- a/lib/create-adapter.ts
+++ b/lib/create-adapter.ts
@@ -13,10 +13,13 @@ export type AdapterParams = {
 /**
  * @private
  */
-export function createAdapter(params: RestAdapterParams | AdapterParams): Adapter {
+export function createAdapter(
+  params: RestAdapterParams | AdapterParams,
+  userAgent?: string
+): Adapter {
   if ('apiAdapter' in params) {
     return params.apiAdapter
   } else {
-    return new RestAdapter(params)
+    return new RestAdapter(params, userAgent)
   }
 }

--- a/lib/create-adapter.ts
+++ b/lib/create-adapter.ts
@@ -13,13 +13,10 @@ export type AdapterParams = {
 /**
  * @private
  */
-export function createAdapter(
-  params: RestAdapterParams | AdapterParams,
-  userAgent?: string
-): Adapter {
+export function createAdapter(params: RestAdapterParams | AdapterParams): Adapter {
   if ('apiAdapter' in params) {
     return params.apiAdapter
   } else {
-    return new RestAdapter(params, userAgent)
+    return new RestAdapter(params)
   }
 }


### PR DESCRIPTION
## Motivation
A single `axios` instance allows for [stateful adapters](https://github.com/contentful/contentful-sdk-core/pull/214). there is technically also no need to create an instance for every call. 

## Implementation
We create a `axiosInstance` calls member to the RestAdapter, and pass it in to the endpoint function. 
