### PR TITLE
feat: add ResourceLink type

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -165,6 +165,17 @@ export interface Link<T extends string> {
   }
 }
 
+/**
+ * ResourceLink is a reference object to another entity outside of the current space/environment
+ */
+export interface ResourceLink<T extends string> {
+  sys: {
+    type: 'ResourceLink'
+    linkType: T
+    urn: string
+  }
+}
+
 export interface VersionedLink<T extends string> {
   sys: {
     type: 'Link'


### PR DESCRIPTION
## Summary

Introduce `ResourceLink` type for resource links which have been used for [cross-space references](https://www.contentful.com/help/cross-space-references/) for a while.

## Motivation and Context

This package is the source of truth for types for multiple other projects. Some already define `ResourceLink` on their own while others need it soon so it’s better to have it in one place.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation
