### PR TITLE
feat: deprecate webhook retry policy methods [EXT-5117]

### DIFF
--- a/lib/adapters/REST/endpoints/webhook.ts
+++ b/lib/adapters/REST/endpoints/webhook.ts
@@ -91,6 +91,9 @@ export const getSigningSecret: RestEndpoint<'Webhook', 'getSigningSecret'> = (
   return raw.get(http, getWebhookSigningSecretUrl(params))
 }
 
+/**
+ * @deprecated The EAP for this feature has ended. This method will be removed in the next major version.
+ */
 export const getRetryPolicy: RestEndpoint<'Webhook', 'getRetryPolicy'> = (
   http: AxiosInstance,
   params: GetSpaceParams
@@ -148,6 +151,9 @@ export const upsertSigningSecret: RestEndpoint<'Webhook', 'upsertSigningSecret'>
   return raw.put<WebhookSigningSecretProps>(http, getWebhookSigningSecretUrl(params), data)
 }
 
+/**
+ * @deprecated The EAP for this feature has ended. This method will be removed in the next major version.
+ */
 export const upsertRetryPolicy: RestEndpoint<'Webhook', 'upsertRetryPolicy'> = async (
   http: AxiosInstance,
   params: GetSpaceParams,
@@ -172,6 +178,9 @@ export const deleteSigningSecret: RestEndpoint<'Webhook', 'deleteSigningSecret'>
   return raw.del<void>(http, getWebhookSigningSecretUrl(params))
 }
 
+/**
+ * @deprecated The EAP for this feature has ended. This method will be removed in the next major version.
+ */
 export const deleteRetryPolicy: RestEndpoint<'Webhook', 'deleteRetryPolicy'> = async (
   http: AxiosInstance,
   params: GetSpaceParams

--- a/lib/plain/entities/webhook.ts
+++ b/lib/plain/entities/webhook.ts
@@ -164,47 +164,18 @@ export type WebhookPlainClientAPI = {
 
   // Webhook Retry Policies
   /**
-   * Fetch the webhook retry policy for a given Space
-   * @param params entity IDs to identify the Space which the retry policy belongs to
-   * @returns the maxRetries value configured in the Retry Policy
-   * @throws if the request fails, the Space is not found, or the retry policy does not exist
-   * @example
-   * ```javascript
-   * const retryPolicy = await client.webhook.getRetryPolicy({
-   *   spaceId: '<space_id>',
-   * });
+   * @deprecated The EAP for this feature has ended. This method will be removed in the next major version.
    */
   getRetryPolicy(params: OptionalDefaults<GetSpaceParams>): Promise<WebhookRetryPolicyProps>
   /**
-   * Creates or updates the webhook retry policy for a given Space
-   * @param params entity IDs to identify the Space which the retry policy belongs to
-   * @param rawData the maxRetries with integer value >= 2 and <= 99 value to set in the Retry Policy
-   * @returns the webhook retry policy
-   * @throws if the request fails, the Space is not found, or the payload is malformed
-   * @example
-   * ```javascript
-   * const retryPolicy = await client.webhook.upsertRetryPolicy({
-   *   spaceId: '<space_id>',
-   * },
-   * {
-   *   maxRetries: 15,
-   * });
-   * ```
+   * @deprecated The EAP for this feature has ended. This method will be removed in the next major version.
    */
   upsertRetryPolicy(
     params: OptionalDefaults<GetSpaceParams>,
     rawData: WebhookRetryPolicyPayload
   ): Promise<WebhookRetryPolicyProps>
   /**
-   * Removes the webhook retry policy for a given Space
-   * @param params entity IDs to identify the Space which the retry policy belongs to
-   * @throws if the request fails, the Space is not found, or the retry policy does not exist
-   * @example
-   * ```javascript
-   * await client.webhook.deleteRetryPolicy({
-   *  spaceId: '<space_id>',
-   * });
-   * ```
+   * @deprecated The EAP for this feature has ended. This method will be removed in the next major version.
    */
   deleteRetryPolicy(params: OptionalDefaults<GetSpaceParams>): Promise<void>
 


### PR DESCRIPTION
## Summary

Deprecates methods for interacting with the custom Webhook Retry Policy API.  The EAP for this feature has ended and the endpoints will no longer work.
