### PR TITLE
fix: revert changes to plain client wrap method that made space/env/org ids required

### DIFF
--- a/lib/plain/entities/app-definition.ts
+++ b/lib/plain/entities/app-definition.ts
@@ -1,3 +1,4 @@
+import { RawAxiosRequestHeaders } from 'axios'
 import {
   CollectionProp,
   GetAppDefinitionParams,
@@ -10,8 +11,6 @@ import {
   CreateAppDefinitionProps,
 } from '../../entities/app-definition'
 import { OptionalDefaults } from '../wrappers/wrap'
-import { CreateOrUpdate } from './base'
-import { Get } from 'type-fest'
 
 export type AppDefinitionPlainClientAPI = {
   /**
@@ -70,7 +69,11 @@ export type AppDefinitionPlainClientAPI = {
    * );
    * ```
    */
-  create: CreateOrUpdate<GetOrganizationParams, CreateAppDefinitionProps, AppDefinitionProps>
+  create: (
+    params: OptionalDefaults<GetOrganizationParams>,
+    rawData: CreateAppDefinitionProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<AppDefinitionProps>
   /**
    * Update an App Definition
    * @param params entity IDs to identify the App Definition
@@ -91,7 +94,11 @@ export type AppDefinitionPlainClientAPI = {
    * );
    * ```
    */
-  update: CreateOrUpdate<GetAppDefinitionParams, AppDefinitionProps, AppDefinitionProps>
+  update: (
+    params: OptionalDefaults<GetAppDefinitionParams>,
+    rawData: AppDefinitionProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<AppDefinitionProps>
   /**
    * Delete an App Definition
    * @param params entity IDs to identify the App Definition

--- a/lib/plain/entities/app-installation.ts
+++ b/lib/plain/entities/app-installation.ts
@@ -1,3 +1,4 @@
+import { RawAxiosRequestHeaders } from 'axios'
 import {
   CollectionProp,
   GetAppDefinitionParams,
@@ -8,7 +9,6 @@ import {
 import { AppInstallationsForOrganizationProps } from '../../entities/app-definition'
 import { AppInstallationProps, CreateAppInstallationProps } from '../../entities/app-installation'
 import { OptionalDefaults } from '../wrappers/wrap'
-import { CreateOrUpdate } from './base'
 
 export type AppInstallationPlainClientAPI = {
   /**
@@ -80,7 +80,11 @@ export type AppInstallationPlainClientAPI = {
    * );
    * ```
    */
-  upsert: CreateOrUpdate<GetAppInstallationParams, CreateAppInstallationProps, AppInstallationProps>
+  upsert: (
+    params: OptionalDefaults<GetAppInstallationParams>,
+    rawData: CreateAppInstallationProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<AppInstallationProps>
   /**
    * Uninstalls the App
    * @param params entity IDs to identify the App to uninstall

--- a/lib/plain/entities/base.ts
+++ b/lib/plain/entities/base.ts
@@ -1,8 +1,0 @@
-import { RawAxiosRequestHeaders } from 'axios'
-import { OptionalDefaults } from '../wrappers/wrap'
-
-export type CreateOrUpdate<T, Props, ReturnProps> = (
-  params: OptionalDefaults<T>,
-  rawData: Props,
-  headers: RawAxiosRequestHeaders
-) => Promise<ReturnProps>

--- a/lib/plain/entities/comment.ts
+++ b/lib/plain/entities/comment.ts
@@ -1,3 +1,4 @@
+import { RawAxiosRequestHeaders } from 'axios'
 import { CollectionProp, GetCommentParams, QueryParams } from '../../common-types'
 import {
   CommentProps,
@@ -13,7 +14,6 @@ import {
   UpdateCommentProps,
 } from '../../entities/comment'
 import { OptionalDefaults } from '../wrappers/wrap'
-import { CreateOrUpdate } from './base'
 
 type GetManyRichText = GetManyCommentsParams & RichTextBodyFormat & QueryParams
 type GetManyPlain = GetManyCommentsParams & PlainTextBodyFormat & QueryParams
@@ -95,11 +95,11 @@ export type CommentPlainClientAPI = {
    * });
    * ```
    */
-  create: CreateOrUpdate<
-    CreateCommentParams,
-    CreateCommentProps | RichTextCommentBodyPayload,
-    CommentProps
-  >
+  create: (
+    params: OptionalDefaults<CreateCommentParams>,
+    rawData: CreateCommentProps | RichTextCommentBodyPayload,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<CommentProps>
   /** Updates a comment
    *
    * @param params
@@ -120,11 +120,11 @@ export type CommentPlainClientAPI = {
    * });
    * ```
    */
-  update: CreateOrUpdate<
-    UpdateCommentParams,
-    UpdateCommentProps | RichTextCommentBodyPayload,
-    RichTextCommentProps
-  >
+  update: (
+    params: OptionalDefaults<UpdateCommentParams>,
+    rawData: UpdateCommentProps | RichTextCommentBodyPayload,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<RichTextCommentProps>
   /** Deletes a comment
    *
    * @param params

--- a/lib/plain/entities/extension.ts
+++ b/lib/plain/entities/extension.ts
@@ -1,3 +1,4 @@
+import { RawAxiosRequestHeaders } from 'axios'
 import {
   CollectionProp,
   GetExtensionParams,
@@ -6,7 +7,6 @@ import {
 } from '../../common-types'
 import { CreateExtensionProps, ExtensionProps } from '../../entities/extension'
 import { OptionalDefaults } from '../wrappers/wrap'
-import { CreateOrUpdate } from './base'
 
 export type ExtensionPlainClientAPI = {
   /**
@@ -69,7 +69,11 @@ export type ExtensionPlainClientAPI = {
    * );
    * ```
    */
-  create: CreateOrUpdate<GetSpaceEnvironmentParams, CreateExtensionProps, ExtensionProps>
+  create: (
+    params: OptionalDefaults<GetSpaceEnvironmentParams>,
+    rawData: CreateExtensionProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<ExtensionProps>
   /**
    * Creates a new Extension with a given ID
    * @param params entity IDs to identify the Environment in which to create the Extension
@@ -100,7 +104,11 @@ export type ExtensionPlainClientAPI = {
    * );
    * ```
    */
-  createWithId: CreateOrUpdate<GetExtensionParams, CreateExtensionProps, ExtensionProps>
+  createWithId: (
+    params: OptionalDefaults<GetExtensionParams>,
+    rawData: CreateExtensionProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<ExtensionProps>
   /**
    * Updates an Extension
    * @param params entity IDs to identify the Extension
@@ -147,7 +155,11 @@ export type ExtensionPlainClientAPI = {
    * );
    * ```
    */
-  update: CreateOrUpdate<GetExtensionParams, ExtensionProps, ExtensionProps>
+  update: (
+    params: OptionalDefaults<GetExtensionParams>,
+    rawData: ExtensionProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<ExtensionProps>
   /**
    * Deletes the Extension
    * @param params entity IDs to identity the Extension

--- a/lib/plain/entities/task.ts
+++ b/lib/plain/entities/task.ts
@@ -1,3 +1,4 @@
+import { RawAxiosRequestHeaders } from 'axios'
 import {
   CreateTaskParams,
   DeleteTaskParams,
@@ -13,7 +14,6 @@ import {
   TaskProps,
 } from '../../export-types'
 import { OptionalDefaults } from '../wrappers/wrap'
-import { CreateOrUpdate } from './base'
 
 export type TaskPlainClientAPI = {
   /** Fetches a task
@@ -80,7 +80,11 @@ export type TaskPlainClientAPI = {
    * );
    * ```
    */
-  create: CreateOrUpdate<CreateTaskParams, CreateTaskProps, TaskProps>
+  create: (
+    params: OptionalDefaults<CreateTaskParams>,
+    rawData: CreateTaskProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<TaskProps>
   /** Updates a task
    *
    * @param params Space ID, Entry ID, Environment ID, and Task ID
@@ -110,7 +114,11 @@ export type TaskPlainClientAPI = {
    * );
    * ```
    */
-  update: CreateOrUpdate<UpdateTaskParams, UpdateTaskProps, TaskProps>
+  update: (
+    params: OptionalDefaults<UpdateTaskParams>,
+    rawData: UpdateTaskProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<TaskProps>
   /** Deletes a task
    *
    * @param params Space ID, Entry ID, Environment ID, and Task ID

--- a/lib/plain/entities/webhook.ts
+++ b/lib/plain/entities/webhook.ts
@@ -18,7 +18,6 @@ import {
   WebhookSigningSecretProps,
 } from '../../entities/webhook'
 import { OptionalDefaults } from '../wrappers/wrap'
-import { CreateOrUpdate } from './base'
 
 export type WebhookPlainClientAPI = {
   // Webhooks
@@ -71,7 +70,11 @@ export type WebhookPlainClientAPI = {
    * );
    * ```
    */
-  create: CreateOrUpdate<GetSpaceParams, CreateWebhooksProps, WebhookProps>
+  create: (
+    params: OptionalDefaults<GetSpaceParams>,
+    rawData: CreateWebhooksProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<WebhookProps>
   /**
    * Creates the Webhook
    * @param params entity IDs to identify the Webhook to update

--- a/lib/plain/entities/workflow-definition.ts
+++ b/lib/plain/entities/workflow-definition.ts
@@ -14,7 +14,6 @@ import {
   DeleteWorkflowDefinitionParams,
 } from '../../export-types'
 import { OptionalDefaults } from '../wrappers/wrap'
-import { CreateOrUpdate } from './base'
 
 export type WorkflowDefinitionPlainClientAPI = {
   /**
@@ -70,11 +69,11 @@ export type WorkflowDefinitionPlainClientAPI = {
    * }, workflowDefinitionProps);
    * ```
    */
-  create: CreateOrUpdate<
-    CreateWorkflowDefinitionParams,
-    CreateWorkflowDefinitionProps,
-    WorkflowDefinitionProps
-  >
+  create: (
+    params: OptionalDefaults<CreateWorkflowDefinitionParams>,
+    rawData: CreateWorkflowDefinitionProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<WorkflowDefinitionProps>
   /**
    * Update a Workflow Definition
    * @param params entity IDs to identify the Space/Environment and Workflow Definition
@@ -95,11 +94,11 @@ export type WorkflowDefinitionPlainClientAPI = {
    * });
    * ```
    */
-  update: CreateOrUpdate<
-    UpdateWorkflowDefinitionParams,
-    UpdateWorkflowDefinitionProps,
-    WorkflowDefinitionProps
-  >
+  update: (
+    params: OptionalDefaults<UpdateWorkflowDefinitionParams>,
+    rawData: UpdateWorkflowDefinitionProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<WorkflowDefinitionProps>
   /**
    * Delete a Workflow Definition
    * @param params entity IDs to identify the Space/Environment and Workflow Definition version

--- a/lib/plain/entities/workflow.ts
+++ b/lib/plain/entities/workflow.ts
@@ -13,7 +13,6 @@ import {
   DeleteWorkflowParams,
 } from '../../export-types'
 import { OptionalDefaults } from '../wrappers/wrap'
-import { CreateOrUpdate } from './base'
 
 export type WorkflowPlainClientAPI = {
   /**
@@ -65,7 +64,11 @@ export type WorkflowPlainClientAPI = {
    * });
    * ```
    */
-  create: CreateOrUpdate<CreateWorkflowParams, CreateWorkflowProps, WorkflowProps>
+  create: (
+    params: OptionalDefaults<CreateWorkflowParams>,
+    rawData: CreateWorkflowProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<WorkflowProps>
   /**
    * Update a Workflow (i.e. move to another step)
    * @param params entity IDs to identify the Space/Environment and Workflow
@@ -83,7 +86,11 @@ export type WorkflowPlainClientAPI = {
    * });
    * ```
    */
-  update: CreateOrUpdate<UpdateWorkflowParams, UpdateWorkflowProps, WorkflowProps>
+  update: (
+    params: OptionalDefaults<UpdateWorkflowParams>,
+    rawData: UpdateWorkflowProps,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<WorkflowProps>
   /**
    * Delete a Workflow
    * @param params entity IDs to identify the Space/Environment and Workflow

--- a/lib/plain/wrappers/wrap.ts
+++ b/lib/plain/wrappers/wrap.ts
@@ -10,9 +10,9 @@ export type DefaultParams = {
  * @private
  */
 export type OptionalDefaults<T> = Omit<T, keyof DefaultParams> &
-  ('organizationId' extends keyof T ? { organizationId: string } : Record<string, unknown>) &
-  ('spaceId' extends keyof T ? { spaceId: string } : Record<string, unknown>) &
-  ('environmentId' extends keyof T ? { environmentId: string } : Record<string, unknown>)
+  ('organizationId' extends keyof T ? { organizationId?: string } : Record<string, unknown>) &
+  ('spaceId' extends keyof T ? { spaceId?: string } : Record<string, unknown>) &
+  ('environmentId' extends keyof T ? { environmentId?: string } : Record<string, unknown>)
 
 /**
  * @private


### PR DESCRIPTION
…

<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

An issue was introduced in https://github.com/contentful/contentful-management.js/pull/2181 (v11.19.0) that caused space/env/org ids to be incorrectly marked as required in the create and update methods for several plain client interfaces. 

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
