### PR TITLE
feat: add installation param schema to app definition INTEG-1385

### DIFF
--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -62,6 +62,7 @@ export type AppDefinitionProps = {
    */
   parameters?: {
     instance?: ParameterDefinition[]
+    installation?: ParameterDefinition[]
   }
 }
 


### PR DESCRIPTION
## Summary

We are adding installation parameter schemas to the app definition

## Description

We need to update this here so we can reference the installation property in User Interface

## Motivation and Context

App creators have to currently use the frontend to validate user's installation params. This will allow them to offload most of that logic to our backend when the user saves

## Checklist (check all before merging)

- [X] Both unit and integration tests are passing
- [X] There are no breaking changes
- [ ] Changes are reflected in the documentation
