### PR TITLE
refactor: rename delivery functions to functions [MONET-1733]

### DIFF
--- a/lib/adapters/REST/endpoints/app-bundle.ts
+++ b/lib/adapters/REST/endpoints/app-bundle.ts
@@ -44,7 +44,7 @@ export const create: RestEndpoint<'AppBundle', 'create'> = (
   params: GetAppDefinitionParams,
   payload: CreateAppBundleProps
 ) => {
-  const { appUploadId, comment, actions, deliveryFunctions } = payload
+  const { appUploadId, comment, actions, functions } = payload
 
   const data = {
     upload: {
@@ -56,7 +56,7 @@ export const create: RestEndpoint<'AppBundle', 'create'> = (
     },
     comment,
     actions,
-    deliveryFunctions,
+    functions,
   }
 
   return raw.post<AppBundleProps>(http, getBaseUrl(params), data)

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -19,7 +19,7 @@ interface ActionManifestProps {
   allowNetworks?: string[]
 }
 
-interface DeliveryFunctionManifestProps {
+interface FunctionManifestProps {
   id: string
   name: string
   description: string
@@ -37,7 +37,7 @@ export type CreateAppBundleProps = {
   appUploadId: string
   comment?: string
   actions?: ActionManifestProps[]
-  deliveryFunctions?: DeliveryFunctionManifestProps[]
+  functions?: FunctionManifestProps[]
 }
 
 export type AppBundleProps = {

--- a/test/unit/create-app-definition-api-test.js
+++ b/test/unit/create-app-definition-api-test.js
@@ -125,24 +125,24 @@ describe('createAppDefinitionApi', () => {
     })
   })
 
-  test('API call createAppBundle with delivery functions', async () => {
+  test('API call createAppBundle with functions', async () => {
     const { api, entitiesMock } = setup(Promise.resolve({}))
-    const appBundleWithDeliveryFns = {
+    const appBundleWithFns = {
       ...appBundleMock,
-      deliveryFunctions: [
+      functions: [
         {
           id: 'myCustomId',
-          name: 'My Delivery function',
-          description: 'Delivery function uploaded with bundle',
+          name: 'My Contenful function',
+          description: 'Function uploaded with bundle',
           path: 'functions/test.js',
         },
       ],
     }
 
-    entitiesMock['appBundle']['wrapAppBundle'].returns(appBundleWithDeliveryFns)
+    entitiesMock['appBundle']['wrapAppBundle'].returns(appBundleWithFns)
 
     return api['createAppBundle']({ appBundleId: 'id' }).then((result) => {
-      expect(result).equals(appBundleWithDeliveryFns)
+      expect(result).equals(appBundleWithFns)
     })
   })
 


### PR DESCRIPTION
This PR renames delivery functions to functions. 
[Ticket](https://contentful.atlassian.net/browse/MONET-1733)

## Summary

Delivery functions is a feature is EAP and it is currently being renamed to Functions. This PR updates the client to be later used in `create-contentful-app` repository. 


