### PR TITLE
feat: add support for GET published asset endpoint []

### DIFF
--- a/lib/adapters/REST/endpoints/asset.ts
+++ b/lib/adapters/REST/endpoints/asset.ts
@@ -32,6 +32,22 @@ export const get: RestEndpoint<'Asset', 'get'> = (
   )
 }
 
+export const getPublished: RestEndpoint<'Asset', 'getPublished'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams & QueryParams,
+  rawData?: unknown,
+  headers?: RawAxiosRequestHeaders
+) => {
+  return raw.get<CollectionProp<AssetProps>>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/public/assets`,
+    {
+      params: normalizeSelect(params.query),
+      headers: headers ? { ...headers } : undefined,
+    }
+  )
+}
+
 export const getMany: RestEndpoint<'Asset', 'getMany'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & QueryParams,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -355,6 +355,7 @@ type MRInternal<UA extends boolean> = {
   >
 
   (opts: MROpts<'Asset', 'getMany', UA>): MRReturn<'Asset', 'getMany'>
+  (opts: MROpts<'Asset', 'getPublished', UA>): MRReturn<'Asset', 'getPublished'>
   (opts: MROpts<'Asset', 'get', UA>): MRReturn<'Asset', 'get'>
   (opts: MROpts<'Asset', 'update', UA>): MRReturn<'Asset', 'update'>
   (opts: MROpts<'Asset', 'delete', UA>): MRReturn<'Asset', 'delete'>
@@ -933,6 +934,11 @@ export type MRActions = {
     }
   }
   Asset: {
+    getPublished: {
+      params: GetSpaceEnvironmentParams & QueryParams
+      headers?: RawAxiosRequestHeaders
+      return: CollectionProp<AssetProps>
+    }
     getMany: {
       params: GetSpaceEnvironmentParams & QueryParams
       headers?: RawAxiosRequestHeaders

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -941,6 +941,36 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
       }).then((data) => wrapAssetCollection(makeRequest, data))
     },
     /**
+     * Gets a collection of published Assets
+     * @param query - Object with search parameters. Check the <a href="https://www.contentful.com/developers/docs/javascript/tutorials/using-js-cda-sdk/#retrieving-entries-with-search-parameters">JS SDK tutorial</a> and the <a href="https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters">REST API reference</a> for more details.
+     * @return Promise for a collection of published Assets
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getSpace('<space_id>')
+     * .then((space) => space.getEnvironment('<environment-id>'))
+     * .then((environment) => environment.getPublishedAssets())
+     * .then((response) => console.log(response.items))
+     * .catch(console.error)
+     * ```
+     */
+    getPublishedAssets(query: QueryOptions = {}) {
+      const raw = this.toPlainObject() as EnvironmentProps
+      return makeRequest({
+        entityType: 'Asset',
+        action: 'getPublished',
+        params: {
+          spaceId: raw.sys.space.sys.id,
+          environmentId: raw.sys.id,
+          query: createRequestConfig({ query: query }).params,
+        },
+      }).then((data) => wrapAssetCollection(makeRequest, data))
+    },
+    /**
      * Creates a Asset. After creation, call asset.processForLocale or asset.processForAllLocales to start asset processing.
      * @param data - Object representation of the Asset to be created. Note that the field object should have an upload property on asset creation, which will be removed and replaced with an url property when processing is finished.
      * @return Promise for the newly created Asset

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -465,6 +465,11 @@ export type PlainClientAPI = {
     ): Promise<EntryReferenceProps>
   }
   asset: {
+    getPublished(
+      params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>,
+      rawData?: unknown,
+      headers?: RawAxiosRequestHeaders
+    ): Promise<CollectionProp<AssetProps>>
     getMany(
       params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>,
       rawData?: unknown,

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -206,6 +206,7 @@ export const createPlainClient = (
       references: wrap(wrapParams, 'Entry', 'references'),
     },
     asset: {
+      getPublished: wrap(wrapParams, 'Asset', 'getPublished'),
       getMany: wrap(wrapParams, 'Asset', 'getMany'),
       get: wrap(wrapParams, 'Asset', 'get'),
       update: wrap(wrapParams, 'Asset', 'update'),

--- a/test/integration/asset-integration.ts
+++ b/test/integration/asset-integration.ts
@@ -4,11 +4,12 @@ const TEST_IMAGE_SOURCE_URL =
 import { expect } from 'chai'
 import { after, before, describe, test } from 'mocha'
 import { initClient, getDefaultSpace, createTestSpace } from '../helpers'
+import type { Environment, Space } from '../../lib/export-types'
 
 describe('Asset api', function () {
   describe('Read', () => {
-    let space
-    let environment
+    let space: Space
+    let environment: Environment
 
     before(async () => {
       space = await getDefaultSpace()
@@ -34,6 +35,12 @@ describe('Asset api', function () {
 
     test('Gets assets', async () => {
       return environment.getAssets().then((response) => {
+        expect(response.items, 'items').to.be.ok
+      })
+    })
+
+    test('Gets published assets', async () => {
+      return environment.getPublishedAssets().then((response) => {
         expect(response.items, 'items').to.be.ok
       })
     })


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

The GET endpoint for published assets was not yet added to the client.


## Motivation and Context

https://www.contentful.com/developers/docs/references/content-management-api/#/reference/assets/published-assets-collection (JavaScript)

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
