### PR TITLE
fix(entities/field-type): correct casing of resourcelink array item types

### DIFF
--- a/lib/entities/field-type.ts
+++ b/lib/entities/field-type.ts
@@ -13,5 +13,5 @@ export type FieldType =
   | { type: 'ResourceLink'; linkType: string }
   | { type: 'Array'; items: { type: 'Symbol' } }
   | { type: 'Array'; items: { type: 'Link'; linkType: 'Entry' } }
-  | { type: 'Array'; items: { type: 'Resourcelink'; linkType: string } }
+  | { type: 'Array'; items: { type: 'ResourceLink'; linkType: string } }
   | { type: 'Array'; items: { type: 'Link'; linkType: 'Asset' } }


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Correct typing of arrays containing resource link items

## Description

The typings exposed for arrays containing resource link items appear to be incorrect, using the casing `Resourcelink` where all other documentation and examples capitalise the `l` like `ResourceLink`

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
