### PR TITLE
fix: renames function to contentful function [MONET-1720]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -143,7 +143,7 @@ import {
   ValidateEnvironmentTemplateInstallationProps,
   EnvironmentTemplateValidationProps,
 } from './entities/environment-template-installation'
-import { FunctionProps } from './entities/function'
+import { ContentfulFunctionProps } from './entities/contentful-function'
 import {
   AppEventSubscriptionProps,
   CreateAppEventSubscriptionProps,
@@ -1100,10 +1100,10 @@ export type MRActions = {
       return: EditorInterfaceProps
     }
   }
-  Function: {
+  ContentfulFunction: {
     getMany: {
       params: GetAppDefinitionParams & QueryParams
-      return: CollectionProp<FunctionProps>
+      return: CollectionProp<ContentfulFunctionProps>
     }
   }
   Environment: {

--- a/lib/entities/contentful-function.ts
+++ b/lib/entities/contentful-function.ts
@@ -1,6 +1,6 @@
 import { Link } from '../common-types'
 
-export type FunctionProps = {
+export type ContentfulFunctionProps = {
   sys: {
     id: string
     type: 'Function'

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -106,7 +106,7 @@ export type {
   GroupControl,
   SidebarItem,
 } from './entities/editor-interface'
-export type { FunctionProps } from './entities/function'
+export type { ContentfulFunctionProps } from './entities/contentful-function'
 export type { CreateEntryProps, Entry, EntryProps, WithResourceName } from './entities/entry'
 export type { CreateEnvironmentProps, Environment, EnvironmentProps } from './entities/environment'
 export type {

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -92,7 +92,7 @@ import { UsageProps } from '../entities/usage'
 import { UserProps } from '../entities/user'
 import { DefaultParams, OptionalDefaults } from './wrappers/wrap'
 import { AssetKeyProps, CreateAssetKeyProps } from '../entities/asset-key'
-import { FunctionProps } from '../entities/function'
+import { ContentfulFunctionProps } from '../entities/contentful-function'
 import {
   BulkActionPayload,
   BulkActionProps,
@@ -183,10 +183,10 @@ export type PlainClientAPI = {
   appKey: AppKeyPlainClientAPI
   appSignedRequest: AppSignedRequestPlainClientAPI
   appSigningSecret: AppSigningSecretPlainClientAPI
-  function: {
+  contentfulFunction: {
     getMany(
       params: OptionalDefaults<GetAppDefinitionParams & QueryParams>
-    ): Promise<CollectionProp<FunctionProps>>
+    ): Promise<CollectionProp<ContentfulFunctionProps>>
   }
   editorInterface: EditorInterfacePlainClientAPI
   space: {

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -100,8 +100,8 @@ export const createPlainClient = (
       get: wrap(wrapParams, 'AppSigningSecret', 'get'),
       delete: wrap(wrapParams, 'AppSigningSecret', 'delete'),
     },
-    function: {
-      getMany: wrap(wrapParams, 'Function', 'getMany'),
+    contentfulFunction: {
+      getMany: wrap(wrapParams, 'ContentfulFunction', 'getMany'),
     },
     editorInterface: {
       get: wrap(wrapParams, 'EditorInterface', 'get'),


### PR DESCRIPTION
## Summary

- @marcolink commented that the current naming may cause some issues if one wants to deconstruct the prop due to `function` being a reserved keyword.
- As such, using the alternative naming of `ContentfulFunction` (the `sys.type` still remains as `Function`).  
