### PR TITLE
normalize babel syntax transforms with other public CTF libs

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -9,17 +9,13 @@ const defaultBabelPresetEnvConfig = {
   modules: false,
 }
 
-// Latest browsers
-const browserBabelPresetEnvConfig = Object.assign({}, defaultBabelPresetEnvConfig, {
-  targets: {
-    browsers: ['last 2 versions', 'not ie < 13', 'not android < 50'],
-  },
-})
+// Latest browsers (via package.json browserslists)
+const browserBabelPresetEnvConfig = Object.assign({}, defaultBabelPresetEnvConfig)
 
 // Node
 const nodeBabelPresetEnvConfig = Object.assign({}, defaultBabelPresetEnvConfig, {
   targets: {
-    node: '6',
+    node: '18',
   },
 })
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,13 @@
   "engines": {
     "node": ">=18"
   },
+  "browserslist": [
+    ">0.3%",
+    "Chrome >= 75",
+    "Edge >= 74",
+    "Firefox >= 73",
+    "Safari >= 13"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/contentful/contentful-management.js.git"


### PR DESCRIPTION
This will make sure the core, CDA and CMA libs all support the very same browsers and node versions.

Partner PRs:

* https://github.com/contentful/contentful-sdk-core/pull/437
*