### PR TITLE
fix: add test step for relase version [NONE]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,6 @@ jobs:
     steps:
       - with-workspace
       - run: npm run build
-      - run: npm run test:version
 
   lint:
     executor: docker-with-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
     steps:
       - with-workspace
       - run: npm run build
+      - run: npm run test:version
 
   lint:
     executor: docker-with-node

--- a/package.json
+++ b/package.json
@@ -43,11 +43,11 @@
     "test:prepush": "npm run build && npm run test:unit && npm run test:size",
     "prettier": "prettier --write '**/*.{jsx,js,ts,tsx}'",
     "prettier:check": "prettier --check '**/*.{jsx,js,ts,tsx}'",
-    "presemantic-release": "npm run build",
     "semantic-release": "semantic-release",
     "precommit": "npm run lint",
     "postpublish": "if [ \"$(git rev-parse --abbrev-ref HEAD)\" = master ] ; then npm run docs:publish && npm run clean ; else exit 0 ; fi",
-    "prepush": "npm run test:prepush"
+    "prepush": "npm run test:prepush",
+    "prepublishOnly": "npm run build && npm run test:version"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:integration": "BABEL_ENV=test babel-node --extensions .ts --extensions .js ./node_modules/.bin/mocha './test/integration/*.[tj]s' --config mocharc.js --require @babel/register  --reporter mocha-junit-reporter --reporter-options mochaFile=reports/integration-results.xml",
     "test:integration-watch": "BABEL_ENV=test babel-node --extensions .ts --extensions .js ./node_modules/.bin/mocha './test/integration/*.[tj]s' --config mocharc.js --watch --require @babel/register",
     "test:browser": "BABEL_ENV=test karma start karma.conf.local.js --log-level info",
+    "test:version": "grep -r \"0.0.0-determined-by-semantic-release\" ./dist > /dev/null && echo \"version 0.0.0-determined-by-semantic-release found in output\" && exit 1 || exit 0",
     "test:size": "bundlesize",
     "test:prepush": "npm run build && npm run test:unit && npm run test:size",
     "prettier": "prettier --write '**/*.{jsx,js,ts,tsx}'",


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

-->

## Summary
Since version `10.27.1` we are not baking in the right version anymore. The problem must have been introduced with [these](https://github.com/contentful/contentful-management.js/compare/v10.27.0...v10.27.1) changes.  

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

With the first commit, we added a new test script `npm run test:version` to check for the occurrence of `0.0.0-determined-by-semantic-release` in the build output ([example run](https://app.circleci.com/pipelines/github/contentful/contentful-management.js/8958/workflows/23ff7b85-1afd-4c01-a2e3-4468bbd4800a/jobs/27465)) 

In a second step, we execute the build step and the version test **AFTER** `npm` already set the right version in the package.json be using npm's the lifecycle hook `prepublishOnly`.  (similar to what we do for [contentful.js](https://github.com/contentful/contentful.js/blob/master/package.json#L67))

In the end - we will only know if this works AFTER this PR is merged :) 

<!-- Describe your changes in detail -->

## Motivation and Context
We found that out the the client doesn't know its version. 
