### PR TITLE
feat!: deprecate legacy client [NONE]

### DIFF
--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -57,31 +57,20 @@ function createClient(params: ClientOptions): ClientAPI
 function createClient(
   params: ClientOptions,
   opts: {
-    type: 'plain'
+    // type: 'plain'
     defaults?: DefaultParams
   }
 ): PlainClientAPI
-// Usually, overloads with more specific signatures should come first but some IDEs are often not able to handle overloads with separate TSDocs correctly
-/**
- * @deprecated The `alphaFeatures` option is no longer supported. Please use the function without this option.
- */
+
 function createClient(
   params: ClientOptions,
   opts: {
-    type?: 'plain'
-    alphaFeatures: string[]
-    defaults?: DefaultParams
-  }
-): ClientAPI | PlainClientAPI
-function createClient(
-  params: ClientOptions,
-  opts: {
-    type?: 'plain'
+    type?: 'legacy'
     defaults?: DefaultParams
   } = {}
 ): ClientAPI | PlainClientAPI {
   const sdkMain =
-    opts.type === 'plain' ? 'contentful-management-plain.js' : 'contentful-management.js'
+    opts.type === 'legacy' ? 'contentful-management.js' : 'contentful-management-plain.js'
   const userAgent = getUserAgentHeader(
     // @ts-expect-error
     `${sdkMain}/${__VERSION__}`,
@@ -98,9 +87,9 @@ function createClient(
   const makeRequest: MakeRequest = (options: Parameters<MakeRequest>[0]): ReturnType<MakeRequest> =>
     adapter.makeRequest({ ...options, userAgent })
 
-  if (opts.type === 'plain') {
-    return createPlainClient(makeRequest, opts.defaults)
-  } else {
+  if (opts.type === 'legacy') {
     return createContentfulApi(makeRequest) as ClientAPI
+  } else {
+    return createPlainClient(makeRequest, opts.defaults)
   }
 }

--- a/lib/create-app-definition-api.ts
+++ b/lib/create-app-definition-api.ts
@@ -39,6 +39,7 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
      * .then((appDefinition) => console.log(`App Definition ${appDefinition.sys.id} updated.`))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     update: function update() {
       const data = this.toPlainObject() as AppDefinitionProps
@@ -67,6 +68,7 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
      * .then(() => console.log(`App Definition deleted.`))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     delete: function del() {
       const data = this.toPlainObject() as AppDefinitionProps
@@ -93,6 +95,7 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
      * .then((appBundle) => console.log(appBundle))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAppBundle(id: string) {
       const raw = this.toPlainObject() as AppDefinitionProps
@@ -122,6 +125,7 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAppBundles(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as AppDefinitionProps
@@ -147,6 +151,7 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
      * .then((appBundle) => console.log(appBundle))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createAppBundle(data: CreateAppBundleProps) {
       const raw = this.toPlainObject() as AppDefinitionProps
@@ -177,6 +182,7 @@ export default function createAppDefinitionApi(makeRequest: MakeRequest) {
      * .then((appInstallationsForOrg) => console.log(appInstallationsForOrg.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getInstallationsForOrg(query: SpaceQueryOptions = {}) {
       const raw = this.toPlainObject() as AppDefinitionProps

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -24,6 +24,9 @@ import {
 } from './entities/environment-template'
 import { RawAxiosRequestConfig } from 'axios'
 
+/**
+ * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
+ */
 export type ClientAPI = ReturnType<typeof createClientApi>
 type CreateSpaceProps = Omit<SpaceProps, 'sys'> & { defaultLocale?: string }
 
@@ -58,6 +61,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getEnvironmentTemplates: function getEnvironmentTemplates(
       organizationId: string,
@@ -90,6 +94,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then((space) => console.log(space))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getEnvironmentTemplate: function getEnvironmentTemplate({
       organizationId,
@@ -127,6 +132,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then((environmentTemplate) => console.log(environmentTemplate))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createEnvironmentTemplate: function createEnvironmentTemplate(
       organizationId: string,
@@ -153,6 +159,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getSpaces: function getSpaces(
       query: QueryOptions = {}
@@ -179,6 +186,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then((space) => console.log(space))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getSpace: function getSpace(spaceId: string): Promise<Space> {
       return makeRequest({
@@ -206,6 +214,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then((space) => console.log(space))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createSpace: function createSpace(
       spaceData: CreateSpaceProps,
@@ -234,6 +243,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then((org) => console.log(org))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getOrganization: function getOrganization(id: string): Promise<Organization> {
       return makeRequest({
@@ -257,6 +267,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then(result => console.log(result.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getOrganizations: function getOrganizations(
       query: PaginationQueryParams['query'] = {}
@@ -282,6 +293,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then(user => console.log(user.firstName))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getCurrentUser: function getCurrentUser<T = UserProps>(params?: QueryParams): Promise<T> {
       return makeRequest({
@@ -307,8 +319,8 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then(appDefinition => console.log(appDefinition.name))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
-
     getAppDefinition: function getAppDefinition(
       params: GetAppDefinitionParams
     ): Promise<AppDefinition> {
@@ -341,6 +353,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then(personalAccessToken => console.log(personalAccessToken.token))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createPersonalAccessToken: function createPersonalAccessToken(
       data: CreatePersonalAccessTokenProps
@@ -374,6 +387,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then(token => console.log(token.token))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getPersonalAccessToken: function getPersonalAccessToken(tokenId: string) {
       return makeRequest({
@@ -399,6 +413,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then(response => console.log(reponse.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getPersonalAccessTokens: function getPersonalAccessTokens() {
       return makeRequest({
@@ -423,6 +438,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then(token => console.log(token.token))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAccessToken: function getAccessToken(tokenId: string) {
       return makeRequest({
@@ -446,6 +462,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then(response => console.log(reponse.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAccessTokens: function getAccessTokens() {
       return makeRequest({
@@ -470,6 +487,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then(response => console.log(reponse.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getOrganizationAccessTokens: function getOrganizationAccessTokens(
       organizationId: string,
@@ -505,6 +523,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then(result => console.log(result.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getOrganizationUsage: function getOrganizationUsage(
       organizationId: string,
@@ -541,6 +560,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then(result => console.log(result.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getSpaceUsage: function getSpaceUsage(organizationId: string, query: UsageQuery = {}) {
       return makeRequest({
@@ -571,6 +591,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .then((responseData) => console.log(responseData))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     rawRequest: function rawRequest({ url, ...config }: RawAxiosRequestConfig & { url: string }) {
       return makeRequest({

--- a/lib/create-entry-api.ts
+++ b/lib/create-entry-api.ts
@@ -54,6 +54,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .then((entry) => console.log(`Entry ${entry.sys.id} updated.`))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     update: function update() {
       const { raw, params } = getParams(this)
@@ -89,6 +90,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .then((entry) => console.log(`Entry ${entry.sys.id} updated.`))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     patch: function patch(ops: OpPatch[]) {
       const { raw, params } = getParams(this)
@@ -145,6 +147,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .then((entry) => console.log(`Entry ${entry.sys.id} published.`))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     publish: function publish() {
       const { raw, params } = getParams(this)
@@ -174,6 +177,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .then((entry) => console.log(`Entry ${entry.sys.id} unpublished.`))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
 
     unpublish: function unpublish() {
@@ -203,6 +207,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .then((entry) => console.log(`Entry ${entry.sys.id} archived.`))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     archive: function archive() {
       const { params } = getParams(this)
@@ -231,6 +236,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .then((entry) => console.log(`Entry ${entry.sys.id} unarchived.`))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     unarchive: function unarchive() {
       const { params } = getParams(this)
@@ -258,6 +264,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .then((snapshots) => console.log(snapshots.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getSnapshots: function (query = {}) {
       const { params } = getParams(this)
@@ -286,6 +293,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .then((snapshot) => console.log(snapshot))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getSnapshot: function (snapshotId: string) {
       const { params } = getParams(this)
@@ -317,6 +325,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .then((comment) => console.log(comment))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createComment: function (data: CreateCommentProps) {
       const { params } = getParams(this)
@@ -349,6 +358,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .then((comments) => console.log(comments))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getComments: function () {
       const { params } = getParams(this)
@@ -375,6 +385,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .then((comment) => console.log(comment))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getComment: function (id: string) {
       const { params } = getParams(this)
@@ -410,6 +421,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .then((task) => console.log(task))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createTask: function (data: CreateTaskProps) {
       const { params } = getParams(this)
@@ -437,6 +449,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .then((tasks) => console.log(tasks))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getTasks: function (query = {}) {
       const { params } = getParams(this)
@@ -463,6 +476,7 @@ export default function createEntryApi(makeRequest: MakeRequest) {
      * .then((task) => console.log(task))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getTask: function (id: string) {
       const { params } = getParams(this)

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -61,6 +61,7 @@ export type ContentfulEnvironmentAPI = ReturnType<typeof createEnvironmentApi>
  * @param {ContentfulEnvironmentAPI} makeRequest - function to make requests via an adapter
  * @return {ContentfulSpaceAPI}
  * @private
+ * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
  */
 export default function createEnvironmentApi(makeRequest: MakeRequest) {
   const { wrapEnvironment } = entities.environment
@@ -96,6 +97,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then(() => console.log('Environment deleted.'))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     delete: function deleteEnvironment() {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -126,6 +128,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((environment) => console.log(`Environment ${environment.sys.id} renamed.`)
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     update: function updateEnvironment() {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -167,6 +170,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *
      * });
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      **/
     getEntryFromData(entryData: EntryProps) {
       return wrapEntry(makeRequest, entryData)
@@ -200,6 +204,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *
      * });
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAssetFromData(assetData: AssetProps) {
       return wrapAsset(makeRequest, assetData)
@@ -224,6 +229,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((environment) => environment.getBulkAction('<bulk_action_id>'))
      * .then((bulkAction) => console.log(bulkAction))
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getBulkAction<T extends BulkActionPayload = any>(bulkActionId: string): Promise<BulkAction<T>> {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -283,6 +289,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *  console.log(error)
      * }
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createPublishBulkAction(payload: BulkActionPublishPayload) {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -343,6 +350,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *  console.log(error)
      * }
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createValidateBulkAction(payload: BulkActionValidatePayload) {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -402,6 +410,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *  console.log(error)
      * }
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createUnpublishBulkAction(payload: BulkActionUnpublishPayload) {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -434,6 +443,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((contentType) => console.log(contentType))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getContentType(contentTypeId: string) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -466,6 +476,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getContentTypes(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -507,6 +518,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((contentType) => console.log(contentType))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createContentType(data: CreateContentTypeProps) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -550,6 +562,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((contentType) => console.log(contentType))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createContentTypeWithId(contentTypeId: string, data: CreateContentTypeProps) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -583,6 +596,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((EditorInterface) => console.log(EditorInterface))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getEditorInterfaceForContentType(contentTypeId: string) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -613,6 +627,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getEditorInterfaces() {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -646,6 +661,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((entry) => console.log(entry))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getEntry(id: string, query: QueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -678,6 +694,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then(() => console.log('Entry deleted.'))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     deleteEntry(id: string) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -713,6 +730,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getEntries(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -744,6 +762,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getPublishedEntries(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -782,6 +801,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((entry) => console.log(entry))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createEntry(contentTypeId: string, data: Omit<EntryProps, 'sys'>) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -823,6 +843,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((entry) => console.log(entry))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createEntryWithId(contentTypeId: string, id: string, data: CreateEntryProps) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -860,6 +881,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((environment) => environment.getEntry('<entry_id>')).then((entry) => entry.references({include: number}))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getEntryReferences(entryId: string, options?: EntryReferenceOptionsProps) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -895,6 +917,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((asset) => console.log(asset))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAsset(id: string, query: QueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -929,6 +952,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAssets(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -959,6 +983,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getPublishedAssets(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1002,6 +1027,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((asset) => console.log(asset))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createAsset(data: CreateAssetProps) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1044,6 +1070,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((asset) => console.log(asset))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createAssetWithId(id: string, data: CreateAssetProps) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1089,6 +1116,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((asset) => console.log(asset))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createAssetFromFiles(data: Omit<AssetFileProp, 'sys'>, options?: CreateAssetFromFilesOptions) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1122,6 +1150,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((policy, secret) => console.log({ policy, secret }))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createAssetKey(payload: CreateAssetKeyProps) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1151,6 +1180,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((environment) => environment.getUpload('<upload-id>')
      * .then((upload) => console.log(upload))
      * .catch(console.error)
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getUpload(id: string) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1182,6 +1212,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((upload) => console.log(upload))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createUpload: function createUpload(data: { file: string | ArrayBuffer | Stream }) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1212,6 +1243,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((locale) => console.log(locale))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getLocale(localeId: string) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1242,6 +1274,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getLocales() {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1277,6 +1310,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((locale) => console.log(locale))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createLocale(data: CreateLocaleProps) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1307,6 +1341,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((extension) => console.log(extension))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getUiExtension(id: string) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1336,6 +1371,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getUiExtensions() {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1379,6 +1415,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((extension) => console.log(extension))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createUiExtension(data: CreateExtensionProps) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1424,6 +1461,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((extension) => console.log(extension))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createUiExtensionWithId(id: string, data: CreateExtensionProps) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1462,6 +1500,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *  .then((appInstallation) => console.log(appInstallation))
      *  .catch(console.error)
      *  ```
+     *  @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createAppInstallation(
       appDefinitionId: string,
@@ -1498,6 +1537,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *  .then((appInstallation) => console.log(appInstallation))
      *  .catch(console.error)
      *  ```
+     *  @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAppInstallation(id: string) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1527,6 +1567,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *  .then((response) => console.log(response.items))
      *  .catch(console.error)
      *  ```
+     *  @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAppInstallations() {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1567,6 +1608,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *  .then((appActionCall) => console.log(appActionCall))
      *  .catch(console.error)
      *  ```
+     *  @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createAppActionCall(
       appDefinitionId: string,
@@ -1613,6 +1655,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *  .then((signedRequest) => console.log(signedRequest))
      *  .catch(console.error)
      *  ```
+     *  @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createAppSignedRequest(appDefinitionId: string, data: CreateAppSignedRequestProps) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1652,6 +1695,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *  .then((appAccessToken) => console.log(appAccessToken))
      *  .catch(console.error)
      *  ```
+     *  @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createAppAccessToken(appDefinitionId: string, data: CreateAppAccessTokenProps) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1685,6 +1729,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((snapshots) => console.log(snapshots.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getEntrySnapshots(entryId: string, query: QueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1718,6 +1763,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((snapshots) => console.log(snapshots.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getContentTypeSnapshots(contentTypeId: string, query: QueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
@@ -1795,6 +1841,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((release) => console.log(release))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getRelease(releaseId: string) {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -1827,6 +1874,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((releases) => console.log(releases))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getReleases(query?: ReleaseQueryOptions) {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -1869,6 +1917,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((release) => console.log(release))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createRelease(payload: ReleasePayload) {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -1916,6 +1965,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((release) => console.log(release))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     updateRelease({
       releaseId,
@@ -1958,6 +2008,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((environment) => environment.deleteRelease('<release_id>')
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     deleteRelease(releaseId: string) {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -1991,6 +2042,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((environment) => environment.publishRelease({ releaseId: '<release_id>', version: 1 }))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     publishRelease({ releaseId, version }: { releaseId: string; version: number }) {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -2025,6 +2077,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((environment) => environment.unpublishRelease({ releaseId: '<release_id>', version: 1 }))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     unpublishRelease({ releaseId, version }: { releaseId: string; version: number }) {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -2060,6 +2113,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((environment) => environment.validateRelease({ releaseId: '<release_id>', payload: { action: 'unpublish' } }))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     validateRelease({
       releaseId,
@@ -2100,6 +2154,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((environment) => environment.archiveRelease({ releaseId: '<release_id>', version: 1 }))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     archiveRelease({ releaseId, version }: { releaseId: string; version: number }) {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -2134,6 +2189,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((environment) => environment.unarchiveRelease({ releaseId: '<release_id>', version: 1 }))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     unarchiveRelease({ releaseId, version }: { releaseId: string; version: number }) {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -2168,6 +2224,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((releaseAction) => console.log(releaseAction))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getReleaseAction({ actionId, releaseId }: { actionId: string; releaseId: string }) {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -2203,6 +2260,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((releaseActions) => console.log(releaseActions))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getReleaseActions({ query }: { query?: ReleaseActionQueryOptions }) {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -2264,6 +2322,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .then((installations) => console.log(installations.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     async getEnvironmentTemplateInstallations(
       environmentTemplateId: string,

--- a/lib/create-environment-template-api.ts
+++ b/lib/create-environment-template-api.ts
@@ -35,6 +35,7 @@ export function createEnvironmentTemplateApi(makeRequest: MakeRequest, organizat
      *   console.log(`Environment template ${environmentTemplate.sys.id} renamed.`)
      * ).catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     update: function updateEnvironmentTemplate() {
       const raw = this.toPlainObject() as EnvironmentTemplateProps
@@ -68,6 +69,7 @@ export function createEnvironmentTemplateApi(makeRequest: MakeRequest, organizat
      *   console.log(`Environment template version ${environmentTemplate.sys.id} renamed.`)
      * ).catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     updateVersion: function updateEnvironmentTemplateVersion({
       versionName,
@@ -99,6 +101,7 @@ export function createEnvironmentTemplateApi(makeRequest: MakeRequest, organizat
      *   .then(() => console.log('Environment template deleted.'))
      *   .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     delete: function deleteEnvironmentTemplate() {
       const raw = this.toPlainObject() as EnvironmentTemplateProps
@@ -122,6 +125,7 @@ export function createEnvironmentTemplateApi(makeRequest: MakeRequest, organizat
      * .then((environmentTemplateVersions) => console.log(environmentTemplateVersions.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getVersions: function getEnvironmentTemplateVersions() {
       const raw = this.toPlainObject() as EnvironmentTemplateProps
@@ -153,6 +157,7 @@ export function createEnvironmentTemplateApi(makeRequest: MakeRequest, organizat
      * )
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getInstallations: function getEnvironmentTemplateInstallations({
       spaceId,
@@ -199,6 +204,7 @@ export function createEnvironmentTemplateApi(makeRequest: MakeRequest, organizat
      * .then((validationResult) => console.log(validationResult))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     validate: function validateEnvironmentTemplate({
       spaceId,
@@ -253,6 +259,7 @@ export function createEnvironmentTemplateApi(makeRequest: MakeRequest, organizat
      * .then((installation) => console.log(installation))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     install: function installEnvironmentTemplate({
       spaceId,
@@ -292,6 +299,7 @@ export function createEnvironmentTemplateApi(makeRequest: MakeRequest, organizat
      * .then(() => console.log('Template disconnected'))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     disconnect: function disconnectEnvironmentTemplate({
       spaceId,

--- a/lib/create-organization-api.ts
+++ b/lib/create-organization-api.ts
@@ -60,6 +60,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((spaces) => console.log(spaces))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getSpaces(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -87,6 +88,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((user) => console.log(user))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getUser(id: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -111,6 +113,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((users) => console.log(users))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getUsers(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -138,6 +141,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((organizationMembership) => console.log(organizationMembership))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getOrganizationMembership(id: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -166,6 +170,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
 
     getOrganizationMemberships(params: QueryParams = {}) {
@@ -196,6 +201,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((team) => console.log(team))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createTeam(data: CreateTeamProps) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -220,6 +226,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((team) => console.log(team))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getTeam(teamId: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -243,6 +250,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((teams) => console.log(teams))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getTeams(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -275,6 +283,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((teamMembership) => console.log(teamMembership))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createTeamMembership(teamId: string, data: CreateTeamMembershipProps) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -300,6 +309,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((teamMembership) => console.log(teamMembership))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getTeamMembership(teamId: string, teamMembershipId: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -324,6 +334,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((teamMemberships) => console.log(teamMemberships))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getTeamMemberships(opts: { teamId?: string; query?: QueryOptions } = {}) {
       const { teamId, query = {} } = opts
@@ -365,6 +376,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((teamSpaceMemberships) => console.log(teamSpaceMemberships))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getTeamSpaceMemberships(opts: { teamId?: string; query?: QueryOptions } = {}) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -393,6 +405,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((teamSpaceMembership) => console.log(teamSpaceMembership))
      * .catch(console.error)]
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getTeamSpaceMembership(teamSpaceMembershipId: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -421,6 +434,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((organizationMembership) => console.log(organizationMembership))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getOrganizationSpaceMembership(id: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -448,6 +462,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getOrganizationSpaceMemberships(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -474,6 +489,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((invitation) => console.log(invitation))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getOrganizationInvitation(invitationId: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -504,6 +520,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      *  })
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createOrganizationInvitation(data: CreateOrganizationInvitationProps) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -531,6 +548,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getRoles(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -559,6 +577,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appDefinition) => console.log(appDefinition))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createAppDefinition(data: CreateAppDefinitionProps) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -583,6 +602,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAppDefinitions(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -607,6 +627,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appDefinition) => console.log(appDefinition))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAppDefinition(id: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -631,6 +652,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appUpload) => console.log(appUpload))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAppUpload(appUploadId: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -656,6 +678,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appUpload) => console.log(appUpload))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createAppUpload(file: string | ArrayBuffer | Stream) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -681,6 +704,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appSigningSecret) => console.log(appSigningSecret))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     upsertAppSigningSecret(appDefinitionId: string, data: CreateAppSigningSecretProps) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -706,6 +730,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appSigningSecret) => console.log(appSigningSecret))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAppSigningSecret(appDefinitionId: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -730,6 +755,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((result) => console.log(result))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     deleteAppSigningSecret(appDefinitionId: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -756,6 +782,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appEventSubscription) => console.log(appEventSubscription))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     upsertAppEventSubscription(appDefinitionId: string, data: CreateAppEventSubscriptionProps) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -781,6 +808,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appEventSubscription) => console.log(appEventSubscription))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAppEventSubscription(appDefinitionId: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -805,6 +833,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((result) => console.log(result))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     deleteAppEventSubscription(appDefinitionId: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -838,6 +867,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appEventSubscription) => console.log(appEventSubscription))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createAppKey(appDefinitionId: string, data: CreateAppKeyProps) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -863,6 +893,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appKey) => console.log(appKey))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAppKey(appDefinitionId: string, fingerprint: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -894,6 +925,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appKeys) => console.log(appKeys))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAppKeys(appDefinitionId: string, query: BasicQueryOptions = {}) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -922,6 +954,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((result) => console.log(result))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     deleteAppKey(appDefinitionId: string, fingerprint: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -950,6 +983,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appDetails) => console.log(appDetails))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     upsertAppDetails(appDefinitionId: string, data: CreateAppDetailsProps) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -975,6 +1009,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appDetails) => console.log(appDetails))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAppDetails(appDefinitionId: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -999,6 +1034,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((result) => console.log(result))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     deleteAppDetails(appDefinitionId: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -1029,6 +1065,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appAction) => console.log(appAction))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createAppAction(appDefinitionId: string, data: CreateAppActionProps) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -1058,6 +1095,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appAction) => console.log(appAction))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     updateAppAction(appDefinitionId: string, appActionId: string, data: CreateAppActionProps) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -1083,6 +1121,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((result) => console.log(result))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     deleteAppAction(appDefinitionId: string, appActionId: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -1109,6 +1148,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appAction) => console.log(appAction))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAppAction(appDefinitionId: string, appActionId: string) {
       const raw = this.toPlainObject() as OrganizationProp
@@ -1133,6 +1173,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * .then((appActions) => console.log(appActions))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getAppActions(appDefinitionId: string) {
       const raw = this.toPlainObject() as OrganizationProp

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -63,6 +63,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      *   .then(() => console.log('Space deleted.'))
      *   .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     delete: function deleteSpace() {
       const raw = this.toPlainObject() as SpaceProps
@@ -90,6 +91,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((space) => console.log(`Space ${space.sys.id} renamed.`)
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     update: function updateSpace() {
       const raw = this.toPlainObject() as SpaceProps
@@ -117,6 +119,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((environment) => console.log(environment))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getEnvironment(environmentId: string) {
       const raw = this.toPlainObject() as SpaceProps
@@ -143,6 +146,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getEnvironments(query: PaginationQueryOptions = {}) {
       const raw = this.toPlainObject() as SpaceProps
@@ -169,6 +173,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((environment) => console.log(environment))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createEnvironment(data: CreateEnvironmentProps = {}) {
       const raw = this.toPlainObject() as SpaceProps
@@ -200,6 +205,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((environment) => console.log(environment))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createEnvironmentWithId(
       id: string,
@@ -235,6 +241,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((webhook) => console.log(webhook))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getWebhook(id: string) {
       const raw = this.toPlainObject() as SpaceProps
@@ -260,6 +267,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getWebhooks() {
       const raw = this.toPlainObject() as SpaceProps
@@ -285,6 +293,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      *   .then((response) => console.log(response.redactedValue))
      *   .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getWebhookSigningSecret: function getSigningSecret() {
       const raw = this.toPlainObject() as SpaceProps
@@ -310,6 +319,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      *   .then((response) => console.log(response.redactedValue))
      *   .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getWebhookRetryPolicy: function getWebhookRetryPolicy() {
       const raw = this.toPlainObject() as SpaceProps
@@ -341,6 +351,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((webhook) => console.log(webhook))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createWebhook(data: CreateWebhooksProps) {
       const raw = this.toPlainObject() as SpaceProps
@@ -374,6 +385,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((webhook) => console.log(webhook))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createWebhookWithId(id: string, data: CreateWebhooksProps) {
       const raw = this.toPlainObject() as SpaceProps
@@ -404,6 +416,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      *   .then((response) => console.log(response.redactedValue))
      *   .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     upsertWebhookSigningSecret: function getSigningSecret(data: UpsertWebhookSigningSecretPayload) {
       const raw = this.toPlainObject() as SpaceProps
@@ -432,6 +445,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      *   .then((response) => console.log(response.redactedValue))
      *   .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     upsertWebhookRetryPolicy: function upsertWebhookRetryPolicy(data: WebhookRetryPolicyPayload) {
       const raw = this.toPlainObject() as SpaceProps
@@ -458,6 +472,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      *   .then(() => console.log("success"))
      *   .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     deleteWebhookSigningSecret: function getSigningSecret() {
       const raw = this.toPlainObject() as SpaceProps
@@ -482,6 +497,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      *   .then(() => console.log("success"))
      *   .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     deleteWebhookRetryPolicy: function deleteRetryPolicy() {
       const raw = this.toPlainObject() as SpaceProps
@@ -514,6 +530,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((role) => console.log(role))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getRole(id: string) {
       const raw = this.toPlainObject() as SpaceProps
@@ -538,6 +555,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getRoles(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as SpaceProps
@@ -593,6 +611,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((role) => console.log(role))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createRole(data: CreateRoleProps) {
       const raw = this.toPlainObject() as SpaceProps
@@ -649,6 +668,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((role) => console.log(role))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createRoleWithId(id: string, roleData: Omit<RoleProps, 'sys'>) {
       const raw = this.toPlainObject() as SpaceProps
@@ -671,6 +691,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((user) => console.log(user))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getSpaceUser(userId: string) {
       const raw = this.toPlainObject() as SpaceProps
@@ -695,6 +716,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((data) => console.log(data))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getSpaceUsers(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as SpaceProps
@@ -720,6 +742,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((teamsCollection) => console.log(teamsCollection))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getTeams(query: QueryOptions = { limit: 100 }) {
       const raw = this.toPlainObject() as SpaceProps
@@ -744,6 +767,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((spaceMember) => console.log(spaceMember))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getSpaceMember(id: string) {
       const raw = this.toPlainObject() as SpaceProps
@@ -765,6 +789,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((spaceMemberCollection) => console.log(spaceMemberCollection))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getSpaceMembers(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as SpaceProps
@@ -790,6 +815,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((spaceMembership) => console.log(spaceMembership))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getSpaceMembership(id: string) {
       const raw = this.toPlainObject() as SpaceProps
@@ -812,6 +838,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getSpaceMemberships(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as SpaceProps
@@ -852,6 +879,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((spaceMembership) => console.log(spaceMembership))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createSpaceMembership(data: CreateSpaceMembershipProps) {
       const raw = this.toPlainObject() as SpaceProps
@@ -892,6 +920,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((spaceMembership) => console.log(spaceMembership))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createSpaceMembershipWithId(id: string, data: CreateSpaceMembershipProps) {
       const raw = this.toPlainObject() as SpaceProps
@@ -918,6 +947,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((teamSpaceMembership) => console.log(teamSpaceMembership))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getTeamSpaceMembership(teamSpaceMembershipId: string) {
       const raw = this.toPlainObject() as SpaceProps
@@ -943,6 +973,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getTeamSpaceMemberships(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as SpaceProps
@@ -983,6 +1014,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
    * .then((teamSpaceMembership) => console.log(teamSpaceMembership))
    * .catch(console.error)
    * ```
+   * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
    */
     createTeamSpaceMembership(teamId: string, data: CreateTeamSpaceMembershipProps) {
       const raw = this.toPlainObject() as SpaceProps
@@ -1012,6 +1044,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((apikey) => console.log(apikey))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getApiKey(id: string) {
       const raw = this.toPlainObject() as SpaceProps
@@ -1039,6 +1072,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getApiKeys() {
       const raw = this.toPlainObject() as SpaceProps
@@ -1065,6 +1099,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getPreviewApiKeys() {
       const raw = this.toPlainObject() as SpaceProps
@@ -1092,6 +1127,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((previewApikey) => console.log(previewApikey))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getPreviewApiKey(id: string) {
       const raw = this.toPlainObject() as SpaceProps
@@ -1132,6 +1168,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((apiKey) => console.log(apiKey))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createApiKey: function createApiKey(payload: CreateApiKeyProps) {
       const raw = this.toPlainObject() as SpaceProps
@@ -1171,6 +1208,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((apiKey) => console.log(apiKey))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createApiKeyWithId(id: string, payload: CreateApiKeyProps) {
       const raw = this.toPlainObject() as SpaceProps
@@ -1203,6 +1241,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((environmentAlias) => console.log(environmentAlias))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createEnvironmentAliasWithId(environmentAliasId: string, data: CreateEnvironmentAliasProps) {
       const raw = this.toPlainObject() as SpaceProps
@@ -1230,6 +1269,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((alias) => console.log(alias))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getEnvironmentAlias(environmentAliasId: string) {
       const raw = this.toPlainObject() as SpaceProps
@@ -1254,6 +1294,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      * .then((response) => console.log(response.items))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getEnvironmentAliases() {
       const raw = this.toPlainObject() as SpaceProps
@@ -1285,6 +1326,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      *    .then((scheduledActionCollection) => console.log(scheduledActionCollection.items))
      *    .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getScheduledActions(query: ScheduledActionQueryOptions) {
       const raw = this.toPlainObject() as SpaceProps
@@ -1314,6 +1356,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      *    .then((scheduledAction) => console.log(scheduledAction))
      *    .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     getScheduledAction({
       scheduledActionId,
@@ -1371,6 +1414,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      *    .then((scheduledAction) => console.log(scheduledAction))
      *    .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     createScheduledAction(data: Omit<ScheduledActionProps, 'sys'>) {
       const raw = this.toPlainObject() as SpaceProps
@@ -1431,6 +1475,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      *    .then((scheduledAction) => console.log(scheduledAction))
      *    .catch(console.error);
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     updateScheduledAction({
       scheduledActionId,
@@ -1479,6 +1524,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      *    .then((scheduledAction) => console.log(scheduledAction))
      *    .catch(console.error);
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     deleteScheduledAction({
       scheduledActionId,

--- a/lib/create-ui-config-api.ts
+++ b/lib/create-ui-config-api.ts
@@ -46,6 +46,7 @@ export default function createUIConfigApi(makeRequest: MakeRequest) {
      * .then((uiConfig) => console.log(`UIConfig updated.`))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     update: async function update() {
       const { raw, params } = getParams(this)

--- a/lib/create-user-ui-config-api.ts
+++ b/lib/create-user-ui-config-api.ts
@@ -46,6 +46,7 @@ export default function createUserUIConfigApi(makeRequest: MakeRequest) {
      * .then((uiConfig) => console.log(`UserUIConfig updated.`))
      * .catch(console.error)
      * ```
+     * @deprecated The `old` client is deprecated in favor of the `plain` client since version 12.0.0.
      */
     update: async function update() {
       const { raw, params } = getParams(this)

--- a/lib/plain/plain-client-test.ts
+++ b/lib/plain/plain-client-test.ts
@@ -19,7 +19,7 @@ describe('Plain Client', () => {
     },
   }
 
-  const plainClient = createClient({ apiAdapter }, { type: 'plain' })
+  const plainClient = createClient({ apiAdapter }, {})
 
   describe('Comment', () => {
     describe('when body is plain text', () => {

--- a/test/unit/contentful-management-test.js
+++ b/test/unit/contentful-management-test.js
@@ -27,21 +27,21 @@ describe('Contentful Management', () => {
   })
 
   it('creates nested client', () => {
-    createClient({ accessToken: 'token' })
+    createClient({ accessToken: 'token' }, { type: 'legacy' })
 
     expect(createPlainClientMock.notCalled).to.be.ok
     expect(createContentfulApiMock.called).to.be.ok
   })
 
   it('creates plain client', () => {
-    createClient({ accessToken: 'token' }, { type: 'plain' })
+    createClient({ accessToken: 'token' })
 
     expect(createPlainClientMock.called).to.be.ok
     expect(createContentfulApiMock.notCalled).to.be.ok
   })
 
   it('generates the correct default user agent', () => {
-    createClient({ accessToken: 'token' })
+    createClient({ accessToken: 'token' }, { type: 'legacy' })
 
     expect(makeRequestMock.notCalled).to.be.ok
 
@@ -59,12 +59,15 @@ describe('Contentful Management', () => {
   })
 
   it('generates the correct user agent', () => {
-    createClient({
-      accessToken: 'token',
-      application: 'myApplication/1.1.1',
-      integration: 'myIntegration/1.0.0',
-      feature: 'some-feature',
-    })
+    createClient(
+      {
+        accessToken: 'token',
+        application: 'myApplication/1.1.1',
+        integration: 'myIntegration/1.0.0',
+        feature: 'some-feature',
+      },
+      { type: 'legacy' }
+    )
 
     expect(makeRequestMock.notCalled).to.be.ok
 


### PR DESCRIPTION
## Summary

With the next major version (`12.0.0`) we finally will deprecate the old client shape.

## Description
From now on, the _old_ client type will be called _legacy_

### Changes
- All legacy client methods are marked as `deprecated` 
- The default client will be the _plain_ client
- Users can opt-in to the _legacy_ client


## Motivation and Context
The plain client comes with a list of advantages over the legacy client:
- Same client API as within the APP SDK (already uses the plain client type)
- No more waterfall calls
- Maintainability and velocity as we only need to support a single client shape in the future 

## ToDo
- [ ] Update Readme
- [ ] Update Tests



## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation


BREAKING CHANGE: The plain client will become the new default client