### PR TITLE
fix(types): revert content type field validation change [NONE]

### DIFF
--- a/lib/entities/content-type-fields.ts
+++ b/lib/entities/content-type-fields.ts
@@ -46,7 +46,7 @@ interface NodesValidation {
 }
 
 export interface ContentTypeFieldValidation {
-  linkContentType?: string | string[]
+  linkContentType?: string[]
   in?: (string | number)[]
   linkMimetypeGroup?: string[]
   enabledNodeTypes?: (`${BLOCKS}` | `${INLINES}`)[]


### PR DESCRIPTION
We realised that the change introduced with [this](https://github.com/contentful/contentful-management.js/pull/1966) is causing same trouble.  After reviewing it again we decided to revert the change. 