### PR TITLE
feat: Add new App Installation Parameter value type 'Secret' [EXT-4836]

### DIFF
--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -6,7 +6,7 @@ import { wrapCollection } from '../common-utils'
 import createAppDefinitionApi, { ContentfulAppDefinitionAPI } from '../create-app-definition-api'
 import { SetOptional, Except } from 'type-fest'
 import { FieldType } from './field-type'
-import { ParameterDefinition } from './widget-parameters'
+import { InstallationParameterType, ParameterDefinition } from './widget-parameters'
 import { AppInstallationProps } from './app-installation'
 import { EnvironmentProps } from './environment'
 
@@ -62,7 +62,7 @@ export type AppDefinitionProps = {
    */
   parameters?: {
     instance?: ParameterDefinition[]
-    installation?: ParameterDefinition[]
+    installation?: ParameterDefinition<InstallationParameterType>[]
   }
 }
 

--- a/lib/entities/extension.ts
+++ b/lib/entities/extension.ts
@@ -2,7 +2,11 @@ import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { FieldType } from './field-type'
-import { DefinedParameters, ParameterDefinition } from './widget-parameters'
+import {
+  DefinedParameters,
+  InstallationParameterType,
+  ParameterDefinition,
+} from './widget-parameters'
 import { wrapCollection } from '../common-utils'
 import { DefaultElements, BasicMetaSysProps, SysLink, MakeRequest } from '../common-types'
 import { SetRequired, RequireExactlyOne } from 'type-fest'
@@ -37,7 +41,7 @@ export type ExtensionProps = {
      */
     parameters?: {
       instance?: ParameterDefinition[]
-      installation?: ParameterDefinition[]
+      installation?: ParameterDefinition<InstallationParameterType>[]
     }
     /**
      * Controls the location of the extension. If true it will be rendered on the sidebar instead of replacing the field's editing control

--- a/lib/entities/widget-parameters.ts
+++ b/lib/entities/widget-parameters.ts
@@ -1,11 +1,12 @@
 type ParameterType = 'Boolean' | 'Symbol' | 'Number' | 'Enum'
+export type InstallationParameterType = ParameterType | 'Secret'
 type ParameterOption = string | { [key: string]: string }
 
-export interface ParameterDefinition {
+export interface ParameterDefinition<T = ParameterType> {
   name: string
   id: string
   description?: string
-  type: ParameterType
+  type: T
   required?: boolean
   default?: boolean | string | number
   options?: ParameterOption[]

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -262,6 +262,7 @@ export type {
   DefinedParameters,
   FreeFormParameters,
   ParameterDefinition,
+  InstallationParameterType,
 } from './entities/widget-parameters'
 export type {
   CreateWorkflowProps,

--- a/test/integration/app-definition-integration.js
+++ b/test/integration/app-definition-integration.js
@@ -43,6 +43,34 @@ describe('AppDefinition api', function () {
     expect(appDefinition.name).equals('Test App', 'name')
   })
 
+  test('createAppDefinition with secret installation param', async () => {
+    const appDefinition = await organization.createAppDefinition({
+      name: 'Test App',
+      src: 'http://localhost:3000',
+      locations: [
+        {
+          location: 'app-config',
+        },
+      ],
+      parameters: {
+        installation: [
+          {
+            name: 'my-secret-param',
+            id: 'secret',
+            type: 'Secret',
+          },
+        ],
+      },
+    })
+
+    expect(appDefinition.sys.type).equals('AppDefinition', 'type')
+    expect(appDefinition.name).equals('Test App', 'name')
+    expect(appDefinition.parameters.installation[0].id).equals(
+      'secret',
+      'installation parameter id'
+    )
+  })
+
   test('getAppDefintion', async () => {
     const appDefinition = await organization.createAppDefinition({
       name: 'Test App',

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -213,6 +213,22 @@ const appDefinitionMock = {
       fieldTypes: [{ type: 'Symbol' }],
     },
   ],
+  parameters: {
+    instance: [
+      {
+        name: 'my-bool-param',
+        id: 'param',
+        type: 'Boolean',
+      },
+    ],
+    installation: [
+      {
+        name: 'my-secret-param',
+        id: 'param',
+        type: 'Secret',
+      },
+    ],
+  },
 }
 
 const appUploadMock = {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

When creating App Installation Parameter schemas by modifying an App Definition, users can now specify that a parameter is of type "Secret". At the time of this PR this functionality is currently only supported on the schema side. 

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Apps will soon be able to use secret app installation parameters for storing params whose exposure should be limited.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

Documentation updates to come as this feature matures. 