### PR TITLE
chore: add new param types to the plain client for upload [INTEG-1492]

### DIFF
--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -31,6 +31,7 @@ import {
   GetEnvironmentTemplateParams,
   BasicCursorPaginationOptions,
   EnvironmentTemplateParams,
+  GetSpaceEnvironmentUploadParams,
 } from '../common-types'
 import { ApiKeyProps, CreateApiKeyProps } from '../entities/api-key'
 import {
@@ -524,12 +525,12 @@ export type PlainClientAPI = {
     ): Promise<AssetKeyProps>
   }
   upload: {
-    get(params: OptionalDefaults<GetSpaceParams & { uploadId: string }>): Promise<any>
+    get(params: OptionalDefaults<GetSpaceEnvironmentUploadParams>): Promise<any>
     create(
-      params: OptionalDefaults<GetSpaceParams>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
       data: { file: string | ArrayBuffer | Stream }
     ): Promise<any>
-    delete(params: OptionalDefaults<GetSpaceParams & { uploadId: string }>): Promise<any>
+    delete(params: OptionalDefaults<GetSpaceEnvironmentUploadParams>): Promise<any>
   }
   locale: {
     get(


### PR DESCRIPTION
Here's the other PR that got merged in to update the upload create,get,delete operations to accept envIds. We forgot to do the plain client which is what this PR fixes https://github.com/contentful/contentful-management.js/pull/2030/files