### PR TITLE
fix: environment-scoped uploads

### DIFF
--- a/lib/adapters/REST/endpoints/asset.ts
+++ b/lib/adapters/REST/endpoints/asset.ts
@@ -154,7 +154,7 @@ export const createWithId: RestEndpoint<'Asset', 'createWithId'> = (
   )
 }
 
-export const createFromFiles: RestEndpoint<'Asset', 'createFromFiles'> = (
+export const createFromFiles: RestEndpoint<'Asset', 'createFromFiles'> = async (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { uploadTimeout?: number },
   data: Omit<AssetFileProp, 'sys'>
@@ -163,7 +163,7 @@ export const createFromFiles: RestEndpoint<'Asset', 'createFromFiles'> = (
 
   const { file } = data.fields
   return Promise.all(
-    Object.keys(file).map((locale) => {
+    Object.keys(file).map(async (locale) => {
       const { contentType, fileName } = file[locale]
 
       return createUpload(httpUpload, params, file[locale]).then((upload) => {
@@ -204,7 +204,7 @@ export const createFromFiles: RestEndpoint<'Asset', 'createFromFiles'> = (
 const ASSET_PROCESSING_CHECK_WAIT = 3000
 const ASSET_PROCESSING_CHECK_RETRIES = 10
 
-function checkIfAssetHasUrl(
+async function checkIfAssetHasUrl(
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { assetId: string },
   {
@@ -247,7 +247,7 @@ function checkIfAssetHasUrl(
   })
 }
 
-export const processForLocale: RestEndpoint<'Asset', 'processForLocale'> = (
+export const processForLocale: RestEndpoint<'Asset', 'processForLocale'> = async (
   http: AxiosInstance,
   {
     asset,
@@ -292,7 +292,7 @@ export const processForLocale: RestEndpoint<'Asset', 'processForLocale'> = (
     })
 }
 
-export const processForAllLocales: RestEndpoint<'Asset', 'processForAllLocales'> = (
+export const processForAllLocales: RestEndpoint<'Asset', 'processForAllLocales'> = async (
   http: AxiosInstance,
   {
     asset,

--- a/lib/adapters/REST/endpoints/upload.ts
+++ b/lib/adapters/REST/endpoints/upload.ts
@@ -1,13 +1,25 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import { Stream } from 'stream'
-import { GetSpaceParams } from '../../../common-types'
+import { GetSpaceEnvironmentParams, GetSpaceEnvironmentUploadParams } from '../../../common-types'
 import { getUploadHttpClient } from '../../../upload-http-client'
 import { RestEndpoint } from '../types'
 import * as raw from './raw'
 
+const getBaseUploadUrl = (params: GetSpaceEnvironmentParams) => {
+  const spacePath = `/spaces/${params.spaceId}/uploads`
+  const environmentPath = `/spaces/${params.spaceId}/environments/${params.environmentId}/uploads`
+  const path = params.environmentId ? environmentPath : spacePath
+  return path
+}
+
+const getEntityUploadUrl = (params: GetSpaceEnvironmentUploadParams) => {
+  const path = getBaseUploadUrl(params)
+  return path + `/${params.uploadId}`
+}
+
 export const create: RestEndpoint<'Upload', 'create'> = (
   http: AxiosInstance,
-  params: GetSpaceParams,
+  params: GetSpaceEnvironmentParams,
   data: { file: string | ArrayBuffer | Stream }
 ) => {
   const httpUpload = getUploadHttpClient(http)
@@ -16,7 +28,8 @@ export const create: RestEndpoint<'Upload', 'create'> = (
   if (!file) {
     return Promise.reject(new Error('Unable to locate a file to upload.'))
   }
-  return raw.post(httpUpload, `/spaces/${params.spaceId}/uploads`, file, {
+  const path = getBaseUploadUrl(params)
+  return raw.post(httpUpload, path, file, {
     headers: {
       'Content-Type': 'application/octet-stream',
     },
@@ -25,18 +38,18 @@ export const create: RestEndpoint<'Upload', 'create'> = (
 
 export const del: RestEndpoint<'Upload', 'delete'> = (
   http: AxiosInstance,
-  params: GetSpaceParams & { uploadId: string }
+  params: GetSpaceEnvironmentUploadParams
 ) => {
   const httpUpload = getUploadHttpClient(http)
-
-  return raw.del(httpUpload, `/spaces/${params.spaceId}/uploads/${params.uploadId}`)
+  const path = getEntityUploadUrl(params)
+  return raw.del(httpUpload, path)
 }
 
 export const get: RestEndpoint<'Upload', 'get'> = (
   http: AxiosInstance,
-  params: GetSpaceParams & { uploadId: string }
+  params: GetSpaceEnvironmentUploadParams
 ) => {
   const httpUpload = getUploadHttpClient(http)
-
-  return raw.get(httpUpload, `/spaces/${params.spaceId}/uploads/${params.uploadId}`)
+  const path = getEntityUploadUrl(params)
+  return raw.get(httpUpload, path)
 }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1668,13 +1668,13 @@ export type MRActions = {
     update: { params: GetUIConfigParams; payload: UIConfigProps; return: UIConfigProps }
   }
   Upload: {
-    get: { params: GetSpaceParams & { uploadId: string }; return: any }
+    get: { params: GetSpaceEnvironmentUploadParams; return: any }
     create: {
-      params: GetSpaceParams
+      params: GetSpaceEnvironmentParams
       payload: { file: string | ArrayBuffer | Stream }
       return: any
     }
-    delete: { params: GetSpaceParams & { uploadId: string }; return: any }
+    delete: { params: GetSpaceEnvironmentUploadParams; return: any }
   }
   Usage: {
     getManyForSpace: {
@@ -1884,6 +1884,7 @@ export type GetSnapshotForContentTypeParams = GetSpaceEnvironmentParams & { cont
 export type GetSnapshotForEntryParams = GetSpaceEnvironmentParams & { entryId: string }
 export type GetSpaceEnvAliasParams = GetSpaceParams & { environmentAliasId: string }
 export type GetSpaceEnvironmentParams = { spaceId: string; environmentId: string }
+export type GetSpaceEnvironmentUploadParams = GetSpaceEnvironmentParams & { uploadId: string }
 export type GetSpaceMembershipProps = GetSpaceParams & { spaceMembershipId: string }
 export type GetSpaceParams = { spaceId: string }
 export type GetTagParams = GetSpaceEnvironmentParams & { tagId: string }

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -1127,6 +1127,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
         action: 'get',
         params: {
           spaceId: raw.sys.space.sys.id,
+          environmentId: raw.sys.id,
           uploadId: id,
         },
       }).then((data) => wrapUpload(makeRequest, data))
@@ -1157,6 +1158,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
         action: 'create',
         params: {
           spaceId: raw.sys.space.sys.id,
+          environmentId: raw.sys.id,
         },
         payload: data,
       }).then((data) => wrapUpload(makeRequest, data))

--- a/lib/entities/upload.ts
+++ b/lib/entities/upload.ts
@@ -43,6 +43,7 @@ function createUploadApi(makeRequest: MakeRequest) {
         action: 'delete',
         params: {
           spaceId: raw.sys.space.sys.id,
+          environmentId: raw.sys.id,
           uploadId: raw.sys.id,
         },
       })

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -31,6 +31,7 @@ import {
   GetEnvironmentTemplateParams,
   BasicCursorPaginationOptions,
   EnvironmentTemplateParams,
+  GetSpaceEnvironmentUploadParams,
 } from '../common-types'
 import { ApiKeyProps, CreateApiKeyProps } from '../entities/api-key'
 import {
@@ -524,12 +525,12 @@ export type PlainClientAPI = {
     ): Promise<AssetKeyProps>
   }
   upload: {
-    get(params: OptionalDefaults<GetSpaceParams & { uploadId: string }>): Promise<any>
+    get(params: OptionalDefaults<GetSpaceEnvironmentUploadParams>): Promise<any>
     create(
-      params: OptionalDefaults<GetSpaceParams>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
       data: { file: string | ArrayBuffer | Stream }
     ): Promise<any>
-    delete(params: OptionalDefaults<GetSpaceParams & { uploadId: string }>): Promise<any>
+    delete(params: OptionalDefaults<GetSpaceEnvironmentUploadParams>): Promise<any>
   }
   locale: {
     get(

--- a/test/integration/asset-integration.js
+++ b/test/integration/asset-integration.js
@@ -99,8 +99,7 @@ describe('Asset api', function () {
       await unarchivedAsset.delete()
     })
 
-    // Skip because this is a flakey test
-    test.skip('Create and process asset with multiple locales', async () => {
+    test('Create and process asset with multiple locales', async () => {
       const asset = await environment.createAsset({
         fields: {
           title: { 'en-US': 'this is the title' },
@@ -124,8 +123,7 @@ describe('Asset api', function () {
       expect(processedAsset.fields.file['de-DE'].url, 'file de-DE was uploaded').to.be.ok
     })
 
-    // Skip because this is a flakey test
-    test.skip('Upload and process asset with multiple locales', async () => {
+    test('Upload and process asset from files with multiple locales', async () => {
       const asset = await environment.createAssetFromFiles({
         fields: {
           title: { 'en-US': 'SVG upload test' },
@@ -144,6 +142,30 @@ describe('Asset api', function () {
         },
       })
 
+      const processedAsset = await asset.processForAllLocales({ processingCheckWait: 5000 })
+      expect(processedAsset.fields.file['en-US'].url, 'file en-US was uploaded').to.be.ok
+      expect(processedAsset.fields.file['de-DE'].url, 'file de-DE was uploaded').to.be.ok
+    })
+
+    test('Upload and process asset from files with multiple locales in non-master environment', async () => {
+      environment = await space.createEnvironment({ name: 'Asset Processing Non-Master' })
+      const asset = await environment.createAssetFromFiles({
+        fields: {
+          title: { 'en-US': 'SVG upload test' },
+          file: {
+            'en-US': {
+              contentType: 'image/svg+xml',
+              fileName: 'blue-square.svg',
+              file: '<svg xmlns="http://www.w3.org/2000/svg"><path fill="blue" d="M50 50h150v50H50z"/></svg>',
+            },
+            'de-DE': {
+              contentType: 'image/svg+xml',
+              fileName: 'red-square.svg',
+              file: '<svg xmlns="http://www.w3.org/2000/svg"><path fill="red" d="M50 50h150v50H50z"/></svg>',
+            },
+          },
+        },
+      })
       const processedAsset = await asset.processForAllLocales({ processingCheckWait: 5000 })
       expect(processedAsset.fields.file['en-US'].url, 'file en-US was uploaded').to.be.ok
       expect(processedAsset.fields.file['de-DE'].url, 'file de-DE was uploaded').to.be.ok

--- a/test/integration/asset-integration.js
+++ b/test/integration/asset-integration.js
@@ -99,7 +99,8 @@ describe('Asset api', function () {
       await unarchivedAsset.delete()
     })
 
-    test('Create and process asset with multiple locales', async () => {
+    // Skip because this is a flakey test
+    test.skip('Create and process asset with multiple locales', async () => {
       const asset = await environment.createAsset({
         fields: {
           title: { 'en-US': 'this is the title' },
@@ -123,7 +124,8 @@ describe('Asset api', function () {
       expect(processedAsset.fields.file['de-DE'].url, 'file de-DE was uploaded').to.be.ok
     })
 
-    test('Upload and process asset with multiple locales', async () => {
+    // Skip because this is a flakey test
+    test.skip('Upload and process asset with multiple locales', async () => {
       const asset = await environment.createAssetFromFiles({
         fields: {
           title: { 'en-US': 'SVG upload test' },

--- a/test/integration/webhook-integration.js
+++ b/test/integration/webhook-integration.js
@@ -28,7 +28,7 @@ describe('Webhook Api', function () {
     const id = generateRandomId('webhook')
     return space.createWebhookWithId(id, {
       name: 'testwebhook',
-      url: 'http://localhost:8080',
+      url: 'https://example.com',
       topics: ['Entry.publish']
     })
       .then((webhook) => {
@@ -50,7 +50,7 @@ describe('Webhook Api', function () {
     return space
       .createWebhook({
         name: 'testname',
-        url: 'http://localhost:8080',
+        url: 'https://example.com',
         topics: ['Entry.publish'],
       })
       .then((webhook) => {
@@ -68,7 +68,7 @@ describe('Webhook Api', function () {
     return space
       .createWebhook({
         name: 'testname',
-        url: 'http://localhost:8080',
+        url: 'https://example.com',
         topics: ['Entry.publish'],
         active: false,
       })

--- a/test/integration/webhook-integration.js
+++ b/test/integration/webhook-integration.js
@@ -28,7 +28,7 @@ describe('Webhook Api', function () {
     const id = generateRandomId('webhook')
     return space.createWebhookWithId(id, {
       name: 'testwebhook',
-      url: 'https://example.com',
+      url: 'http://localhost:8080',
       topics: ['Entry.publish']
     })
       .then((webhook) => {
@@ -50,7 +50,7 @@ describe('Webhook Api', function () {
     return space
       .createWebhook({
         name: 'testname',
-        url: 'https://example.com',
+        url: 'http://localhost:8080',
         topics: ['Entry.publish'],
       })
       .then((webhook) => {
@@ -68,7 +68,7 @@ describe('Webhook Api', function () {
     return space
       .createWebhook({
         name: 'testname',
-        url: 'https://example.com',
+        url: 'http://localhost:8080',
         topics: ['Entry.publish'],
         active: false,
       })

--- a/test/unit/adapters/REST/endpoints/upload-test.js
+++ b/test/unit/adapters/REST/endpoints/upload-test.js
@@ -11,7 +11,34 @@ function setup(promise, params = {}) {
 }
 
 describe('Rest Upload', async () => {
-  test('API call createUpload', async () => {
+  test('API call createUpload with envId', async () => {
+    const { adapterMock, httpMock } = setup(Promise.resolve({}))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Upload',
+        action: 'create',
+        params: {
+          spaceId: 'id',
+          environmentId: 'envId',
+        },
+        payload: {
+          contentType: 'image/svg',
+          fileName: 'filename.svg',
+          file: '<svg><path fill="red" d="M50 50h150v50H50z"/></svg>',
+        },
+      })
+      .then(() => {
+        expect(httpMock.post.args[0][0]).equals('/spaces/id/environments/envId/uploads')
+        expect(httpMock.post.args[0][2].headers['Content-Type']).equals('application/octet-stream')
+        expect(httpMock.post.args[0][1]).equals(
+          '<svg><path fill="red" d="M50 50h150v50H50z"/></svg>',
+          'uploads file to upload endpoint'
+        )
+      })
+  })
+
+  test('API call createUpload without envId', async () => {
     const { adapterMock, httpMock } = setup(Promise.resolve({}))
 
     return adapterMock

--- a/test/unit/entities/upload-test.js
+++ b/test/unit/entities/upload-test.js
@@ -15,7 +15,7 @@ function setup(promise) {
   }
 }
 
-describe('Entity TeamSpaceMembership', () => {
+describe('Entity Uploads', () => {
   test('Upload is wrapped', async () => {
     return entityWrappedTest(setup, {
       wrapperMethod: wrapUpload,


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

(Re)introduce environment scoped uploads.

## Description

This PR restores environment scope uploads that were introduced here https://github.com/contentful/contentful-management.js/pull/2030 and reverted here https://github.com/contentful/contentful-management.js/pull/2084 

The issue with the original PR was raised here https://github.com/contentful/contentful-management.js/issues/2075 . Further investigation revealed that the problem was in fact an issue with the backend asset processing service. This service was missing a key piece of logic to make it aware that the upload passed for processing could be in a specific environment instead of at the space level. The SDK change revealed that backend issue when it exposed environment scoping to uploads.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
