### PR TITLE
feat: export enum values for WorkflowStepPermission* types [CFISO-1367]

### DIFF
--- a/lib/entities/workflow-definition.ts
+++ b/lib/entities/workflow-definition.ts
@@ -25,6 +25,7 @@ export enum WorkflowStepPermissionType {
 export enum WorkflowStepPermissionAction {
   Edit = 'edit',
   Publish = 'publish',
+  Delete = 'delete',
 }
 
 export enum WorkflowStepPermissionEffect {

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -245,15 +245,19 @@ export type {
   WorkflowStepActionType,
   // Property: step.permissions
   WorkflowStepPermission,
-  WorkflowStepPermissionType,
-  WorkflowStepPermissionAction,
-  WorkflowStepPermissionEffect,
   WorkflowStepPermissionActors,
   WorkflowStepEmailActionRecipient,
   WorkflowStepEmailAction,
   WorkflowStepTaskAction,
   WorkflowStepAppAction,
 } from './entities/workflow-definition'
+
+export {
+  WorkflowStepPermissionType,
+  WorkflowStepPermissionAction,
+  WorkflowStepPermissionEffect,
+} from './entities/workflow-definition'
+
 export type {
   DefinedParameters,
   FreeFormParameters,


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

This PR changes the export of 3 enums that are needed in the workflow-management-api and workflows-marketplace-app as normal types, since they were exported before as `export type ... ` it was not possible to access their values