### PR TITLE
feat: fix comment types & support parentEntityReference, replies & status

### DIFF
--- a/lib/adapters/REST/endpoints/comment.ts
+++ b/lib/adapters/REST/endpoints/comment.ts
@@ -23,7 +23,10 @@ import { RestEndpoint } from '../types'
 import * as raw from './raw'
 import { normalizeSelect } from './utils'
 
+const VERSION_HEADER = 'X-Contentful-Version'
 const BODY_FORMAT_HEADER = 'x-contentful-comment-body-format'
+const PARENT_ENTITY_REFERENCE_HEADER = 'x-contentful-parent-entity-reference'
+const PARENT_COMMENT_ID_HEADER = 'x-contentful-parent-id'
 
 const getSpaceEnvBaseUrl = (params: GetSpaceEnvironmentParams) =>
   `/spaces/${params.spaceId}/environments/${params.environmentId}`
@@ -99,12 +102,13 @@ export const create: RestEndpoint<'Comment', 'create'> = (
 ) => {
   const data = copy(rawData)
   return raw.post<CommentProps>(http, getEntityBaseUrl(params), data, {
-    headers:
-      typeof rawData.body !== 'string'
-        ? {
-            [BODY_FORMAT_HEADER]: 'rich-text',
-          }
-        : {},
+    headers: {
+      ...(typeof rawData.body !== 'string' ? { [BODY_FORMAT_HEADER]: 'rich-text' } : {}),
+      ...(params.parentEntityReference
+        ? { [PARENT_ENTITY_REFERENCE_HEADER]: params.parentEntityReference }
+        : {}),
+      ...(params.parentCommentId ? { [PARENT_COMMENT_ID_HEADER]: params.parentCommentId } : {}),
+    },
   })
 }
 
