### PR TITLE
fix: add environment to upload props

### DIFF
--- a/lib/entities/upload.ts
+++ b/lib/entities/upload.ts
@@ -7,7 +7,7 @@ export type UploadProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { space: SysLink }
+  sys: MetaSysProps & { space: SysLink; environment: SysLink }
 }
 
 export interface Upload extends UploadProps, DefaultElements<UploadProps> {

--- a/lib/entities/upload.ts
+++ b/lib/entities/upload.ts
@@ -7,7 +7,7 @@ export type UploadProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { space: SysLink; environment: SysLink }
+  sys: MetaSysProps & { space: SysLink; environment?: SysLink }
 }
 
 export interface Upload extends UploadProps, DefaultElements<UploadProps> {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary


## Description

* Include environment as optional parameter in `UploadProps`

## Motivation and Context


In https://github.com/contentful/contentful-management.js/pull/2088 we added support for environment-scoped uploads. When an environment id is provided, the upload created is scoped to that environment. When no environment is created, the upload remains at the space level.

We overlooked one type change, however, which is that the `Upload` object returned from the API will have the environment link in the sys if it has been explicitly environment scoped.

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
