### PR TITLE
chore(axios): bump to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@contentful/rich-text-types": "^16.3.0",
         "@types/json-patch": "0.0.30",
-        "axios": "^1.6.2",
+        "axios": "^1.6.7",
         "contentful-sdk-core": "^8.1.0",
         "fast-copy": "^3.0.0",
         "lodash.isplainobject": "^4.0.6",
@@ -5087,9 +5087,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
-      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dependencies": {
         "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@contentful/rich-text-types": "^16.3.0",
         "@types/json-patch": "0.0.30",
-        "axios": "^1.6.7",
+        "axios": "^1.6.2",
         "contentful-sdk-core": "^8.1.0",
         "fast-copy": "^3.0.0",
         "lodash.isplainobject": "^4.0.6",


### PR DESCRIPTION
## Summary

Upgrades `axios` to the latest available version in the lock file to prevent sniffers from reporting a security vulnerability fixed in `1.6.4`.

## Motivation and Context

Axios `1.6.4` release: https://github.com/axios/axios/releases/tag/v1.6.4

Customer signal with sniffer report (Snyk): 
![Screenshot 2024-02-01 at 9 09 57 AM](https://github.com/contentful/contentful-management.js/assets/103024358/608aff7d-42e9-4b05-b94b-b9352fe67be4)