### PR TITLE
feat: add accepts as an optional parameter [MONET-1825]

### DIFF
--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -24,6 +24,7 @@ interface FunctionManifestProps {
   name: string
   description: string
   path: string
+  accepts?: string[]
   allowNetworks?: string[]
 }
 

--- a/lib/entities/function.ts
+++ b/lib/entities/function.ts
@@ -14,6 +14,6 @@ export type FunctionProps = {
   name: string
   description: string
   path: string
+  accepts: string[]
   allowNetworks?: string[]
-  accepts?: string[]
 }

--- a/lib/entities/function.ts
+++ b/lib/entities/function.ts
@@ -15,4 +15,5 @@ export type FunctionProps = {
   description: string
   path: string
   allowNetworks?: string[]
+  accepts?: string[]
 }


### PR DESCRIPTION
[Ticket](https://contentful.atlassian.net/browse/MONET-1825)

## Summary

This PR adds `accepts` as an optional parameter to `appBundle` and `function` props. 
