### PR TITLE
docs: add inline docs for the plain client Tag interface [EXT-4966]

### DIFF
--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -10,7 +10,6 @@ import {
   GetSnapshotForEntryParams,
   GetSpaceEnvironmentParams,
   GetSpaceParams,
-  GetTagParams,
   GetTeamMembershipParams,
   GetTeamParams,
   GetTeamSpaceMembershipParams,
@@ -51,7 +50,6 @@ import {
   CreateUpdateScheduledActionProps,
 } from '../entities/scheduled-action'
 import { SnapshotProps } from '../entities/snapshot'
-import { CreateTagProps, DeleteTagParams, TagProps, UpdateTagProps } from '../entities/tag'
 import { CreateTeamProps, TeamProps } from '../entities/team'
 import { CreateTeamMembershipProps, TeamMembershipProps } from '../entities/team-membership'
 import {
@@ -117,6 +115,7 @@ import { WorkflowPlainClientAPI } from './entities/workflow'
 import { WorkflowsChangelogPlainClientAPI } from './entities/workflows-changelog'
 import { WorkflowDefinitionPlainClientAPI } from './entities/workflow-definition'
 import { RolePlainClientAPI } from './entities/role'
+import { TagPlainClientAPI } from './entities/tag'
 
 export type PlainClientAPI = {
   raw: {
@@ -527,19 +526,7 @@ export type PlainClientAPI = {
       params: OptionalDefaults<GetSnapshotForContentTypeParams & { snapshotId: string }>
     ): Promise<SnapshotProps<ContentTypeProps>>
   }
-  tag: {
-    get(params: OptionalDefaults<GetTagParams>): Promise<TagProps>
-    getMany(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>
-    ): Promise<CollectionProp<TagProps>>
-    createWithId(params: OptionalDefaults<GetTagParams>, rawData: CreateTagProps): Promise<TagProps>
-    update(
-      params: OptionalDefaults<GetTagParams>,
-      rawData: UpdateTagProps,
-      headers?: RawAxiosRequestHeaders
-    ): Promise<TagProps>
-    delete(params: OptionalDefaults<DeleteTagParams>): Promise<any>
-  }
+  tag: TagPlainClientAPI
   organization: OrganizationPlainClientAPI
   organizationInvitation: {
     get(

--- a/lib/plain/entities/tag.ts
+++ b/lib/plain/entities/tag.ts
@@ -1,3 +1,4 @@
+import { RawAxiosRequestHeaders } from 'axios'
 import {
   GetTagParams,
   GetSpaceEnvironmentParams,
@@ -7,7 +8,6 @@ import {
 import { UpdateTagProps, DeleteTagParams } from '../../entities/tag'
 import { TagProps, CreateTagProps } from '../../export-types'
 import { OptionalDefaults } from '../wrappers/wrap'
-import { CreateOrUpdate } from './base'
 
 export type TagPlainClientAPI = {
   /**
@@ -64,7 +64,11 @@ export type TagPlainClientAPI = {
    * });
    * ```
    */
-  createWithId: CreateOrUpdate<GetTagParams, CreateTagProps, TagProps>
+  createWithId: (
+    params: OptionalDefaults<GetTagParams>,
+    rawData: CreateTagProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<TagProps>
   /**
    * Update a tag
    * @param params the space, environment, and tag IDs
@@ -92,7 +96,11 @@ export type TagPlainClientAPI = {
    * );
    * ```
    */
-  update: CreateOrUpdate<GetTagParams, UpdateTagProps, TagProps>
+  update: (
+    params: OptionalDefaults<GetTagParams>,
+    rawData: UpdateTagProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<TagProps>
   /**
    * Delete a single tag by ID and version
    * @param params the tag ID, version, and the IDs of the space and environment

--- a/lib/plain/entities/tag.ts
+++ b/lib/plain/entities/tag.ts
@@ -1,0 +1,111 @@
+import {
+  GetTagParams,
+  GetSpaceEnvironmentParams,
+  QueryParams,
+  CollectionProp,
+} from '../../common-types'
+import { UpdateTagProps, DeleteTagParams } from '../../entities/tag'
+import { TagProps, CreateTagProps } from '../../export-types'
+import { OptionalDefaults } from '../wrappers/wrap'
+import { CreateOrUpdate } from './base'
+
+export type TagPlainClientAPI = {
+  /**
+   * Fetch a single tag by ID
+   * @param params the tag ID and the IDs of the space and environment
+   * @returns the tag
+   * @throws if the space, environment, or tag are not found
+   * @example
+   * ```javascript
+   * const tag = await client.tag.get({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   tagId: '<tag_id>',
+   * });
+   * ```
+   */
+  get(params: OptionalDefaults<GetTagParams>): Promise<TagProps>
+  /**
+   * Fetch all tags in a space and environment
+   * @param params the space and environment IDs, along with optional query parameters to filter results
+   * @returns a collection of tags
+   * @throws if the space or environment are not found
+   * @example
+   * ```javascript
+   * const tags = await client.tag.getMany({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   query: {
+   *     limit: 10,
+   *   },
+   * });
+   * ```
+   */
+  getMany(
+    params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>
+  ): Promise<CollectionProp<TagProps>>
+  /**
+   * Create a new tag
+   * @param params the space and environment ID to create the tag in
+   * @param data the tag data
+   * @returns the created tag
+   * @throws if the space or environment are not found or the payload is malformed
+   * @example
+   * ```javascript
+   * const tag = await client.tag.createWithId({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   tagId: '<tag_id>'
+   * }, {
+   *   name: '<tag_name>',
+   *   sys: {
+   *     visibility: "public",
+   *   }
+   * });
+   * ```
+   */
+  createWithId: CreateOrUpdate<GetTagParams, CreateTagProps, TagProps>
+  /**
+   * Update a tag
+   * @param params the space, environment, and tag IDs
+   * @param rawData the updated tag data
+   * @returns the updated tag
+   * @throws if the space, environment, or tag are not found, or the payload is malformed
+   * @example
+   * ```javascript
+   * let tag = await client.tag.get({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   tagId: '<tag_id>',
+   * });
+   *
+   * tag = await client.tag.update(
+   *   {
+   *     spaceId: '<space_id>',
+   *     environmentId: '<environment_id>',
+   *     tagId: '<tag_id>',
+   *   },
+   *   {
+   *     ...tag,
+   *     name: 'New Name',
+   *   }
+   * );
+   * ```
+   */
+  update: CreateOrUpdate<GetTagParams, UpdateTagProps, TagProps>
+  /**
+   * Delete a single tag by ID and version
+   * @param params the tag ID, version, and the IDs of the space and environment
+   * @throws if the space, environment, tag, or tag version are not found
+   * @example
+   * ```javascript
+   * await client.tag.delete({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   tagId: '<tag_id>',
+   *   version: <tag_version>,
+   * });
+   * ```
+   */
+  delete(params: OptionalDefaults<DeleteTagParams>): Promise<void>
+}

--- a/lib/plain/entities/tag.ts
+++ b/lib/plain/entities/tag.ts
@@ -64,11 +64,7 @@ export type TagPlainClientAPI = {
    * });
    * ```
    */
-  createWithId: (
-    params: OptionalDefaults<GetTagParams>,
-    rawData: CreateTagProps,
-    headers?: RawAxiosRequestHeaders
-  ) => Promise<TagProps>
+  createWithId(params: OptionalDefaults<GetTagParams>, rawData: CreateTagProps): Promise<TagProps>
   /**
    * Update a tag
    * @param params the space, environment, and tag IDs
@@ -96,11 +92,11 @@ export type TagPlainClientAPI = {
    * );
    * ```
    */
-  update: (
+  update(
     params: OptionalDefaults<GetTagParams>,
     rawData: UpdateTagProps,
     headers?: RawAxiosRequestHeaders
-  ) => Promise<TagProps>
+  ): Promise<TagProps>
   /**
    * Delete a single tag by ID and version
    * @param params the tag ID, version, and the IDs of the space and environment
@@ -115,5 +111,5 @@ export type TagPlainClientAPI = {
    * });
    * ```
    */
-  delete(params: OptionalDefaults<DeleteTagParams>): Promise<void>
+  delete(params: OptionalDefaults<DeleteTagParams>): Promise<any>
 }


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

adds inline documentation for the Tag plain client interface


<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

we want the `plain` client to be the default use of this SDK, so we're providing inline docs for how to use that



<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

