### PR TITLE
feat: add client methods for AppEventSubscriptions and AppKeys [EXT-4755] [EXT-4757]

### DIFF
--- a/lib/adapters/REST/endpoints/app-event-subscription.ts
+++ b/lib/adapters/REST/endpoints/app-event-subscription.ts
@@ -1,0 +1,40 @@
+import type { AxiosInstance } from 'contentful-sdk-core'
+import {
+  CreateAppEventSubscriptionProps,
+  AppEventSubscriptionProps,
+} from '../../../entities/app-event-subscription'
+import * as raw from './raw'
+import { RestEndpoint } from '../types'
+import { GetAppDefinitionParams } from '../../../common-types'
+
+export const get: RestEndpoint<'AppEventSubscription', 'get'> = (
+  http: AxiosInstance,
+  params: GetAppDefinitionParams
+) => {
+  return raw.get<AppEventSubscriptionProps>(
+    http,
+    `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/event_subscription`
+  )
+}
+
+export const upsert: RestEndpoint<'AppEventSubscription', 'upsert'> = (
+  http: AxiosInstance,
+  params: GetAppDefinitionParams,
+  data: CreateAppEventSubscriptionProps
+) => {
+  return raw.put<AppEventSubscriptionProps>(
+    http,
+    `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/event_subscription`,
+    data
+  )
+}
+
+export const del: RestEndpoint<'AppEventSubscription', 'delete'> = (
+  http: AxiosInstance,
+  params: GetAppDefinitionParams
+) => {
+  return raw.del(
+    http,
+    `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/event_subscription`
+  )
+}

--- a/lib/adapters/REST/endpoints/app-key.ts
+++ b/lib/adapters/REST/endpoints/app-key.ts
@@ -1,0 +1,47 @@
+import type { AxiosInstance } from 'contentful-sdk-core'
+import { CreateAppKeyProps, AppKeyProps } from '../../../entities/app-key'
+import * as raw from './raw'
+import { RestEndpoint } from '../types'
+import { CollectionProp, GetAppDefinitionParams, GetAppKeyParams } from '../../../common-types'
+
+export const get: RestEndpoint<'AppKey', 'get'> = (
+  http: AxiosInstance,
+  params: GetAppKeyParams
+) => {
+  return raw.get<AppKeyProps>(
+    http,
+    `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/keys/${params.fingerprint}`
+  )
+}
+
+export const getMany: RestEndpoint<'AppKey', 'getMany'> = (
+  http: AxiosInstance,
+  params: GetAppDefinitionParams
+) => {
+  return raw.get<CollectionProp<AppKeyProps>>(
+    http,
+    `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/keys`
+  )
+}
+
+export const create: RestEndpoint<'AppKey', 'create'> = (
+  http: AxiosInstance,
+  params: GetAppDefinitionParams,
+  data: CreateAppKeyProps
+) => {
+  return raw.post<AppKeyProps>(
+    http,
+    `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/keys`,
+    data
+  )
+}
+
+export const del: RestEndpoint<'AppKey', 'delete'> = (
+  http: AxiosInstance,
+  params: GetAppKeyParams
+) => {
+  return raw.del(
+    http,
+    `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/keys/${params.fingerprint}`
+  )
+}

--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -7,6 +7,8 @@ import * as AppDetails from './app-details'
 import * as AppInstallation from './app-installation'
 import * as AppSignedRequest from './app-signed-request'
 import * as AppSigningSecret from './app-signing-secret'
+import * as AppEventSubscription from './app-event-subscription'
+import * as AppKey from './app-key'
 import * as AppUpload from './app-upload'
 import * as Asset from './asset'
 import * as AssetKey from './asset-key'
@@ -61,6 +63,8 @@ export default {
   AppUpload,
   AppSignedRequest,
   AppSigningSecret,
+  AppEventSubscription,
+  AppKey,
   AppDetails,
   Asset,
   AssetKey,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -139,6 +139,11 @@ import {
   EnvironmentTemplateValidationProps,
 } from './entities/environment-template-installation'
 import { DeliveryFunctionProps } from './entities/delivery-function'
+import {
+  AppEventSubscriptionProps,
+  CreateAppEventSubscriptionProps,
+} from './entities/app-event-subscription'
+import { AppKeyProps, CreateAppKeyProps } from './entities/app-key'
 
 export interface DefaultElements<TPlainObject extends object = object> {
   toPlainObject(): TPlainObject
@@ -371,6 +376,15 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'AppSigningSecret', 'upsert', UA>): MRReturn<'AppSigningSecret', 'upsert'>
   (opts: MROpts<'AppSigningSecret', 'get', UA>): MRReturn<'AppSigningSecret', 'get'>
   (opts: MROpts<'AppSigningSecret', 'delete', UA>): MRReturn<'AppSigningSecret', 'delete'>
+
+  (opts: MROpts<'AppEventSubscription', 'upsert', UA>): MRReturn<'AppEventSubscription', 'upsert'>
+  (opts: MROpts<'AppEventSubscription', 'get', UA>): MRReturn<'AppEventSubscription', 'get'>
+  (opts: MROpts<'AppEventSubscription', 'delete', UA>): MRReturn<'AppEventSubscription', 'delete'>
+
+  (opts: MROpts<'AppKey', 'get', UA>): MRReturn<'AppKey', 'get'>
+  (opts: MROpts<'AppKey', 'getMany', UA>): MRReturn<'AppKey', 'getMany'>
+  (opts: MROpts<'AppKey', 'create', UA>): MRReturn<'AppKey', 'create'>
+  (opts: MROpts<'AppKey', 'delete', UA>): MRReturn<'AppKey', 'delete'>
 
   (opts: MROpts<'AssetKey', 'create', UA>): MRReturn<'AssetKey', 'create'>
 
@@ -868,6 +882,40 @@ export type MRActions = {
     }
     delete: {
       params: GetAppDefinitionParams
+      return: void
+    }
+  }
+  AppEventSubscription: {
+    upsert: {
+      params: GetAppDefinitionParams
+      payload: CreateAppEventSubscriptionProps
+      return: AppEventSubscriptionProps
+    }
+    get: {
+      params: GetAppDefinitionParams
+      return: AppEventSubscriptionProps
+    }
+    delete: {
+      params: GetAppDefinitionParams
+      return: void
+    }
+  }
+  AppKey: {
+    create: {
+      params: GetAppDefinitionParams
+      payload: CreateAppKeyProps
+      return: AppKeyProps
+    }
+    get: {
+      params: GetAppDefinitionParams & { fingerprint: string }
+      return: AppKeyProps
+    }
+    getMany: {
+      params: GetAppDefinitionParams & QueryParams
+      return: CollectionProp<AppKeyProps>
+    }
+    delete: {
+      params: GetAppDefinitionParams & { fingerprint: string }
       return: void
     }
   }