@@ -119,12 +123,8 @@ export const update: RestEndpoint<'Comment', 'update'> = (
 
   return raw.put<CommentProps>(http, getEntityCommentUrl(params), data, {
     headers: {
-      'X-Contentful-Version': rawData.sys.version ?? 0,
-      ...(typeof rawData.body !== 'string'
-        ? {
-            [BODY_FORMAT_HEADER]: 'rich-text',
-          }
-        : {}),
+      [VERSION_HEADER]: rawData.sys.version ?? 0,
+      ...(typeof rawData.body !== 'string' ? { [BODY_FORMAT_HEADER]: 'rich-text' } : {}),
       ...headers,
     },
   })
@@ -135,7 +135,7 @@ export const del: RestEndpoint<'Comment', 'delete'> = (
   { version, ...params }: DeleteCommentParams
 ) => {
   return raw.del(http, getEntityCommentUrl(params), {
-    headers: { 'X-Contentful-Version': version },
+    headers: { [VERSION_HEADER]: version },
   })
 }
 

--- a/lib/adapters/REST/endpoints/comment.ts
+++ b/lib/adapters/REST/endpoints/comment.ts
@@ -104,7 +104,7 @@ export const create: RestEndpoint<'Comment', 'create'> = (
   return raw.post<CommentProps>(http, getEntityBaseUrl(params), data, {
     headers: {
       ...(typeof rawData.body !== 'string' ? { [BODY_FORMAT_HEADER]: 'rich-text' } : {}),
-      ...(params.parentEntityReference
+      ...('parentEntityReference' in params && params.parentEntityReference
         ? { [PARENT_ENTITY_REFERENCE_HEADER]: params.parentEntityReference }
         : {}),
       ...(params.parentCommentId ? { [PARENT_COMMENT_ID_HEADER]: params.parentCommentId } : {}),

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -30,6 +30,7 @@ import {
   RichTextCommentProps,
   PlainTextBodyFormat,
   RichTextCommentBodyPayload,
+  GetCommentParentEntityParams,
 } from './entities/comment'
 import { EditorInterfaceProps } from './entities/editor-interface'
 import { CreateEntryProps, EntryProps, EntryReferenceProps } from './entities/entry'
@@ -1857,7 +1858,9 @@ export type GetAppInstallationsForOrgParams = GetOrganizationParams & {
 }
 export type GetAppInstallationParams = GetSpaceEnvironmentParams & { appDefinitionId: string }
 export type GetBulkActionParams = GetSpaceEnvironmentParams & { bulkActionId: string }
-export type GetCommentParams = GetEntryParams & { commentId: string }
+export type GetCommentParams = (GetEntryParams | GetCommentParentEntityParams) & {
+  commentId: string
+}
 export type GetContentTypeParams = GetSpaceEnvironmentParams & { contentTypeId: string }
 export type GetEditorInterfaceParams = GetSpaceEnvironmentParams & { contentTypeId: string }
 export type GetEntryParams = GetSpaceEnvironmentParams & { entryId: string }

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -32,6 +32,7 @@ export type CommentSysProps = Pick<
   environment: SysLink
   parentEntity:
     | Link<'ContentType'>
+    | LinkWithReference<'ContentType'>
     | Link<'Entry'>
     | LinkWithReference<'Entry'>
     | VersionedLink<'Workflow'>
@@ -91,10 +92,12 @@ export type GetCommentParentEntityParams = GetSpaceEnvironmentParams &
     | {
         parentEntityType: 'ContentType'
         parentEntityId: string
+        parentEntityReference?: string
       }
     | {
         parentEntityType: 'Entry'
         parentEntityId: string
+        parentEntityReference?: string
       }
     | {
         parentEntityType: 'Workflow'
@@ -106,7 +109,6 @@ export type GetCommentParentEntityParams = GetSpaceEnvironmentParams &
 export type GetManyCommentsParams = GetEntryParams | GetCommentParentEntityParams
 export type CreateCommentParams = (GetEntryParams | GetCommentParentEntityParams) & {
   parentCommentId?: string
-  parentEntityReference?: string
 }
 export type UpdateCommentParams = GetCommentParams
 export type DeleteCommentParams = GetCommentParams & {

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -109,7 +109,9 @@ export type GetCommentParentEntityParams = GetSpaceEnvironmentParams &
       }
   )
 
-export type GetManyCommentsParams = GetEntryParams | GetCommentParentEntityParams
+export type GetManyCommentsParams = (GetEntryParams | GetCommentParentEntityParams) & {
+  status?: CommentStatus
+}
 export type CreateCommentParams = (GetEntryParams | GetCommentParentEntityParams) & {
   parentCommentId?: string
 }

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -45,13 +45,15 @@ export type RichTextBodyProperty = 'rich-text'
 export type RichTextBodyFormat = { bodyFormat: RichTextBodyProperty }
 export type PlainTextBodyFormat = { bodyFormat?: PlainTextBodyProperty }
 
+export type CommentStatus = 'active' | 'resolved'
+
 export type CommentProps = {
   sys: CommentSysProps
   body: string
-  status: 'resolved' | 'active'
+  status: CommentStatus
 }
 
-export type CreateCommentProps = Omit<CommentProps, 'sys'>
+export type CreateCommentProps = Omit<CommentProps, 'sys' | 'status'> & { status?: CommentStatus }
 export type UpdateCommentProps = Omit<CommentProps, 'sys'> & {
   sys: Pick<CommentSysProps, 'version'>
 }

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -48,6 +48,7 @@ export type PlainTextBodyFormat = { bodyFormat?: PlainTextBodyProperty }
 export type CommentProps = {
   sys: CommentSysProps
   body: string
+  status: 'resolved' | 'active'
 }
 
 export type CreateCommentProps = Omit<CommentProps, 'sys'>

--- a/lib/plain/plain-client-test.ts
+++ b/lib/plain/plain-client-test.ts
@@ -64,7 +64,11 @@ describe('Plain Client', () => {
       })
 
       it('should create a update object', async () => {
-        await plainClient.comment.update(props, { body: updateText, sys: { version: 2 } })
+        await plainClient.comment.update(props, {
+          body: updateText,
+          sys: { version: 2 },
+          status: 'active',
+        })
         expect(stub).to.have.been.calledWithMatch({
           entityType: 'Comment',
           action: 'update',
@@ -162,18 +166,22 @@ describe('Plain Client', () => {
           entityType: 'Comment',
           action: 'create',
           params: props,
-          payload: { body: richTextBody },
+          payload: { body: richTextBody, status: 'active' },
           headers: undefined,
         })
       })
 
       it('should create a update object', async () => {
-        await plainClient.comment.update(props, { body: richTextBody, sys: { version: 2 } })
+        await plainClient.comment.update(props, {
+          body: richTextBody,
+          sys: { version: 2 },
+          status: 'active',
+        })
         expect(stub).to.have.been.calledWithMatch({
           entityType: 'Comment',
           action: 'update',
           params: props,
-          payload: { body: richTextBody },
+          payload: { body: richTextBody, status: 'active' },
           headers: undefined,
         })
       })

--- a/test/integration/comment-integration.ts
+++ b/test/integration/comment-integration.ts
@@ -136,7 +136,7 @@ describe('Comment Api', () => {
         environmentId: environment.sys.id,
         parentEntityType: 'ContentType',
         parentEntityId: contentType.sys.id,
-        parentEntityReference: 'field',
+        parentEntityReference: 'fields.firstField',
       }
       const {
         sys: { id, version },

--- a/test/integration/comment-integration.ts
+++ b/test/integration/comment-integration.ts
@@ -1,20 +1,21 @@
 import { expect } from 'chai'
 import { before, describe, test, after } from 'mocha'
 import { initClient, createTestEnvironment, createTestSpace, initPlainClient } from '../helpers'
+import { ContentType, Entry, Environment, PlainClientAPI, Space } from '../../lib/export-types'
 
 describe('Comment Api', () => {
-  let plainClient
-  let space
-  let environment
-  let contentType
-  let entry
+  let plainClient: PlainClientAPI
+  let space: Space
+  let environment: Environment
+  let contentType: ContentType
+  let entry: Entry
   const commentBody = 'JS SDK Comment Integration Test'
 
   before(async () => {
     plainClient = initPlainClient()
-    space = await createTestSpace(initClient(), 'Comment')
-    environment = await createTestEnvironment(space, 'Comment Testing Environment')
-    contentType = await environment.createContentType({ name: 'Content Type' })
+    space = (await createTestSpace(initClient(), 'Comment')) as Space
+    environment = (await createTestEnvironment(space, 'Comment Testing Environment')) as Environment
+    contentType = await environment.createContentType({ name: 'Content Type', fields: [] })
     await contentType.publish()
     entry = await environment.createEntry(contentType.sys.id, { fields: {} })
   })

--- a/test/integration/comment-integration.ts
+++ b/test/integration/comment-integration.ts
@@ -20,8 +20,8 @@ describe('Comment Api', () => {
       name: 'Content Type',
       fields: [
         {
-          id: 'field',
-          name: 'Field',
+          id: 'firstField',
+          name: 'First Field',
           type: 'Text',
           required: false,
           localized: false,
@@ -148,7 +148,7 @@ describe('Comment Api', () => {
       expect(response.items.map((item) => item.sys.id)).to.include(id)
       expect(
         response.items.map((item) => (item.sys.parentEntity.sys as { ref: string }).ref)
-      ).to.include('field')
+      ).to.include('fields.firstField')
 
       // delete
       await plainClient.comment.delete({

--- a/test/integration/comment-integration.ts
+++ b/test/integration/comment-integration.ts
@@ -111,8 +111,8 @@ describe('Comment Api', () => {
       // check
       const response = await plainClient.comment.getMany(params)
       expect(response.items).to.be.an('array')
-      expect(response.items.find((item) => item.sys.id === replyComment.sys.id)).to.eq(
-        parentComment.sys.id
+      expect(response.items.find((item) => item.sys.id === replyComment.sys.id)?.body).to.eq(
+        commentBodyReply
       )
 
       // delete

--- a/test/integration/comment-integration.ts
+++ b/test/integration/comment-integration.ts
@@ -111,7 +111,7 @@ describe('Comment Api', () => {
       // check
       const response = await plainClient.comment.getMany(params)
       expect(response.items).to.be.an('array')
-      expect(response.items.find((item) => item.sys.id === replyComment.sys.id)).to.include(
+      expect(response.items.find((item) => item.sys.id === replyComment.sys.id)).to.eq(
         parentComment.sys.id
       )
 


### PR DESCRIPTION
Follow-up of https://github.com/contentful/contentful-management.js/pull/2023

* You can create replies by passing `parentCommentId`
* You can add a parent entity reference by passing `parentEntityReference`
* Types for deletion and updating now support content types and workflows
* Add `status` type
* Allow filtering by `status`

Do we want to deprecate the old `{ entryId: string }` syntax for creating comments?