### PR TITLE
feat: add `getRoles` for organization [CFCX-1226]

### DIFF
--- a/lib/adapters/REST/endpoints/role.ts
+++ b/lib/adapters/REST/endpoints/role.ts
@@ -2,7 +2,12 @@ import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
-import { CollectionProp, GetSpaceParams, QueryParams } from '../../../common-types'
+import {
+  CollectionProp,
+  GetOrganizationParams,
+  GetSpaceParams,
+  QueryParams,
+} from '../../../common-types'
 import { CreateRoleProps, RoleProps } from '../../../entities/role'
 import { RestEndpoint } from '../types'
 import * as raw from './raw'
@@ -20,6 +25,15 @@ export const getMany: RestEndpoint<'Role', 'getMany'> = (
   params: GetSpaceParams & QueryParams
 ) => {
   return raw.get<CollectionProp<RoleProps>>(http, `/spaces/${params.spaceId}/roles`, {
+    params: normalizeSelect(params.query),
+  })
+}
+
+export const getManyForOrganization: RestEndpoint<'Role', 'getManyForOrganization'> = (
+  http: AxiosInstance,
+  params: GetOrganizationParams & QueryParams
+) => {
+  return raw.get<CollectionProp<RoleProps>>(http, `/organizations/${params.organizationId}/roles`, {
     params: normalizeSelect(params.query),
   })
 }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -550,6 +550,7 @@ type MRInternal<UA extends boolean> = {
 
   (opts: MROpts<'Role', 'get', UA>): MRReturn<'Role', 'get'>
   (opts: MROpts<'Role', 'getMany', UA>): MRReturn<'Role', 'getMany'>
+  (opts: MROpts<'Role', 'getManyForOrganization', UA>): MRReturn<'Role', 'getManyForOrganization'>
   (opts: MROpts<'Role', 'create', UA>): MRReturn<'Role', 'create'>
   (opts: MROpts<'Role', 'createWithId', UA>): MRReturn<'Role', 'createWithId'>
   (opts: MROpts<'Role', 'update', UA>): MRReturn<'Role', 'update'>
@@ -1459,6 +1460,10 @@ export type MRActions = {
   Role: {
     get: { params: GetSpaceParams & { roleId: string }; return: RoleProps }
     getMany: { params: GetSpaceParams & QueryParams; return: CollectionProp<RoleProps> }
+    getManyForOrganization: {
+      params: GetOrganizationParams & QueryParams
+      return: CollectionProp<RoleProps>
+    }
     create: {
       params: GetSpaceParams
       payload: CreateRoleProps

--- a/lib/create-organization-api.ts
+++ b/lib/create-organization-api.ts
@@ -41,6 +41,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
   const { wrapAppKey, wrapAppKeyCollection } = entities.appKey
   const { wrapAppDetails } = entities.appDetails
   const { wrapAppAction, wrapAppActionCollection } = entities.appAction
+  const { wrapRoleCollection } = entities.role
 
   return {
     /**
@@ -485,6 +486,30 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
         },
         payload: data,
       }).then((data) => wrapOrganizationInvitation(makeRequest, data))
+    },
+    /**
+     * Gets a collection of Roles
+     * @return Promise for a collection of Roles
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getRoles())
+     * .then((response) => console.log(response.items))
+     * .catch(console.error)
+     * ```
+     */
+    getRoles(query: QueryOptions = {}) {
+      const raw = this.toPlainObject() as OrganizationProp
+      return makeRequest({
+        entityType: 'Role',
+        action: 'getManyForOrganization',
+        params: { organizationId: raw.sys.id, query: createRequestConfig({ query }).params },
+      }).then((data) => wrapRoleCollection(makeRequest, data))
     },
     /**
      * Creates an app definition

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -625,6 +625,9 @@ export type PlainClientAPI = {
     getMany(
       params: OptionalDefaults<GetSpaceParams & QueryParams>
     ): Promise<CollectionProp<RoleProps>>
+    getManyForOrganization(
+      params: OptionalDefaults<GetOrganizationParams & QueryParams>
+    ): Promise<CollectionProp<RoleProps>>
     create(
       params: OptionalDefaults<GetSpaceParams>,
       data: CreateRoleProps,

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -309,6 +309,7 @@ export const createPlainClient = (
     role: {
       get: wrap(wrapParams, 'Role', 'get'),
       getMany: wrap(wrapParams, 'Role', 'getMany'),
+      getManyForOrganization: wrap(wrapParams, 'Role', 'getManyForOrganization'),
       create: wrap(wrapParams, 'Role', 'create'),
       createWithId: wrap(wrapParams, 'Role', 'createWithId'),
       update: wrap(wrapParams, 'Role', 'update'),

--- a/test/integration/role-integration.js
+++ b/test/integration/role-integration.js
@@ -1,4 +1,4 @@
-import { initClient, createTestSpace, generateRandomId } from '../helpers'
+import { initClient, createTestSpace, generateRandomId, getTestOrganization } from '../helpers'
 import { after, before, describe, test } from 'mocha'
 import { expect } from 'chai'
 
@@ -25,9 +25,11 @@ const roleDefinition = {
 }
 
 describe('Role Api', function () {
+  let org
   let space
 
   before(async () => {
+    org = await getTestOrganization()
     space = await createTestSpace(initClient(), 'Role')
   })
 
@@ -39,6 +41,13 @@ describe('Role Api', function () {
 
   test('Gets roles', async () => {
     return space.getRoles().then((response) => {
+      expect(response.sys, 'sys').ok
+      expect(response.items, 'fields').ok
+    })
+  })
+
+  test('Gets roles for organization', async () => {
+    return org.getRoles().then((response) => {
       expect(response.sys, 'sys').ok
       expect(response.items, 'fields').ok
     })


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

Add method to query all roles of an organization (`/organization/:orgId/roles`)

## Description

Plain: `client.roles.getManyForOrganization(...)`
Nested: `organization.getRoles(...)`

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [x] Added an integration test for the new method
- [ ] The new method is added to the documentation
