### PR TITLE
fix: export ParameterType and ParameterOption [EXT-5252]

### DIFF
--- a/lib/entities/widget-parameters.ts
+++ b/lib/entities/widget-parameters.ts
@@ -1,6 +1,6 @@
-type ParameterType = 'Boolean' | 'Symbol' | 'Number' | 'Enum'
+export type ParameterType = 'Boolean' | 'Symbol' | 'Number' | 'Enum'
 export type InstallationParameterType = ParameterType | 'Secret'
-type ParameterOption = string | { [key: string]: string }
+export type ParameterOption = string | { [key: string]: string }
 
 export interface ParameterDefinition<T = ParameterType> {
   name: string

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -262,6 +262,8 @@ export type {
   DefinedParameters,
   FreeFormParameters,
   ParameterDefinition,
+  ParameterOption,
+  ParameterType,
   InstallationParameterType,
 } from './entities/widget-parameters'
 export type {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

`ParameterType` and `ParameterOption` should be exported from `entities/widget-parameters` so they can be used in other codebases without duplication. 

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

