### PR TITLE
feat: adds taxonomy validation and assignmnt [GROOT-1263]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -258,6 +258,7 @@ export interface MetaLinkProps {
 
 export interface MetadataProps {
   tags: Link<'Tag'>[]
+  concepts?: Link<'TaxonomyConcept'>[]
 }
 
 export interface SysLink {

--- a/lib/entities/content-type.ts
+++ b/lib/entities/content-type.ts
@@ -1,6 +1,6 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import { Except, SetOptional, RequireAtLeastOne } from 'type-fest'
+import { Except, RequireAtLeastOne, SetOptional } from 'type-fest'
 import {
   BasicMetaSysProps,
   Collection,
@@ -26,6 +26,7 @@ export type ContentTypeMetadata = {
     },
     'ContentType' | 'ContentTypeField'
   >
+  taxonomy?: Array<Link<'TaxonomyConcept'> | Link<'TaxonomyConceptScheme'>>
 }
 
 export type AnnotationAssignment = Link<'Annotation'> & {

--- a/lib/entities/entry.ts
+++ b/lib/entities/entry.ts
@@ -3,7 +3,6 @@ import copy from 'fast-copy'
 import {
   CollectionProp,
   DefaultElements,
-  EntityMetaSysProps,
   EntryMetaSysProps,
   KeyValueMap,
   MakeRequest,
@@ -17,7 +16,6 @@ import { AssetProps } from './asset'
 export type EntryProps<T = KeyValueMap> = {
   sys: EntryMetaSysProps
   metadata?: MetadataProps
-
   fields: T
 }
 


### PR DESCRIPTION
## Summary
### Content Type
Adds taxonomy validations to metadata object

### Entry
Adds Concept assignment object to

## Description
This is the first step of bringing taxonomy data to the management client. IN a follow up PR we will introduce the management functionality for taxonomy

Docs: https://www.contentful.com/developers/docs/references/content-management-api/#/reference/taxonomy
