### PR TITLE
chore: remove non-master releases [NONE]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,5 +127,5 @@ workflows:
             branches:
               only:
                 - master
-                - next
-                - next-major
+#                - next
+#                - next-major


### PR DESCRIPTION
We currently don't want to create releases from branches other than `master` 