### PR TITLE
fix: return private key if generate is enabled during app key creation [EXT-4757]

### DIFF
--- a/lib/entities/app-key.ts
+++ b/lib/entities/app-key.ts
@@ -28,6 +28,15 @@ export type AppKeyProps = {
    * JSON Web Key
    */
   jwk: JWK
+  /**
+   * If generated, private key is returned
+   */
+  generated?: {
+    /**
+     * Base64 PEM
+     */
+    privateKey: string
+  }
 }
 
 export type CreateAppKeyProps = {

--- a/test/integration/app-key-integration.js
+++ b/test/integration/app-key-integration.js
@@ -27,10 +27,11 @@ describe('AppKey api', function () {
   })
 
   test('createAppKey', async () => {
-    const key = await client.appKey.create(entityId, { generate: true })
-    entityId.fingerprint = key.sys.id
+    const { sys, generated, jwk } = await client.appKey.create(entityId, { generate: true })
+    entityId.fingerprint = sys.id
 
-    expect(key.jwk.kty).equals('RSA')
+    expect(jwk.kty).equals('RSA')
+    expect(generated).to.have.property('privateKey')
 
     await client.appKey.delete(entityId)
   })


### PR DESCRIPTION
## Summary

Updates AppKeyProps to reflect that the generated private key is returned alongside the JWK.

## Description

This is a followup to https://github.com/contentful/contentful-management.js/pull/2011

## Motivation and Context

The [default-values-backend example app](https://github.com/contentful/apps/tree/master/examples/default-values-backend) is using this functionality. 

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation
