### PR TITLE
feat: add client methods for AppAccessTokens [EXT-4754]

### DIFF
--- a/lib/adapters/REST/endpoints/app-access-token.ts
+++ b/lib/adapters/REST/endpoints/app-access-token.ts
@@ -1,0 +1,18 @@
+import type { AxiosInstance } from 'contentful-sdk-core'
+import { AppAccessTokenProps, CreateAppAccessTokenProps } from '../../../entities/app-access-token'
+import * as raw from './raw'
+import { RestEndpoint } from '../types'
+import { GetAppInstallationParams } from '../../../common-types'
+
+export const create: RestEndpoint<'AppAccessToken', 'create'> = (
+  http: AxiosInstance,
+  params: GetAppInstallationParams,
+  data: CreateAppAccessTokenProps
+) => {
+  return raw.post<AppAccessTokenProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/app_installations/${params.appDefinitionId}/access_tokens`,
+    undefined,
+    { headers: { Authorization: `Bearer ${data.jwt}` } }
+  )
+}

--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -9,6 +9,7 @@ import * as AppSignedRequest from './app-signed-request'
 import * as AppSigningSecret from './app-signing-secret'
 import * as AppEventSubscription from './app-event-subscription'
 import * as AppKey from './app-key'
+import * as AppAccessToken from './app-access-token'
 import * as AppUpload from './app-upload'
 import * as Asset from './asset'
 import * as AssetKey from './asset-key'
@@ -65,6 +66,7 @@ export default {
   AppSigningSecret,
   AppEventSubscription,
   AppKey,
+  AppAccessToken,
   AppDetails,
   Asset,
   AssetKey,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -149,6 +149,7 @@ import {
   CreateAppEventSubscriptionProps,
 } from './entities/app-event-subscription'
 import { AppKeyProps, CreateAppKeyProps } from './entities/app-key'
+import { AppAccessTokenProps, CreateAppAccessTokenProps } from './entities/app-access-token'
 
 export interface DefaultElements<TPlainObject extends object = object> {
   toPlainObject(): TPlainObject
@@ -402,6 +403,8 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'AppKey', 'getMany', UA>): MRReturn<'AppKey', 'getMany'>
   (opts: MROpts<'AppKey', 'create', UA>): MRReturn<'AppKey', 'create'>
   (opts: MROpts<'AppKey', 'delete', UA>): MRReturn<'AppKey', 'delete'>
+
+  (opts: MROpts<'AppAccessToken', 'create', UA>): MRReturn<'AppAccessToken', 'create'>
 
   (opts: MROpts<'AssetKey', 'create', UA>): MRReturn<'AssetKey', 'create'>
 
@@ -942,6 +945,13 @@ export type MRActions = {
     delete: {
       params: GetAppDefinitionParams & { fingerprint: string }
       return: void
+    }
+  }
+  AppAccessToken: {
+    create: {
+      params: GetAppInstallationParams
+      payload: CreateAppAccessTokenProps
+      return: AppAccessTokenProps
     }
   }
   Asset: {

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -1634,13 +1634,16 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * @return Promise for an app access token
      * @example ```javascript
      * const contentful = require('contentful-management')
+     * const { sign } = require('jsonwebtoken')
+     *
+     * const signOptions = { algorithm: 'RS256', issuer: '<app_definition_id>', expiresIn: '10m' }
      *
      * const client = contentful.createClient({
      *   accessToken: '<content_management_api_key>'
      * })
      *
      * const data = {
-     *   jwt: '<jwt>'
+     *   jwt: sign({}, '<private_key>', signOptions)
      * }
      *
      * client.getSpace('<space_id>')

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -49,6 +49,7 @@ import { TagVisibility, wrapTag, wrapTagCollection } from './entities/tag'
 import { wrapUIConfig } from './entities/ui-config'
 import { wrapUserUIConfig } from './entities/user-ui-config'
 import { wrapEnvironmentTemplateInstallationCollection } from './entities/environment-template-installation'
+import { CreateAppAccessTokenProps } from './entities/app-access-token'
 
 /**
  * @private
@@ -76,6 +77,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
   const { wrapAppSignedRequest } = entities.appSignedRequest
   const { wrapAppActionCall } = entities.appActionCall
   const { wrapBulkAction } = entities.bulkAction
+  const { wrapAppAccessToken } = entities.appAccessToken
 
   return {
     /**
@@ -1624,6 +1626,42 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
         },
         payload: data,
       }).then((payload) => wrapAppSignedRequest(makeRequest, payload))
+    },
+    /**
+     * Creates an app access token
+     * @param appDefinitionId - AppDefinition ID
+     * @param data - Json Web Token
+     * @return Promise for an app access token
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * const data = {
+     *   jwt: '<jwt>'
+     * }
+     *
+     * client.getSpace('<space_id>')
+     *  .then((space) => space.getEnvironment('<environment-id>'))
+     *  .then((environment) => environment.createAppAccessToken('<app_definition_id>', data)
+     *  .then((appAccessToken) => console.log(appAccessToken))
+     *  .catch(console.error)
+     *  ```
+     */
+    createAppAccessToken(appDefinitionId: string, data: CreateAppAccessTokenProps) {
+      const raw = this.toPlainObject() as EnvironmentProps
+      return makeRequest({
+        entityType: 'AppAccessToken',
+        action: 'create',
+        params: {
+          spaceId: raw.sys.space.sys.id,
+          environmentId: raw.sys.id,
+          appDefinitionId,
+        },
+        payload: data,
+      }).then((payload) => wrapAppAccessToken(makeRequest, payload))
     },
     /**
      * Gets all snapshots of an entry

--- a/lib/entities/app-access-token.ts
+++ b/lib/entities/app-access-token.ts
@@ -1,0 +1,45 @@
+import copy from 'fast-copy'
+import { freezeSys, toPlainObject } from 'contentful-sdk-core'
+import { Except } from 'type-fest'
+import { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '../common-types'
+
+type AppAccessTokenSys = Except<BasicMetaSysProps, 'version' | 'id'> & {
+  space: SysLink
+  environment: SysLink
+  appDefinition: SysLink
+  expiresAt: string
+}
+
+export type AppAccessTokenProps = {
+  /**
+   * System metadata
+   */
+  sys: AppAccessTokenSys
+  /**
+   * Token for an app installation in a space environment
+   */
+  token: string
+}
+
+export type CreateAppAccessTokenProps = {
+  /**
+   * JSON Web Token
+   */
+  jwt: string
+}
+
+export interface AppAccessToken extends AppAccessTokenProps, DefaultElements<AppAccessTokenProps> {}
+
+/**
+ * @private
+ * @param makeRequest - function to make requests via an adapter
+ * @param data - Raw app access token data
+ * @return {AppAccessToken} Wrapped AppAccessToken data
+ */
+export function wrapAppAccessToken(
+  _makeRequest: MakeRequest,
+  data: AppAccessTokenProps
+): AppAccessToken {
+  const appAccessToken = toPlainObject(copy(data))
+  return freezeSys(appAccessToken)
+}

--- a/lib/entities/index.ts
+++ b/lib/entities/index.ts
@@ -9,6 +9,7 @@ import * as appSignedRequest from './app-signed-request'
 import * as appSigningSecret from './app-signing-secret'
 import * as appEventSubscription from './app-event-subscription'
 import * as appKey from './app-key'
+import * as appAccessToken from './app-access-token'
 import * as appUpload from './app-upload'
 import * as asset from './asset'
 import * as assetKey from './asset-key'
@@ -64,6 +65,7 @@ export default {
   appSigningSecret,
   appEventSubscription,
   appKey,
+  appAccessToken,
   asset,
   assetKey,
   bulkAction,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -58,6 +58,11 @@ export type {
   CreateAppEventSubscriptionProps,
 } from './entities/app-event-subscription'
 export type { AppKey, AppKeyProps, CreateAppKeyProps } from './entities/app-key'
+export type {
+  AppAccessToken,
+  AppAccessTokenProps,
+  CreateAppAccessTokenProps,
+} from './entities/app-access-token'
 export type { AppUpload, AppUploadProps } from './entities/app-upload'
 export type { Asset, AssetFileProp, AssetProps, CreateAssetProps } from './entities/asset'
 export type { AssetKey, AssetKeyProps, CreateAssetKeyProps } from './entities/asset-key'

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -119,6 +119,7 @@ import { UsagePlainClientAPI } from './entities/usage'
 import { TeamSpaceMembershipPlainClientAPI } from './entities/team-space-membership'
 import { TeamPlainClientAPI } from './entities/team'
 import { TeamMembershipPlainClientAPI } from './entities/team-membership'
+import { AppAccessTokenPlainClientAPI } from './entities/app-access-token'
 
 export type PlainClientAPI = {
   raw: {
@@ -138,6 +139,7 @@ export type PlainClientAPI = {
   appKey: AppKeyPlainClientAPI
   appSignedRequest: AppSignedRequestPlainClientAPI
   appSigningSecret: AppSigningSecretPlainClientAPI
+  appAccessToken: AppAccessTokenPlainClientAPI
   function: {
     getMany(
       params: OptionalDefaults<GetAppDefinitionParams & QueryParams>

--- a/lib/plain/entities/app-access-token.ts
+++ b/lib/plain/entities/app-access-token.ts
@@ -1,0 +1,29 @@
+import { GetAppInstallationParams } from '../../common-types'
+import { AppAccessTokenProps, CreateAppAccessTokenProps } from '../../entities/app-access-token'
+import { OptionalDefaults } from '../wrappers/wrap'
+
+export type AppAccessTokenPlainClientAPI = {
+  /**
+   * Issue a token for an app installation in a space environment
+   * @param params space, environment, and app definition IDs
+   * @param payload the JWT to be used to issue the token
+   * @returns the issued token, which can be cached until it expires
+   * @throws if the request fails
+   * @example
+   * ```javascript
+   * const { token } = await client.appAccessToken.create(
+   *   {
+   *     spaceId: '<space_id>',
+   *     environmentId: '<environment_id>',
+   *     appDefinitionId: '<app_definition_id>',
+   *   }, {
+   *     jwt: '<jwt>',
+   *   }
+   * );
+   * ```
+   */
+  create(
+    params: OptionalDefaults<GetAppInstallationParams>,
+    payload: CreateAppAccessTokenProps
+  ): Promise<AppAccessTokenProps>
+}

--- a/lib/plain/entities/app-access-token.ts
+++ b/lib/plain/entities/app-access-token.ts
@@ -11,13 +11,17 @@ export type AppAccessTokenPlainClientAPI = {
    * @throws if the request fails
    * @example
    * ```javascript
+   * import { sign } from 'jsonwebtoken'
+   *
+   * const signOptions = { algorithm: 'RS256', issuer: '<app_definition_id>', expiresIn: '10m' }
+   *
    * const { token } = await client.appAccessToken.create(
    *   {
    *     spaceId: '<space_id>',
    *     environmentId: '<environment_id>',
    *     appDefinitionId: '<app_definition_id>',
    *   }, {
-   *     jwt: '<jwt>',
+   *     jwt: sign({}, '<private_key>', signOptions)
    *   }
    * );
    * ```

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -100,6 +100,9 @@ export const createPlainClient = (
       get: wrap(wrapParams, 'AppSigningSecret', 'get'),
       delete: wrap(wrapParams, 'AppSigningSecret', 'delete'),
     },
+    appAccessToken: {
+      create: wrap(wrapParams, 'AppAccessToken', 'create'),
+    },
     function: {
       getMany: wrap(wrapParams, 'Function', 'getMany'),
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "in-publish": "^2.0.1",
         "istanbul": "^1.0.0-alpha.2",
         "json": "^11.0.0",
+        "jsonwebtoken": "^9.0.2",
         "karma": "^6.3.4",
         "karma-chrome-launcher": "^3.1.0",
         "karma-env-preprocessor": "^0.1.1",
@@ -5448,6 +5449,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true
+    },
     "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -7708,6 +7715,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -11472,6 +11488,49 @@
         "node": "*"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dev": true,
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jstransformer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
@@ -11487,6 +11546,27 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dev": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dev": true,
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/karma": {
       "version": "6.4.3",
@@ -12264,16 +12344,40 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true
+    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true
+    },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
+      "dev": true
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
       "dev": true
     },
     "node_modules/lodash.isplainobject": {
@@ -12296,6 +12400,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
     },
     "node_modules/lodash.uniqby": {

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "in-publish": "^2.0.1",
     "istanbul": "^1.0.0-alpha.2",
     "json": "^11.0.0",
+    "jsonwebtoken": "^9.0.2",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-env-preprocessor": "^0.1.1",

--- a/test/integration/app-access-token-integration.js
+++ b/test/integration/app-access-token-integration.js
@@ -1,0 +1,70 @@
+import { expect } from 'chai'
+import { before, after, describe, test } from 'mocha'
+import {
+  initPlainClient,
+  getDefaultSpace,
+  createAppInstallation,
+  getTestOrganization,
+} from '../helpers'
+import { sign } from 'jsonwebtoken'
+
+describe('AppAccessToken api', function () {
+  let organization
+  let appDefinition
+  let appKey
+  let client
+  let space
+  let environment
+  let entityId
+  let jwt
+
+  before(async () => {
+    space = await getDefaultSpace()
+    environment = await space.getEnvironment('master')
+    organization = await getTestOrganization()
+
+    appDefinition = await organization.createAppDefinition({
+      name: 'Test AppAccessToken',
+    })
+
+    entityId = {
+      organizationId: appDefinition.sys.organization.sys.id,
+      appDefinitionId: appDefinition.sys.id,
+    }
+    await createAppInstallation(entityId.appDefinitionId)
+
+    client = initPlainClient()
+
+    appKey = await client.appKey.create(entityId, { generate: true })
+
+    const signOptions = { algorithm: 'RS256', issuer: appDefinition.sys.id, expiresIn: '10m' }
+    jwt = sign({}, appKey.generated.privateKey, signOptions)
+  })
+
+  after(async () => {
+    if (appDefinition) {
+      if (appKey) {
+        await client.appKey.delete({
+          ...entityId,
+          fingerprint: appKey.sys.id,
+        })
+      }
+      await appDefinition.delete()
+    }
+  })
+
+  test('createAppAccessToken', async () => {
+    const appAccessToken = await client.appAccessToken.create(
+      {
+        spaceId: space.sys.id,
+        environmentId: environment.sys.id,
+        appDefinitionId: appDefinition.sys.id,
+      },
+      {
+        jwt,
+      }
+    )
+
+    expect(appAccessToken.token).to.have.lengthOf(292)
+  })
+})

--- a/test/unit/create-environment-api-test.js
+++ b/test/unit/create-environment-api-test.js
@@ -18,6 +18,7 @@ import {
   snapShotMock,
   UiExtensionMock,
   uploadMock,
+  appAccessTokenMock,
 } from './mocks/entities'
 import { afterEach, describe, test } from 'mocha'
 import { expect } from 'chai'
@@ -554,6 +555,14 @@ describe('A createEnvironmentApi', () => {
   test('API call getAppInstallations fails', async () => {
     return makeEntityMethodFailingTest(setup, {
       methodToTest: 'getAppInstallations',
+    })
+  })
+
+  test('API call createAppAccessToken', async () => {
+    return makeCreateEntityWithIdTest(setup, {
+      entityType: 'appAccessToken',
+      mockToReturn: appAccessTokenMock,
+      methodToTest: 'createAppAccessToken',
     })
   })
 

--- a/test/unit/entities/app-access-token.ts
+++ b/test/unit/entities/app-access-token.ts
@@ -1,0 +1,22 @@
+import { describe, test } from 'mocha'
+import { wrapAppAccessToken } from '../../../lib/entities/app-access-token'
+import { appAccessTokenMock } from '../mocks/entities'
+import setupHttpMock from '../mocks/http'
+import setupMakeRequest from '../mocks/makeRequest'
+import { entityWrappedTest } from '../test-creators/instance-entity-methods'
+
+function setup(promise) {
+  return {
+    makeRequest: setupMakeRequest(promise),
+    httpMock: setupHttpMock(promise),
+    entityMock: appAccessTokenMock,
+  }
+}
+
+describe('AppAccessToken', () => {
+  test('AppAccessToken is wrapped', async () => {
+    return entityWrappedTest(setup, {
+      wrapperMethod: wrapAppAccessToken,
+    })
+  })
+})

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -272,6 +272,18 @@ const appKeyMock = {
   },
 }
 
+const appAccessTokenMock = {
+  sys: Object.assign(cloneDeep(sysMock), {
+    type: 'AppAccessToken',
+    space: { sys: { id: 'space-id' } },
+    environment: { sys: { id: 'environment-id' } },
+    appDefinition: { sys: { id: 'app-definition-id' } },
+    expiresAt: '2020-03-30T13:38:37.000Z',
+  }),
+  token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImViZWY2MDJlLTMxZGItNGMzYi1iZjAwL',
+  id: undefined,
+}
+
 const appDetailsMock = {
   sys: Object.assign(cloneDeep(sysMock), {
     type: 'AppDetails',
@@ -948,6 +960,7 @@ const mocks = {
   appSigningSecret: appSigningSecretMock,
   appEventSubscription: appEventSubscriptionMock,
   appKey: appKeyMock,
+  appAccessToken: appAccessTokenMock,
   appDetails: appDetailsMock,
   asset: assetMock,
   assetKey: assetKeyMock,
@@ -1049,6 +1062,9 @@ function setupEntitiesMock(rewiredModuleApi) {
     appKey: {
       wrapAppKey: sinon.stub(),
       wrapAppKeyCollection: sinon.stub(),
+    },
+    appAccessToken: {
+      wrapAppAccessToken: sinon.stub(),
     },
     appDetails: {
       wrapAppDetails: sinon.stub(),
@@ -1228,6 +1244,7 @@ export {
   appSigningSecretMock,
   appEventSubscriptionMock,
   appKeyMock,
+  appAccessTokenMock,
   appDetailsMock,
   linkMock,
   sysMock,


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Adds the `create` client method for AppAccessTokens

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

CMA JS client <-> API feature parity


<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
