### PR TITLE
feat: add `getSpaces` for organization

### DIFF
--- a/lib/adapters/REST/endpoints/space.ts
+++ b/lib/adapters/REST/endpoints/space.ts
@@ -2,7 +2,12 @@ import { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import { SetOptional } from 'type-fest'
-import { CollectionProp, GetSpaceParams, QueryParams } from '../../../common-types'
+import {
+  CollectionProp,
+  GetOrganizationParams,
+  GetSpaceParams,
+  QueryParams,
+} from '../../../common-types'
 import { SpaceProps } from '../../../entities/space'
 import { RestEndpoint } from '../types'
 import * as raw from './raw'
@@ -15,6 +20,14 @@ export const getMany: RestEndpoint<'Space', 'getMany'> = (
   params: QueryParams
 ) =>
   raw.get<CollectionProp<SpaceProps>>(http, `/spaces`, {
+    params: params.query,
+  })
+
+export const getManyForOrganization: RestEndpoint<'Space', 'getManyForOrganization'> = (
+  http: AxiosInstance,
+  params: GetOrganizationParams & QueryParams
+) =>
+  raw.get<CollectionProp<SpaceProps>>(http, `/organizations/${params.organizationId}/spaces`, {
     params: params.query,
   })
 

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -572,6 +572,7 @@ type MRInternal<UA extends boolean> = {
 
   (opts: MROpts<'Space', 'get', UA>): MRReturn<'Space', 'get'>
   (opts: MROpts<'Space', 'getMany', UA>): MRReturn<'Space', 'getMany'>
+  (opts: MROpts<'Space', 'getManyForOrganization', UA>): MRReturn<'Space', 'getManyForOrganization'>
   (opts: MROpts<'Space', 'create', UA>): MRReturn<'Space', 'create'>
   (opts: MROpts<'Space', 'update', UA>): MRReturn<'Space', 'update'>
   (opts: MROpts<'Space', 'delete', UA>): MRReturn<'Space', 'delete'>
@@ -1523,6 +1524,10 @@ export type MRActions = {
   Space: {
     get: { params: GetSpaceParams; return: SpaceProps }
     getMany: { params: QueryParams; return: CollectionProp<SpaceProps> }
+    getManyForOrganization: {
+      params: GetOrganizationParams & QueryParams
+      return: CollectionProp<SpaceProps>
+    }
     create: {
       params: { organizationId?: string }
       payload: Omit<SpaceProps, 'sys'>

--- a/lib/create-organization-api.ts
+++ b/lib/create-organization-api.ts
@@ -42,8 +42,37 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
   const { wrapAppDetails } = entities.appDetails
   const { wrapAppAction, wrapAppActionCollection } = entities.appAction
   const { wrapRoleCollection } = entities.role
+  const { wrapSpaceCollection } = entities.space
 
   return {
+    /**
+     * Gets a collection of spaces in the organization
+     * @param query - Object with search parameters. Check the <a href="https://www.contentful.com/developers/docs/javascript/tutorials/using-js-cda-sdk/#retrieving-entries-with-search-parameters">JS SDK tutorial</a> and the <a href="https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters">REST API reference</a> for more details.
+     * @return Promise a collection of Spaces in the organization
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<organization_id>')
+     * .then((organization) => organization.getSpaces())
+     * .then((spaces) => console.log(spaces))
+     * .catch(console.error)
+     * ```
+     */
+    getSpaces(query: QueryOptions = {}) {
+      const raw = this.toPlainObject() as OrganizationProp
+      return makeRequest({
+        entityType: 'Space',
+        action: 'getManyForOrganization',
+        params: {
+          organizationId: raw.sys.id,
+          query: createRequestConfig({ query }).params,
+        },
+      }).then((data) => wrapSpaceCollection(makeRequest, data))
+    },
+
     /**
      * Gets a User
      * @return Promise for a User
@@ -79,7 +108,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      *
      * client.getOrganization('<organization_id>')
      * .then((organization) => organization.getUsers())
-     * .then((user) => console.log(user))
+     * .then((users) => console.log(users))
      * .catch(console.error)
      * ```
      */

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -194,6 +194,9 @@ export type PlainClientAPI = {
   space: {
     get(params: OptionalDefaults<GetSpaceParams>): Promise<SpaceProps>
     getMany(params: OptionalDefaults<QueryParams>): Promise<CollectionProp<SpaceProps>>
+    getManyForOrganization(
+      params: OptionalDefaults<GetOrganizationParams & QueryParams>
+    ): Promise<CollectionProp<SpaceProps>>
     create(
       params: OptionalDefaults<{ organizationId?: string }>,
       payload: Omit<SpaceProps, 'sys'>,

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -111,6 +111,7 @@ export const createPlainClient = (
     space: {
       get: wrap(wrapParams, 'Space', 'get'),
       getMany: wrap(wrapParams, 'Space', 'getMany'),
+      getManyForOrganization: wrap(wrapParams, 'Space', 'getManyForOrganization'),
       update: wrap(wrapParams, 'Space', 'update'),
       delete: wrap(wrapParams, 'Space', 'delete'),
       create: wrap(wrapParams, 'Space', 'create'),

--- a/test/integration/space-integration.js
+++ b/test/integration/space-integration.js
@@ -1,0 +1,18 @@
+import { before, describe, test } from 'mocha'
+import { expect } from 'chai'
+import { getTestOrganization } from '../helpers'
+
+describe('Space api', function () {
+  let organization
+
+  before(async () => {
+    organization = await getTestOrganization()
+  })
+
+  test('Gets organization spaces', async () => {
+    return organization.getUsers().then((response) => {
+      expect(response.sys, 'sys').ok
+      expect(response.items, 'items').ok
+    })
+  })
+})


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Adds `client.spaces.getManyForOrganization` (plain) and `organization.getSpaces()` (nested)

Required for requests in the Web App

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->



## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Currently, only the `/spaces` endpoint is implemented. It's not possible to query the spaces of a specific org.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [x] Added an integration test for the new method
- [ ] The new method is added to the documentation