@@ -1834,6 +1882,7 @@ export type GetOrganizationMembershipParams = GetOrganizationParams & {
   organizationMembershipId: string
 }
 
+export type GetAppKeyParams = GetAppDefinitionParams & { fingerprint: string }
 export type GetAppUploadParams = GetOrganizationParams & { appUploadId: string }
 export type GetWorkflowDefinitionParams = GetSpaceEnvironmentParams & {
   workflowDefinitionId: string

--- a/lib/create-organization-api.ts
+++ b/lib/create-organization-api.ts
@@ -4,10 +4,12 @@ import { Stream } from 'stream'
 import { CreateTeamMembershipProps } from './entities/team-membership'
 import { CreateTeamProps } from './entities/team'
 import { CreateOrganizationInvitationProps } from './entities/organization-invitation'
-import { MakeRequest, QueryOptions, QueryParams } from './common-types'
+import { BasicQueryOptions, MakeRequest, QueryOptions, QueryParams } from './common-types'
 import { CreateAppDefinitionProps } from './entities/app-definition'
 import { CreateAppActionProps } from './entities/app-action'
 import { CreateAppSigningSecretProps } from './entities/app-signing-secret'
+import { CreateAppEventSubscriptionProps } from './entities/app-event-subscription'
+import { CreateAppKeyProps } from './entities/app-key'
 import { CreateAppDetailsProps } from './entities/app-details'
 import { OrganizationProp } from './entities/organization'
 
@@ -35,6 +37,8 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
   const { wrapOrganizationInvitation } = entities.organizationInvitation
   const { wrapAppUpload } = entities.appUpload
   const { wrapAppSigningSecret } = entities.appSigningSecret
+  const { wrapAppEventSubscription } = entities.appEventSubscription
+  const { wrapAppKey, wrapAppKeyCollection } = entities.appKey
   const { wrapAppDetails } = entities.appDetails
   const { wrapAppAction, wrapAppActionCollection } = entities.appAction
 
@@ -680,6 +684,198 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
         entityType: 'AppSigningSecret',
         action: 'delete',
         params: { organizationId: raw.sys.id, appDefinitionId },
+      }).then(() => {
+        /* noop*/
+      })
+    },
+    /**
+     * Creates or updates an app event subscription
+     * @return Promise for an App Event Subscription
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.upsertAppEventSubscription('app_definition_id', { targetUrl: '<target_url>', topics: ['<topic>'] }))
+     * .then((appEventSubscription) => console.log(appEventSubscription))
+     * .catch(console.error)
+     * ```
+     */
+    upsertAppEventSubscription(appDefinitionId: string, data: CreateAppEventSubscriptionProps) {
+      const raw = this.toPlainObject() as OrganizationProp
+
+      return makeRequest({
+        entityType: 'AppEventSubscription',
+        action: 'upsert',
+        params: { organizationId: raw.sys.id, appDefinitionId },
+        payload: data,
+      }).then((payload) => wrapAppEventSubscription(makeRequest, payload))
+    },
+    /**
+     * Gets an app event subscription
+     * @return Promise for an App Event Subscription
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppEventSubscription('app_definition_id'))
+     * .then((appEventSubscription) => console.log(appEventSubscription))
+     * .catch(console.error)
+     * ```
+     */
+    getAppEventSubscription(appDefinitionId: string) {
+      const raw = this.toPlainObject() as OrganizationProp
+
+      return makeRequest({
+        entityType: 'AppEventSubscription',
+        action: 'get',
+        params: { organizationId: raw.sys.id, appDefinitionId },
+      }).then((payload) => wrapAppEventSubscription(makeRequest, payload))
+    },
+    /**
+     * Deletes the current App Event Subscription for the given App
+     * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.deleteAppEventSubscription('app_definition_id'))
+     * .then((result) => console.log(result))
+     * .catch(console.error)
+     * ```
+     */
+    deleteAppEventSubscription(appDefinitionId: string) {
+      const raw = this.toPlainObject() as OrganizationProp
+
+      return makeRequest({
+        entityType: 'AppEventSubscription',
+        action: 'delete',
+        params: { organizationId: raw.sys.id, appDefinitionId },
+      }).then(() => {
+        /* noop*/
+      })
+    },
+    /**
+     * Creates or updates an app event subscription
+     * @return Promise for an App Event Subscription
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * // generate a new private key
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.upsertAppEventSubscription('app_definition_id', { generate: true }))
+     * .then((appEventSubscription) => console.log(appEventSubscription))
+     * .catch(console.error)
+     *
+     * // or use an existing JSON Web Key
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.upsertAppEventSubscription('app_definition_id', { jwk: 'jwk' }))
+     * .then((appEventSubscription) => console.log(appEventSubscription))
+     * .catch(console.error)
+     * ```
+     */
+    createAppKey(appDefinitionId: string, data: CreateAppKeyProps) {
+      const raw = this.toPlainObject() as OrganizationProp
+
+      return makeRequest({
+        entityType: 'AppKey',
+        action: 'create',
+        params: { organizationId: raw.sys.id, appDefinitionId },
+        payload: data,
+      }).then((payload) => wrapAppKey(makeRequest, payload))
+    },
+    /**
+     * Gets an app key by fingerprint
+     * @return Promise for an App Key
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppKey('app_definition_id', 'fingerprint'))
+     * .then((appKey) => console.log(appKey))
+     * .catch(console.error)
+     * ```
+     */
+    getAppKey(appDefinitionId: string, fingerprint: string) {
+      const raw = this.toPlainObject() as OrganizationProp
+
+      return makeRequest({
+        entityType: 'AppKey',
+        action: 'get',
+        params: { organizationId: raw.sys.id, appDefinitionId, fingerprint },
+      }).then((payload) => wrapAppKey(makeRequest, payload))
+    },
+    /**
+     * Gets all keys for the given app
+     * @return Promise for an array of App Keys
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * // with default pagination
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppKeys('app_definition_id'))
+     * .then((appKeys) => console.log(appKeys))
+     * .catch(console.error)
+     *
+     * // with explicit pagination
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppKeys('app_definition_id', { skip: 'skip', limit: 'limit' }))
+     * .then((appKeys) => console.log(appKeys))
+     * .catch(console.error)
+     * ```
+     */
+    getAppKeys(appDefinitionId: string, query: BasicQueryOptions = {}) {
+      const raw = this.toPlainObject() as OrganizationProp
+
+      return makeRequest({
+        entityType: 'AppKey',
+        action: 'getMany',
+        params: {
+          organizationId: raw.sys.id,
+          appDefinitionId,
+          query: createRequestConfig({ query }).params,
+        },
+      }).then((payload) => wrapAppKeyCollection(makeRequest, payload))
+    },
+    /**
+     * Deletes an app key by fingerprint.
+     * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.deleteAppKey('app_definition_id', 'fingerprint'))
+     * .then((result) => console.log(result))
+     * .catch(console.error)
+     * ```
+     */
+    deleteAppKey(appDefinitionId: string, fingerprint: string) {
+      const raw = this.toPlainObject() as OrganizationProp
+
+      return makeRequest({
+        entityType: 'AppKey',
+        action: 'delete',
+        params: { organizationId: raw.sys.id, appDefinitionId, fingerprint },
       }).then(() => {
         /* noop*/
       })

--- a/lib/entities/app-event-subscription.ts
+++ b/lib/entities/app-event-subscription.ts
@@ -1,0 +1,77 @@
+import copy from 'fast-copy'
+import { toPlainObject } from 'contentful-sdk-core'
+import { Except } from 'type-fest'
+import { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '../common-types'
+import enhanceWithMethods from '../enhance-with-methods'
+
+type AppEventSubscriptionSys = Except<BasicMetaSysProps, 'version' | 'id'> & {
+  appDefinition: SysLink
+  organization: SysLink
+}
+
+export type AppEventSubscriptionProps = {
+  /**
+   * System metadata
+   */
+  sys: AppEventSubscriptionSys
+  /** Subscription url that will receive events */
+  targetUrl: string
+  /** List of topics to subscribe to */
+  topics: string[]
+}
+
+export type CreateAppEventSubscriptionProps = Except<AppEventSubscriptionProps, 'sys'>
+
+export interface AppEventSubscription
+  extends AppEventSubscriptionProps,
+    DefaultElements<AppEventSubscriptionProps> {
+  /**
+   * Deletes this object on the server.
+   * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
+   * @example ```javascript
+   * const contentful = require('contentful-management')
+   *
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
+   * client.getOrganization('<organization_id>')
+   * .then((organization) => organization.getAppEventSubscription(<app-definition-id>))
+   * .then((eventSubscription) => eventSubscription.delete())
+   * .then(() => console.log('eventSubscription deleted'))
+   * .catch(console.error)
+   * ```
+   */
+  delete(): Promise<void>
+}
+
+function createEventSubscriptionApi(makeRequest: MakeRequest) {
+  const getParams = (data: AppEventSubscriptionProps) => ({
+    organizationId: data.sys.organization.sys.id,
+    appDefinitionId: data.sys.appDefinition.sys.id,
+  })
+
+  return {
+    delete: function del() {
+      const self = this as AppEventSubscriptionProps
+      return makeRequest({
+        entityType: 'AppEventSubscription',
+        action: 'delete',
+        params: getParams(self),
+      })
+    },
+  }
+}
+
+/**
+ * @private
+ * @param http - HTTP client instance
+ * @param data - Raw AppEventSubscription data
+ * @return Wrapped AppEventSubscription data
+ */
+export function wrapAppEventSubscription(
+  makeRequest: MakeRequest,
+  data: AppEventSubscriptionProps
+): AppEventSubscription {
+  const eventSubscription = toPlainObject(copy(data))
+  return enhanceWithMethods(eventSubscription, createEventSubscriptionApi(makeRequest))
+}

--- a/lib/entities/app-key.ts
+++ b/lib/entities/app-key.ts
@@ -10,19 +10,35 @@ type AppKeySys = Except<BasicMetaSysProps, 'version'> & {
   organization: SysLink
 }
 
+export interface JWK {
+  alg: 'RS256'
+  kty: 'RSA'
+  use: 'sig'
+  x5c: [string]
+  kid: string
+  x5t: string
+}
+
 export type AppKeyProps = {
   /**
    * System metadata
    */
   sys: AppKeySys
-  jwk: JsonWebKey
+  /**
+   * JSON Web Key
+   */
+  jwk: JWK
 }
 
 export type CreateAppKeyProps = {
-  /** Toggle for automatic private key generation */
+  /**
+   * Toggle for automatic private key generation
+   */
   generate?: boolean
-  /** JSON Web Key, required if generate is falsy */
-  jwk?: string
+  /**
+   * JSON Web Key, required if generate is falsy
+   */
+  jwk?: JWK
 }
 
 export interface AppKey extends AppKeyProps, DefaultElements<AppKeyProps> {

--- a/lib/entities/app-key.ts
+++ b/lib/entities/app-key.ts
@@ -1,0 +1,84 @@
+import copy from 'fast-copy'
+import { toPlainObject } from 'contentful-sdk-core'
+import { Except } from 'type-fest'
+import { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '../common-types'
+import enhanceWithMethods from '../enhance-with-methods'
+import { wrapCollection } from '../common-utils'
+
+type AppKeySys = Except<BasicMetaSysProps, 'version'> & {
+  appDefinition: SysLink
+  organization: SysLink
+}
+
+export type AppKeyProps = {
+  /**
+   * System metadata
+   */
+  sys: AppKeySys
+  jwk: JsonWebKey
+}
+
+export type CreateAppKeyProps = {
+  /** Toggle for automatic private key generation */
+  generate?: boolean
+  /** JSON Web Key, required if generate is falsy */
+  jwk?: string
+}
+
+export interface AppKey extends AppKeyProps, DefaultElements<AppKeyProps> {
+  /**
+   * Deletes this object on the server.
+   * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
+   * @example ```javascript
+   * const contentful = require('contentful-management')
+   *
+   * const client = contentful.createClient({
+   *   accessToken: '<content_management_api_key>'
+   * })
+   * client.getOrganization('<organization_id>')
+   * .then((organization) => organization.getAppKey(<api-key-id>))
+   * .then((signingSecret) => signingSecret.delete())
+   * .then(() => console.log('signingSecret deleted'))
+   * .catch(console.error)
+   * ```
+   */
+  delete(): Promise<void>
+}
+
+function createKeyApi(makeRequest: MakeRequest) {
+  const getParams = (data: AppKeyProps) => ({
+    organizationId: data.sys.organization.sys.id,
+    appDefinitionId: data.sys.appDefinition.sys.id,
+    fingerprint: data.sys.id,
+  })
+
+  return {
+    delete: function del() {
+      const self = this as AppKeyProps
+      return makeRequest({
+        entityType: 'AppKey',
+        action: 'delete',
+        params: getParams(self),
+      })
+    },
+  }
+}
+
+/**
+ * @private
+ * @param http - HTTP client instance
+ * @param data - Raw AppKey data
+ * @return Wrapped AppKey data
+ */
+export function wrapAppKey(makeRequest: MakeRequest, data: AppKeyProps): AppKey {
+  const key = toPlainObject(copy(data))
+  return enhanceWithMethods(key, createKeyApi(makeRequest))
+}
+
+/**
+ * @private
+ * @param makeRequest - function to make requests via an adapter
+ * @param data - Raw App Key collection data
+ * @return Wrapped App Key collection data
+ */
+export const wrapAppKeyCollection = wrapCollection(wrapAppKey)

--- a/lib/entities/index.ts
+++ b/lib/entities/index.ts
@@ -7,6 +7,8 @@ import * as appDetails from './app-details'
 import * as appInstallation from './app-installation'
 import * as appSignedRequest from './app-signed-request'
 import * as appSigningSecret from './app-signing-secret'
+import * as appEventSubscription from './app-event-subscription'
+import * as appKey from './app-key'
 import * as appUpload from './app-upload'
 import * as asset from './asset'
 import * as assetKey from './asset-key'
@@ -60,6 +62,8 @@ export default {
   appDetails,
   appSignedRequest,
   appSigningSecret,
+  appEventSubscription,
+  appKey,
   asset,
   assetKey,
   bulkAction,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -52,6 +52,12 @@ export type {
   AppSigningSecretProps,
   CreateAppSigningSecretProps,
 } from './entities/app-signing-secret'
+export type {
+  AppEventSubscription,
+  AppEventSubscriptionProps,
+  CreateAppEventSubscriptionProps,
+} from './entities/app-event-subscription'
+export type { AppKey, AppKeyProps, CreateAppKeyProps } from './entities/app-key'
 export type { AppUpload, AppUploadProps } from './entities/app-upload'
 export type { Asset, AssetFileProp, AssetProps, CreateAssetProps } from './entities/asset'
 export type { AssetKey, AssetKeyProps, CreateAssetKeyProps } from './entities/asset-key'

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -163,6 +163,8 @@ import { WebhookPlainClientAPI } from './entities/webhook'
 import { AppSignedRequestPlainClientAPI } from './entities/app-signed-request'
 import { AppSigningSecretPlainClientAPI } from './entities/app-signing-secret'
 import { ExtensionPlainClientAPI } from './entities/extension'
+import { AppEventSubscriptionPlainClientAPI } from './entities/app-event-subscription'
+import { AppKeyPlainClientAPI } from './entities/app-key'
 
 export type PlainClientAPI = {
   raw: {
@@ -178,6 +180,8 @@ export type PlainClientAPI = {
   appActionCall: AppActionCallPlainClientAPI
   appBundle: AppBundlePlainClientAPI
   appDetails: AppDetailsPlainClientAPI
+  appEventSubscription: AppEventSubscriptionPlainClientAPI
+  appKey: AppKeyPlainClientAPI
   appSignedRequest: AppSignedRequestPlainClientAPI
   appSigningSecret: AppSigningSecretPlainClientAPI
   deliveryFunction: {

--- a/lib/plain/entities/app-event-subscription.ts
+++ b/lib/plain/entities/app-event-subscription.ts
@@ -1,0 +1,57 @@
+import { GetAppDefinitionParams } from '../../common-types'
+import {
+  AppEventSubscriptionProps,
+  CreateAppEventSubscriptionProps,
+} from '../../entities/app-event-subscription'
+import { OptionalDefaults } from '../wrappers/wrap'
+
+export type AppEventSubscriptionPlainClientAPI = {
+  /**
+   * Creates or updates an App Event Subscription
+   * @param params entity IDs to identify the App that the Event Subscription belongs to
+   * @param payload the new or updated Event Subscription
+   * @returns the App Event Subscription and its metadata
+   * @throws if the request fails, the App or Event Subscription is not found, or the payload is malformed
+   * @example
+   * ```javascript
+   * const eventSubscription = await client.appEventSubscription.upsert({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * }, {
+   *   targetUrl: `<target_url>`,
+   *   topics: ['<Topic>'],
+   * })
+   * ```
+   */
+  upsert(
+    params: OptionalDefaults<GetAppDefinitionParams>,
+    payload: CreateAppEventSubscriptionProps
+  ): Promise<AppEventSubscriptionProps>
+  /**
+   * Fetches the current App Event Subscription for the given App
+   * @param params entity IDs to identify the App that the Event Subscription belongs to
+   * @returns the App Event Subscription
+   * @throws if the request fails, or the App or the Event Subscription is not found
+   * @example
+   * ```javascript
+   * const eventSubscription = await client.appEventSubscription.get({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * })
+   * ```
+   */
+  get(params: OptionalDefaults<GetAppDefinitionParams>): Promise<AppEventSubscriptionProps>
+  /**
+   * Removes the current App Event Subscription for the given App
+   * @param params entity IDs to identify the App that the Event Subscription belongs to
+   * @throws if the request fails, or the App or the Event Subscription is not found
+   * @example
+   * ```javascript
+   * await client.appEventSubscription.delete({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * })
+   * ```
+   */
+  delete(params: OptionalDefaults<GetAppDefinitionParams>): Promise<void>
+}

--- a/lib/plain/entities/app-key.ts
+++ b/lib/plain/entities/app-key.ts
@@ -76,7 +76,7 @@ export type AppKeyPlainClientAPI = {
    * ```
    */
   getMany(
-    params: OptionalDefaults<GetAppDefinitionParams & QueryParams>
+    params: OptionalDefaults<GetAppDefinitionParams> & QueryParams
   ): Promise<CollectionProp<AppKeyProps>>
   /**
    * Removes the App Key with the given fingerprint

--- a/lib/plain/entities/app-key.ts
+++ b/lib/plain/entities/app-key.ts
@@ -1,0 +1,95 @@
+import { CollectionProp, GetAppDefinitionParams, QueryParams } from '../../common-types'
+import { AppKeyProps, CreateAppKeyProps } from '../../entities/app-key'
+import { OptionalDefaults } from '../wrappers/wrap'
+
+export type AppKeyPlainClientAPI = {
+  /**
+   * Creates an App Key
+   * @param params entity IDs to identify the App that the Key belongs to
+   * @param payload options for Key creation, see example for details
+   * @returns the App Key and its metadata
+   * @throws if the request fails, the App or Key is not found, or the payload is malformed
+   * @example
+   * ```javascript
+   * // create an App Key by generating a new private key
+   * const key = await client.appKey.create({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * }, {
+   *   generate: true
+   * })
+   *
+   * // create an App Key by specifying an existing private key
+   * const keyFromExistingJWK = await client.appKey.create({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * }, {
+   *   jwk: '<jwk>'
+   * })
+   * ```
+   */
+  create(
+    params: OptionalDefaults<GetAppDefinitionParams>,
+    payload: CreateAppKeyProps
+  ): Promise<AppKeyProps>
+  /**
+   * Fetches the App Key with the given fingerprint
+   * @param params entity IDs to identify the App Key
+   * @returns the App Key
+   * @throws if the request fails, or the App or the Key is not found
+   * @example
+   * ```javascript
+   * const key = await client.appKey.get({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   *   fingerprint: '<fingerprint>',
+   * })
+   * ```
+   */
+  get(
+    params: OptionalDefaults<GetAppDefinitionParams> & { fingerprint: string }
+  ): Promise<AppKeyProps>
+  /**
+   * Fetches all Keys for the given App
+   * @param params entity IDs to identify the App
+   * @param payload optional pagination query, see example for details
+   * @returns the App Keys
+   * @throws if the request fails, or the App is not found
+   * @example
+   * ```javascript
+   * // with default pagination
+   * const keys = await client.appKey.getMany({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * })
+   *
+   * // with explicit pagination
+   * const paginatedKeys = await client.appKey.getMany({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * }, {
+   *   query: {
+   *     skip: '<skip>',
+   *     limit: '<limit>',
+   *   }
+   * })
+   * ```
+   */
+  getMany(
+    params: OptionalDefaults<GetAppDefinitionParams & QueryParams>
+  ): Promise<CollectionProp<AppKeyProps>>
+  /**
+   * Removes the App Key with the given fingerprint
+   * @param params entity IDs to identify the App Key
+   * @throws if the request fails, or the App or the Key is not found
+   * @example
+   * ```javascript
+   * await client.appKey.delete({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   *   fingerprint: '<fingerprint>',
+   * })
+   * ```
+   */
+  delete(params: OptionalDefaults<GetAppDefinitionParams> & { fingerprint: string }): Promise<void>
+}

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -81,6 +81,17 @@ export const createPlainClient = (
       get: wrap(wrapParams, 'AppDetails', 'get'),
       delete: wrap(wrapParams, 'AppDetails', 'delete'),
     },
+    appEventSubscription: {
+      upsert: wrap(wrapParams, 'AppEventSubscription', 'upsert'),
+      get: wrap(wrapParams, 'AppEventSubscription', 'get'),
+      delete: wrap(wrapParams, 'AppEventSubscription', 'delete'),
+    },
+    appKey: {
+      create: wrap(wrapParams, 'AppKey', 'create'),
+      get: wrap(wrapParams, 'AppKey', 'get'),
+      getMany: wrap(wrapParams, 'AppKey', 'getMany'),
+      delete: wrap(wrapParams, 'AppKey', 'delete'),
+    },
     appSignedRequest: {
       create: wrap(wrapParams, 'AppSignedRequest', 'create'),
     },

--- a/test/integration/app-event-subscription-integration.js
+++ b/test/integration/app-event-subscription-integration.js
@@ -53,13 +53,13 @@ describe('AppEventSubscription api', function () {
       topics: ['Entry.create'],
     })
 
-    expect(eventSubscription.topics).equals(['Entry.create'])
+    expect(eventSubscription.topics).deep.equals(['Entry.create'])
 
     const updatedEventSubscription = await client.appEventSubscription.upsert(entityId, {
       topics: ['Entry.save'],
     })
 
-    expect(updatedEventSubscription.topics).equals(['Entry.save'])
+    expect(updatedEventSubscription.topics).deep.equals(['Entry.save'])
 
     await client.appEventSubscription.delete(entityId)
   })

--- a/test/integration/app-event-subscription-integration.js
+++ b/test/integration/app-event-subscription-integration.js
@@ -1,0 +1,76 @@
+import { expect } from 'chai'
+import { before, after, describe, test } from 'mocha'
+import { initPlainClient, getTestOrganization } from '../helpers'
+
+describe('AppEventSubscription api', function () {
+  let appDefinition
+  let client
+  let organization
+  let entityId
+
+  let targetUrl = 'https://contentful.fake/event-handler'
+
+  before(async () => {
+    organization = await getTestOrganization()
+
+    appDefinition = await organization.createAppDefinition({
+      name: 'Test AppEventSubscription',
+    })
+
+    entityId = { organizationId: organization.sys.id, appDefinitionId: appDefinition.sys.id }
+
+    client = initPlainClient()
+  })
+
+  after(async () => {
+    if (appDefinition) {
+      await appDefinition.delete()
+    }
+  })
+
+  test('createAppEventSubscription', async () => {
+    const eventSubscription = await client.appEventSubscription.upsert(entityId, {
+      targetUrl,
+      topics: ['Entry.create'],
+    })
+
+    expect(eventSubscription.targetUrl).equals(targetUrl)
+
+    await client.appEventSubscription.delete(entityId)
+  })
+
+  test('getAppEventSubscription', async () => {
+    await client.appEventSubscription.upsert(entityId, { targetUrl, topics: ['Entry.create'] })
+    const eventSubscription = await client.appEventSubscription.get(entityId)
+
+    expect(eventSubscription.targetUrl).equals(targetUrl)
+    await client.appEventSubscription.delete(entityId)
+  })
+
+  test('updateAppEventSubscription', async () => {
+    const eventSubscription = await client.appEventSubscription.upsert(entityId, {
+      targetUrl,
+      topics: ['Entry.create'],
+    })
+
+    expect(eventSubscription.topics).equals(['Entry.create'])
+
+    const updatedEventSubscription = await client.appEventSubscription.upsert(entityId, {
+      topics: ['Entry.save'],
+    })
+
+    expect(updatedEventSubscription.topics).equals(['Entry.save'])
+
+    await client.appEventSubscription.delete(entityId)
+  })
+
+  test('deleteAppEventSubscription', async () => {
+    await client.appEventSubscription.upsert(entityId, { targetUrl, topics: ['Entry.create'] })
+
+    await client.appEventSubscription.delete(entityId)
+
+    await expect(client.appEventSubscription.get(entityId)).to.be.rejectedWith(
+      'The resource could not be found'
+    )
+  })
+})

--- a/test/integration/app-event-subscription-integration.js
+++ b/test/integration/app-event-subscription-integration.js
@@ -56,6 +56,7 @@ describe('AppEventSubscription api', function () {
     expect(eventSubscription.topics).deep.equals(['Entry.create'])
 
     const updatedEventSubscription = await client.appEventSubscription.upsert(entityId, {
+      targetUrl,
       topics: ['Entry.save'],
     })
 

--- a/test/integration/app-key-integration.js
+++ b/test/integration/app-key-integration.js
@@ -57,7 +57,7 @@ describe('AppKey api', function () {
   })
 
   test('deleteAppKey', async () => {
-    const key = await client.appKey.upsert(entityId, { generate: true })
+    const key = await client.appKey.create(entityId, { generate: true })
     entityId.fingerprint = key.sys.id
 
     await client.appKey.delete(entityId)

--- a/test/integration/app-key-integration.js
+++ b/test/integration/app-key-integration.js
@@ -49,7 +49,7 @@ describe('AppKey api', function () {
     const key1 = await client.appKey.create(entityId, { generate: true })
     const key2 = await client.appKey.create(entityId, { generate: true })
 
-    const keys = await client.appKey.getMany()
+    const keys = await client.appKey.getMany(entityId)
 
     expect(keys).to.have.lengthOf(2)
     await client.appKey.delete({ ...entityId, fingerprint: key1.sys.id })

--- a/test/integration/app-key-integration.js
+++ b/test/integration/app-key-integration.js
@@ -49,9 +49,9 @@ describe('AppKey api', function () {
     const key1 = await client.appKey.create(entityId, { generate: true })
     const key2 = await client.appKey.create(entityId, { generate: true })
 
-    const keys = await client.appKey.getMany(entityId)
+    const { items } = await client.appKey.getMany(entityId)
 
-    expect(keys).to.have.lengthOf(2)
+    expect(items).to.have.lengthOf(2)
     await client.appKey.delete({ ...entityId, fingerprint: key1.sys.id })
     await client.appKey.delete({ ...entityId, fingerprint: key2.sys.id })
   })

--- a/test/integration/app-key-integration.js
+++ b/test/integration/app-key-integration.js
@@ -1,0 +1,67 @@
+import { expect } from 'chai'
+import { before, after, describe, test } from 'mocha'
+import { initPlainClient, getTestOrganization } from '../helpers'
+
+describe('AppKey api', function () {
+  let appDefinition
+  let client
+  let organization
+  let entityId
+
+  before(async () => {
+    organization = await getTestOrganization()
+
+    appDefinition = await organization.createAppDefinition({
+      name: 'Test AppKey',
+    })
+
+    entityId = { organizationId: organization.sys.id, appDefinitionId: appDefinition.sys.id }
+
+    client = initPlainClient()
+  })
+
+  after(async () => {
+    if (appDefinition) {
+      await appDefinition.delete()
+    }
+  })
+
+  test('createAppKey', async () => {
+    const key = await client.appKey.create(entityId, { generate: true })
+    entityId.fingerprint = key.sys.id
+
+    expect(key.jwk.kty).equals('RSA')
+
+    await client.appKey.delete(entityId)
+  })
+
+  test('getAppKey', async () => {
+    let key = await client.appKey.create(entityId, { generate: true })
+    entityId.fingerprint = key.sys.id
+
+    key = await client.appKey.get(entityId)
+
+    expect(key.jwk.kty).equals('RSA')
+    await client.appKey.delete(entityId)
+  })
+
+  test('getAppKeys', async () => {
+    const key1 = await client.appKey.create(entityId, { generate: true })
+    const key2 = await client.appKey.create(entityId, { generate: true })
+
+    const keys = await client.appKey.getMany()
+
+    expect(keys).to.have.lengthOf(2)
+    await client.appKey.delete({ ...entityId, fingerprint: key1.sys.id })
+    await client.appKey.delete({ ...entityId, fingerprint: key2.sys.id })
+  })
+
+  test('deleteAppKey', async () => {
+    const key = await client.appKey.upsert(entityId, { generate: true })
+    entityId.fingerprint = key.sys.id
+
+    await client.appKey.delete(entityId)
+
+    await expect(client.appKey.get(entityId)).to.be.rejectedWith('The resource could not be found')
+  })
+})

--- a/test/unit/create-organization-api-test.js
+++ b/test/unit/create-organization-api-test.js
@@ -6,6 +6,8 @@ import {
   appDefinitionMock,
   appUploadMock,
   appSigningSecretMock,
+  appEventSubscriptionMock,
+  appKeyMock,
   appDetailsMock,
   cloneMock,
   organizationInvitationMock,
@@ -602,6 +604,156 @@ describe('A createOrganizationApi', () => {
     const { api } = setup(Promise.reject(error))
 
     api['deleteAppSigningSecret']('app-def-id').then(
+      () => {},
+      (errorResponse) => {
+        expect(errorResponse).eql(error)
+      }
+    )
+  })
+
+  test('API call createEventSubscription', async () => {
+    const { api, entitiesMock } = setup(Promise.resolve({}))
+    entitiesMock['appEventSubscription']['wrapAppEventSubscription'].returns(
+      appEventSubscriptionMock
+    )
+    return api['upsertAppEventSubscription']('app-def-id', {
+      targetUrl: 'https://contentful.fake/event-processor',
+      topics: ['Entry.create'],
+    }).then((result) => {
+      expect(result).eql(appEventSubscriptionMock)
+    })
+  })
+
+  test('API call createEventSubscription fails', async () => {
+    const error = cloneMock('error')
+    const { api } = setup(Promise.reject(error))
+
+    api['upsertAppEventSubscription']('app-def-id', {
+      targetUrl: 'https://contentful.fake/event-processor',
+      topics: ['Entry.create'],
+    }).then(
+      () => {},
+      (errorResponse) => {
+        expect(errorResponse).eql(error)
+      }
+    )
+  })
+
+  test('API call getAppEventSubscription', async () => {
+    const { api, entitiesMock } = setup(Promise.resolve({}))
+    entitiesMock['appEventSubscription']['wrapAppEventSubscription'].returns(
+      appEventSubscriptionMock
+    )
+    return api['getAppEventSubscription']('app-def-id').then((result) => {
+      expect(result).eql(appEventSubscriptionMock)
+    })
+  })
+
+  test('API call getAppEventSubscription fails', async () => {
+    const error = cloneMock('error')
+    const { api } = setup(Promise.reject(error))
+
+    api['getAppEventSubscription']('app-def-id').then(
+      () => {},
+      (errorResponse) => {
+        expect(errorResponse).eql(error)
+      }
+    )
+  })
+
+  test('API call deleteAppEventSubscription', async () => {
+    const { api, entitiesMock } = setup(Promise.resolve({}))
+    entitiesMock['appEventSubscription']['wrapAppEventSubscription'].returns(undefined)
+    return api['deleteAppEventSubscription']('app-def-id').then((result) => {
+      expect(result).eql(undefined)
+    })
+  })
+
+  test('API call deleteAppEventSubscription fails', async () => {
+    const error = cloneMock('error')
+    const { api } = setup(Promise.reject(error))
+
+    api['deleteAppEventSubscription']('app-def-id').then(
+      () => {},
+      (errorResponse) => {
+        expect(errorResponse).eql(error)
+      }
+    )
+  })
+
+  test('API call createKey', async () => {
+    const { api, entitiesMock } = setup(Promise.resolve({}))
+    entitiesMock['appKey']['wrapAppKey'].returns(appKeyMock)
+    return api['createAppKey']('app-def-id', { generate: true }).then((result) => {
+      expect(result).eql(appKeyMock)
+    })
+  })
+
+  test('API call createKey fails', async () => {
+    const error = cloneMock('error')
+    const { api } = setup(Promise.reject(error))
+
+    api['createAppKey']('app-def-id', { generate: true }).then(
+      () => {},
+      (errorResponse) => {
+        expect(errorResponse).eql(error)
+      }
+    )
+  })
+
+  test('API call getAppKey', async () => {
+    const { api, entitiesMock } = setup(Promise.resolve({}))
+    entitiesMock['appKey']['wrapAppKey'].returns(appKeyMock)
+    return api['getAppKey']('app-def-id', 'fingerprint').then((result) => {
+      expect(result).eql(appKeyMock)
+    })
+  })
+
+  test('API call getAppKey fails', async () => {
+    const error = cloneMock('error')
+    const { api } = setup(Promise.reject(error))
+
+    api['getAppKey']('app-def-id', 'fingerprint').then(
+      () => {},
+      (errorResponse) => {
+        expect(errorResponse).eql(error)
+      }
+    )
+  })
+
+  test('API call getAppKeys', async () => {
+    return makeGetCollectionTest(setup, {
+      entityType: 'appKey',
+      mockToReturn: appKeyMock,
+      methodToTest: 'getAppKeys',
+    })
+  })
+
+  test('API call getAppKeys fails', async () => {
+    const error = cloneMock('error')
+    const { api } = setup(Promise.reject(error))
+
+    api['getAppKeys']('app-def-id').then(
+      () => {},
+      (errorResponse) => {
+        expect(errorResponse).eql(error)
+      }
+    )
+  })
+
+  test('API call deleteAppKey', async () => {
+    const { api, entitiesMock } = setup(Promise.resolve({}))
+    entitiesMock['appKey']['wrapAppKey'].returns(undefined)
+    return api['deleteAppKey']('app-def-id').then((result) => {
+      expect(result).eql(undefined)
+    })
+  })
+
+  test('API call deleteAppKey fails', async () => {
+    const error = cloneMock('error')
+    const { api } = setup(Promise.reject(error))
+
+    api['deleteAppKey']('app-def-id').then(
       () => {},
       (errorResponse) => {
         expect(errorResponse).eql(error)

--- a/test/unit/entities/app-event-subscription-test.ts
+++ b/test/unit/entities/app-event-subscription-test.ts
@@ -1,0 +1,39 @@
+import { describe, test } from 'mocha'
+import { wrapAppEventSubscription } from '../../../lib/entities/app-event-subscription'
+import { appEventSubscriptionMock } from '../mocks/entities'
+import setupHttpMock from '../mocks/http'
+import setupMakeRequest from '../mocks/makeRequest'
+import {
+  entityDeleteTest,
+  entityWrappedTest,
+  failingActionTest,
+} from '../test-creators/instance-entity-methods'
+
+function setup(promise) {
+  return {
+    makeRequest: setupMakeRequest(promise),
+    httpMock: setupHttpMock(promise),
+    entityMock: appEventSubscriptionMock,
+  }
+}
+
+describe('AppEventSubscription', () => {
+  test('EventSubscription is wrapped', async () => {
+    return entityWrappedTest(setup, {
+      wrapperMethod: wrapAppEventSubscription,
+    })
+  })
+
+  test('AppEventSubscription delete', async () => {
+    return entityDeleteTest(setup, {
+      wrapperMethod: wrapAppEventSubscription,
+    })
+  })
+
+  test('AppEventSubscription delete fails', async () => {
+    return failingActionTest(setup, {
+      wrapperMethod: wrapAppEventSubscription,
+      actionMethod: 'delete',
+    })
+  })
+})

--- a/test/unit/entities/app-key-test.ts
+++ b/test/unit/entities/app-key-test.ts
@@ -1,0 +1,46 @@
+import { describe, test } from 'mocha'
+import { wrapAppKey, wrapAppKeyCollection } from '../../../lib/entities/app-key'
+import { appKeyMock } from '../mocks/entities'
+import setupHttpMock from '../mocks/http'
+import setupMakeRequest from '../mocks/makeRequest'
+import {
+  entityCollectionWrappedTest,
+  entityDeleteTest,
+  entityWrappedTest,
+  failingActionTest,
+} from '../test-creators/instance-entity-methods'
+
+function setup(promise) {
+  return {
+    makeRequest: setupMakeRequest(promise),
+    httpMock: setupHttpMock(promise),
+    entityMock: appKeyMock,
+  }
+}
+
+describe('AppKey', () => {
+  test('Key is wrapped', async () => {
+    return entityWrappedTest(setup, {
+      wrapperMethod: wrapAppKey,
+    })
+  })
+
+  test('AppKey collection is wrapped', async () => {
+    return entityCollectionWrappedTest(setup, {
+      wrapperMethod: wrapAppKeyCollection,
+    })
+  })
+
+  test('AppKey delete', async () => {
+    return entityDeleteTest(setup, {
+      wrapperMethod: wrapAppKey,
+    })
+  })
+
+  test('AppKey delete fails', async () => {
+    return failingActionTest(setup, {
+      wrapperMethod: wrapAppKey,
+      actionMethod: 'delete',
+    })
+  })
+})

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -246,6 +246,32 @@ const appSigningSecretMock = {
   redactedValue: 'wI74',
 }
 
+const appEventSubscriptionMock = {
+  sys: Object.assign(cloneDeep(sysMock), {
+    type: 'AppEventSubscription',
+    organization: { sys: { id: 'org-id' } },
+    appDefinition: { sys: { type: 'link', linkType: 'AppDefinition', id: 'app-definition-id' } },
+  }),
+  targetUrl: 'https://contentful.fake/event-processor',
+  topics: ['Entry.create'],
+}
+
+const appKeyMock = {
+  sys: Object.assign(cloneDeep(sysMock), {
+    type: 'AppKey',
+    organization: { sys: { id: 'org-id' } },
+    appDefinition: { sys: { type: 'link', linkType: 'AppDefinition', id: 'app-definition-id' } },
+  }),
+  jwk: {
+    alg: 'RS256',
+    kty: 'RSA',
+    use: 'sig',
+    x56: ['x5c'],
+    kid: 'kid',
+    x5t: 'x5t',
+  },
+}
+
 const appDetailsMock = {
   sys: Object.assign(cloneDeep(sysMock), {
     type: 'AppDetails',
@@ -920,6 +946,8 @@ const mocks = {
   appUpload: appUploadMock,
   appSignedRequest: appSignedRequestMock,
   appSigningSecret: appSigningSecretMock,
+  appEventSubscription: appEventSubscriptionMock,
+  appKey: appKeyMock,
   appDetails: appDetailsMock,
   asset: assetMock,
   assetKey: assetKeyMock,
@@ -1012,6 +1040,13 @@ function setupEntitiesMock(rewiredModuleApi) {
     },
     appSigningSecret: {
       wrapAppSigningSecret: sinon.stub(),
+    },
+    appEventSubscription: {
+      wrapAppEventSubscription: sinon.stub(),
+    },
+    appKey: {
+      wrapAppKey: sinon.stub(),
+      wrapAppKeyCollection: sinon.stub(),
     },
     appDetails: {
       wrapAppDetails: sinon.stub(),
@@ -1189,6 +1224,8 @@ export {
   appUploadMock,
   appSignedRequestMock,
   appSigningSecretMock,
+  appEventSubscriptionMock,
+  appKeyMock,
   appDetailsMock,
   linkMock,
   sysMock,


### PR DESCRIPTION
## Summary

Adds the `upsert`, `get`, and `delete` client methods for AppEventSubscriptions, and the `create`, `get`, `getMany` and `delete` client methods for AppKeys

## Motivation and Context

CMA JS client <-> API feature parity

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
