### PR TITLE
docs: fix inline doc example for the plain client locale getMany method [EXT-4965]

### DIFF
--- a/lib/plain/entities/locale.ts
+++ b/lib/plain/entities/locale.ts
@@ -32,8 +32,6 @@ export type LocalePlainClientAPI = {
    *   {
    *     spaceId: '<space_id>',
    *     environmentId: '<environment_id>',
-   *   },
-   *   {
    *     query: {
    *       limit: 10,
    *     },


### PR DESCRIPTION


<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

We recently added inline documentation for the Locale plain client interface, this changeset includes a tiny tweak to the locale.getMany inline example


<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context
we want the `plain` client to be the default use of this SDK, so we're providing inline docs for how to use that



<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation
