### PR TITLE
fix: pin axios to 1.6.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ registries:
     token: ${{secrets.NPM_REGISTRY_REGISTRY_GH_ORG_TOKEN}}
 updates:
   - package-ecosystem: npm
+    versioning-strategy: lockfile-only
     registries:
       - npm-github
     directory: "/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@contentful/rich-text-types": "^16.3.0",
         "@types/json-patch": "0.0.30",
-        "axios": "^1.6.2",
+        "axios": "~1.6.8",
         "contentful-sdk-core": "^8.1.0",
         "fast-copy": "^3.0.0",
         "lodash.isplainobject": "^4.0.6",
@@ -4796,9 +4796,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.1.tgz",
-      "integrity": "sha512-+LV37nQcd1EpFalkXksWNBiA17NZ5m5/WspmHGmZmdx1qBOg/VNq/c4eRJiA9VQQHBOs+N0ZhhdU10h2TyNK7Q==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@contentful/rich-text-types": "^16.3.0",
     "@types/json-patch": "0.0.30",
-    "axios": "^1.6.2",
+    "axios": "~1.6.8",
     "contentful-sdk-core": "^8.1.0",
     "fast-copy": "^3.0.0",
     "lodash.isplainobject": "^4.0.6",


### PR DESCRIPTION
We're not yet certain that axios 1.7.x is compatible with the underlying [contentful-sdk-core](https://github.com/contentful/contentful-sdk-core) library that this SDK depends on. We'll upgrade to that version manually when we're more certain about that. In the mean time, this change will prevent Dependabot from making that upgrade for us.