### PR TITLE
fix: omitAndDelete function [PHX-2612]

### DIFF
--- a/lib/methods/content-type.ts
+++ b/lib/methods/content-type.ts
@@ -48,6 +48,14 @@ export const omitAndDeleteField = (
       })
     })
     .then((newContentType) => {
+      return makeRequest({
+        entityType: 'ContentType',
+        action: 'publish',
+        params,
+        payload: newContentType,
+      })
+    })
+    .then((newContentType) => {
       return findAndUpdateField(newContentType, fieldId, 'deleted')
     })
     .then((newContentType) => {

--- a/test/integration/content-type-integration.js
+++ b/test/integration/content-type-integration.js
@@ -97,48 +97,53 @@ describe('ContentType Api', async function () {
             ]
             return publishedContentType
               .update() // update with fields
-              .then((updatedContentType) => {
-                expect(updatedContentType.isUpdated(), 'contentType is updated').to.be.ok
-                expect(updatedContentType.fields[0].id).equals('field', 'field id')
-                expect(updatedContentType.fields[1].id).equals('field2delete', 'field2delete id')
-                expect(updatedContentType.fields[2].id).equals(
-                  'multiRefXSpace',
-                  'multiRefXSpace id'
-                )
-                return updatedContentType
-                  .omitAndDeleteField('field2delete') // omit and delete field
-                  .then((deletedFieldContentType) => {
-                    expect(
-                      deletedFieldContentType.fields.filter((field) => field.id === 'field2delete')
-                    ).length(0, 'field should be deleted')
-                    expect(
-                      deletedFieldContentType.getEditorInterface,
-                      'updatedContentType.getEditorInterface'
-                    ).to.be.ok
-                    return deletedFieldContentType
-                      .publish() // publish changes
-                      .then((publishedContentType) => {
-                        return publishedContentType
-                          .getEditorInterface() // get editorInterface
-                          .then((editorInterface) => {
-                            expect(editorInterface.controls, 'editor interface controls').to.be.ok
-                            expect(editorInterface.sys, 'editor interface sys').to.be.ok
-                            return editorInterface
-                              .update() // update editor interface
-                              .then(() => {
-                                return updatedContentType
-                                  .unpublish() // unpublish contentType
-                                  .then((unpublishedContentType) => {
-                                    expect(
-                                      unpublishedContentType.isDraft(),
-                                      'contentType is back in draft'
-                                    ).to.be.ok
-                                    return unpublishedContentType.delete() // delete contentType
-                                  })
-                              })
-                          })
-                      })
-                  })
+              .then((tryContentType) => {
+                expect(tryContentType.isUpdated(), 'contentType is updated').to.be.ok
+                return tryContentType.publish().then((updatedContentType) => {
+                  expect(updatedContentType.isUpdated(), 'contentType is updated').to.not.be.ok
+                  expect(updatedContentType.fields[0].id).equals('field', 'field id')
+                  expect(updatedContentType.fields[1].id).equals('field2delete', 'field2delete id')
+                  expect(updatedContentType.fields[2].id).equals(
+                    'multiRefXSpace',
+                    'multiRefXSpace id'
+                  )
+                  return updatedContentType
+                    .omitAndDeleteField('field2delete') // omit and delete field
+                    .then((deletedFieldContentType) => {
+                      expect(
+                        deletedFieldContentType.fields.filter(
+                          (field) => field.id === 'field2delete'
+                        )
+                      ).length(0, 'field should be deleted')
+                      expect(
+                        deletedFieldContentType.getEditorInterface,
+                        'updatedContentType.getEditorInterface'
+                      ).to.be.ok
+                      return deletedFieldContentType
+                        .publish() // publish changes
+                        .then((publishedContentType) => {
+                          return publishedContentType
+                            .getEditorInterface() // get editorInterface
+                            .then((editorInterface) => {
+                              expect(editorInterface.controls, 'editor interface controls').to.be.ok
+                              expect(editorInterface.sys, 'editor interface sys').to.be.ok
+                              return editorInterface
+                                .update() // update editor interface
+                                .then(() => {
+                                  return updatedContentType
+                                    .unpublish() // unpublish contentType
+                                    .then((unpublishedContentType) => {
+                                      expect(
+                                        unpublishedContentType.isDraft(),
+                                        'contentType is back in draft'
+                                      ).to.be.ok
+                                      return unpublishedContentType.delete() // delete contentType
+                                    })
+                                })
+                            })
+                        })
+                    })
+                })
               })
           })
       })


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Fix content type omitAndDelete function

## Description

Turned out that if a field is published the omitted step also needs to be published in order to delete the field finally.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Customers are reporting that this function doesn't work under certain circumstances.

## Checklist (check all before merging)

- [X] Both unit and integration tests are passing
- [X] There are no breaking changes
- [X] Changes are reflected in the documentation
