### PR TITLE
[fix] Update axios to 1.6.2 to remove vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@contentful/rich-text-types": "^16.3.0",
         "@types/json-patch": "0.0.30",
-        "axios": "^1.4.0",
+        "axios": "^1.6.2",
         "contentful-sdk-core": "^8.1.0",
         "fast-copy": "^3.0.0",
         "lodash.isplainobject": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@contentful/rich-text-types": "^16.3.0",
     "@types/json-patch": "0.0.30",
-    "axios": "^1.4.0",
+    "axios": "^1.6.2",
     "contentful-sdk-core": "^8.1.0",
     "fast-copy": "^3.0.0",
     "lodash.isplainobject": "^4.0.6",


### PR DESCRIPTION
## Summary

See: https://github.com/contentful/contentful-management.js/issues/2054

## Description

Upgrade axios to latest available version

## Motivation and Context

Using contentful-management introduces a vulnerable transitive dependency into any user that uses this library. This fix will mitigate this.