### PR TITLE
refactor: normalize package managers & CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - checkout
       - run: node --version
-      - node/install-packages
+      - install-dependencies
       - persist-workspace
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,29 +1,15 @@
 version: 2.1
 orbs:
   vault: contentful/vault@1
+  node: circleci/node@5.2.0
 
 executors:
   docker-with-node:
     docker:
-      - image: cimg/node:18.18
+      - image: cimg/node:18
     working_directory: ~/build-and-test
 
 commands:
-  install-dependencies:
-    steps:
-      - restore_cache:
-          keys:
-            - npm-cache-{{ arch }}-{{ checksum ".nvmrc" }}-{{ checksum "package-lock.json" }}
-            - npm-cache
-      - run: npm ci --prefer-offline
-
-  cache-dependencies:
-    steps:
-      - save_cache:
-          key: npm-cache-{{ arch }}-{{ checksum ".nvmrc" }}-{{ checksum "package-lock.json" }}
-          paths:
-            - node_modules
-
   persist-workspace:
     steps:
       - persist_to_workspace:
@@ -47,8 +33,7 @@ jobs:
     steps:
       - checkout
       - run: node --version
-      - install-dependencies
-      - cache-dependencies
+      - node/install-packages
       - persist-workspace
 
   build:
@@ -91,7 +76,7 @@ jobs:
     steps:
       - checkout
       - use-vault
-      - install-dependencies
+      - node/install-packages
       - run: npm run semantic-release
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   docker-with-node:
     docker:
-      - image: cimg/node:18
+      - image: cimg/node:18.19
     working_directory: ~/build-and-test
 
 commands:


### PR DESCRIPTION
Our 3 core packages, contentful.js, contentful-management.js and contentful-sdk-core all differ in the way they store and lock dependencies.

This is one of 3 PRs that will align that behavior:

* Migrate from yarn to npm
* Ensure lock file is committed to repository, but not included in package releases
* Ensure CircleCI uses modern, recommended way by CircleCI to install packages
* Ensure CircleCI uses the latest minor version of our minimum node version

Related PRs:

* https://github.com/contentful/contentful.js/pull/2164
* https://github.com/contentful/contentful-sdk-core/pull/440