### PR TITLE
feat: add `fetchAll` convenience method on top of paginated endpoints

### DIFF
--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -16,6 +16,7 @@ import * as editorInterfaceDefaults from './constants/editor-interface-defaults'
 
 export type { ClientAPI } from './create-contentful-api'
 export { asIterator } from './plain/as-iterator'
+export { fetchAll } from './plain/pagination-helper'
 export { isDraft, isPublished, isUpdated } from './plain/checks'
 export type { PlainClientAPI } from './plain/common-types'
 export { createClient }

--- a/lib/plain/pagination-helper.ts
+++ b/lib/plain/pagination-helper.ts
@@ -1,0 +1,110 @@
+import {
+  BasicCursorPaginationOptions,
+  CollectionProp,
+  CursorPaginatedCollectionProp,
+  PaginationQueryOptions,
+} from '../common-types'
+
+export type OffsetBasedParams = { query?: PaginationQueryOptions }
+export type CursorBasedParams = { query?: BasicCursorPaginationOptions }
+
+type ExpectedParams = OffsetBasedParams | CursorBasedParams
+type IterableCollection<T> = CollectionProp<T> | CursorPaginatedCollectionProp<T>
+export type FetchFn<P extends ExpectedParams, T = unknown> = (
+  params: P
+) => Promise<IterableCollection<T>>
+type ParamsType<P extends ExpectedParams, T extends FetchFn<P>> = T extends (
+  params: infer P
+) => unknown
+  ? P
+  : never
+
+function isOffsetBasedCollection<T>(collection: any): collection is CollectionProp<T> {
+  return 'total' in collection
+}
+
+type CursorBasedCollection<T> = Required<Pick<CursorPaginatedCollectionProp<T>, 'pages'>> &
+  Omit<CursorPaginatedCollectionProp<T>, 'pages'>
+
+function isCursorBasedCollection<T>(collection: any): collection is CursorBasedCollection<T> {
+  return 'pages' in collection
+}
+
+function getSearchParam(url: string, paramName: string): string | null {
+  const searchIndex = url.indexOf('?')
+  if (searchIndex < 0) {
+    return null
+  }
+
+  const rawSearchParams = url.slice(searchIndex + 1)
+  const searchParams = new URLSearchParams(rawSearchParams)
+  return searchParams.get(paramName)
+}
+
+function range(from: number, to: number): number[] {
+  return Array.from(Array(Math.abs(to - from)), (_, i) => from + i)
+}
+
+/**
+ * Parameters for endpoint methods that can be paginated are inconsistent, `fetchAll` will only
+ * work with the more common version of supplying the limit, skip, and pageNext parameters via a distinct `query` property in the
+ * parameters.
+ */
+export async function fetchAll<
+  Params extends ExpectedParams,
+  Entity,
+  F extends FetchFn<Params, Entity>
+>(fetchFn: FetchFn<Params, Entity>, params: ParamsType<Params, F>): Promise<Entity[]> {
+  const response = await fetchFn({ ...params })
+
+  if (isOffsetBasedCollection(response)) {
+    const { total, limit, items } = response
+    const hasMorePages = total > items.length
+
+    if (!hasMorePages) {
+      return items
+    }
+
+    const pageCount = Math.ceil(total / limit)
+    const promises = range(1, pageCount).map((page) =>
+      fetchFn({
+        ...params,
+        query: {
+          ...params.query,
+          limit,
+          skip: page * limit,
+        },
+      }).then((result) => result.items)
+    )
+    const remainingItems = await Promise.all(promises)
+
+    return [...items, ...remainingItems.flat(1)]
+  }
+
+  if (isCursorBasedCollection(response)) {
+    const { pages, items } = response
+    if (!pages.next) {
+      return items
+    }
+
+    const pageNext = getSearchParam(pages.next, 'pageNext')
+    if (!pageNext) {
+      throw new Error('Missing "pageNext" query param from pages.next from response.')
+    }
+
+    return [
+      ...items,
+      ...(await fetchAll(fetchFn, {
+        ...params,
+        query: {
+          ...params.query,
+          pageNext,
+        },
+      })),
+    ]
+  }
+
+  throw new Error(
+    `Can not determine collection type of response, neither property "total" nor "pages" are present.`
+  )
+}

--- a/test/unit/plain/pagination-helper-test.ts
+++ b/test/unit/plain/pagination-helper-test.ts
@@ -1,0 +1,141 @@
+import { describe, it } from 'mocha'
+import sinon from 'sinon'
+import defaultsDeep from 'lodash/defaultsDeep'
+import {
+  CursorBasedParams,
+  fetchAll,
+  FetchFn,
+  OffsetBasedParams,
+} from '../../../lib/plain/pagination-helper'
+import {
+  BasicCursorPaginationOptions,
+  type CollectionProp,
+  type CursorPaginatedCollectionProp,
+} from '../../../lib/common-types'
+import { expect } from 'chai'
+
+const defaultLimit = 2
+
+describe(`pagination helpers`, () => {
+  describe('offset based pagination', () => {
+    function createOffsetBasedEndpoint<T>(items: T[]): FetchFn<OffsetBasedParams, T> {
+      return async (params): Promise<CollectionProp<T>> => {
+        const {
+          query: { skip, limit },
+        } = defaultsDeep(params, { query: { limit: defaultLimit, skip: 0 } })
+        return {
+          sys: {
+            type: 'Array',
+          },
+          items: items.slice(skip, skip + limit),
+          total: items.length,
+          skip,
+          limit,
+        }
+      }
+    }
+
+    it('only fires one request if all fetched are in one request', async () => {
+      const items = [1, 2, 3, 4, 5]
+      const iterableFn = sinon.spy(createOffsetBasedEndpoint(items))
+
+      const params = { query: { limit: 100 } }
+      const actualItems = await fetchAll(iterableFn, params)
+
+      expect(actualItems).to.eql(items)
+      sinon.assert.calledOnce(iterableFn)
+      sinon.assert.calledWith(iterableFn, params)
+    })
+
+    it('returns all items from offset based endpoints', async () => {
+      const items = [1, 2, 3, 4, 5]
+      const iterableFn = sinon.spy(createOffsetBasedEndpoint(items))
+
+      const actualItems = await fetchAll(iterableFn, {})
+
+      expect(actualItems).to.eql(items)
+      sinon.assert.calledThrice(iterableFn)
+      sinon.assert.calledWith(iterableFn, { query: { limit: defaultLimit, skip: 0 } })
+      sinon.assert.calledWith(iterableFn, { query: { limit: defaultLimit, skip: 2 } })
+      sinon.assert.calledWith(iterableFn, { query: { limit: defaultLimit, skip: 4 } })
+    })
+
+    it('forwards given params', async () => {
+      const items = [1, 2, 3, 4, 5]
+      const iterableFn = sinon.spy(createOffsetBasedEndpoint(items))
+
+      const actualItems = await fetchAll(iterableFn, {
+        query: { limit: 99, order: '-sys.updatedAt' },
+      })
+
+      expect(actualItems).to.eql(items)
+      sinon.assert.calledOnce(iterableFn)
+      sinon.assert.calledWith(iterableFn, {
+        query: { limit: 99, skip: 0, order: '-sys.updatedAt' },
+      })
+    })
+  })
+
+  describe(`cursor based pagination`, () => {
+    function createCursorBasedEndpoint<
+      P extends CursorBasedParams = CursorBasedParams,
+      T = unknown
+    >(items: T[]): FetchFn<P, T> {
+      return async (params): Promise<CursorPaginatedCollectionProp<T>> => {
+        const {
+          query: { limit, pageNext },
+        } = defaultsDeep(params, { query: { limit: defaultLimit } })
+        const skip = parseInt(pageNext ?? '0', 10)
+        const end = skip + limit
+        const next = end < items.length ? `/does/not/matter?pageNext=${String(end)}` : undefined
+
+        return {
+          sys: {
+            type: 'Array',
+          },
+          items: items.slice(skip, skip + limit),
+          limit,
+          pages: { next },
+        }
+      }
+    }
+
+    it('only fires one request if all fetched are in one request', async () => {
+      const items = [1, 2, 3, 4, 5]
+      const iterableFn = sinon.spy(createCursorBasedEndpoint(items))
+      const actualItems = await fetchAll(iterableFn, { query: { limit: 10 } })
+
+      expect(actualItems).to.eql(items)
+      sinon.assert.calledOnce(iterableFn)
+    })
+
+    it('returns all items from cursor based endpoints', async () => {
+      const items = [1, 2, 3, 4, 5]
+      const iterableFn = sinon.spy(createCursorBasedEndpoint(items))
+
+      const actualItems = await fetchAll(iterableFn, {})
+
+      expect(actualItems).to.eql(items)
+      sinon.assert.calledThrice(iterableFn)
+      sinon.assert.calledWith(iterableFn, { query: { limit: defaultLimit } })
+      sinon.assert.calledWith(iterableFn, { query: { limit: defaultLimit, pageNext: '2' } })
+      sinon.assert.calledWith(iterableFn, { query: { limit: defaultLimit, pageNext: '4' } })
+    })
+
+    it('forwards given params', async () => {
+      const items = [1, 2, 3, 4, 5]
+      type AdditionalParams = {
+        query?: {
+          foo?: string
+        } & BasicCursorPaginationOptions
+      }
+      const iterableFn = sinon.spy(createCursorBasedEndpoint<AdditionalParams>(items))
+
+      const actualItems = await fetchAll(iterableFn, { query: { foo: 'bar', limit: 100 } })
+
+      expect(actualItems).to.eql(items)
+      sinon.assert.calledOnce(iterableFn)
+      sinon.assert.calledWith(iterableFn, { query: { limit: 100, foo: 'bar' } })
+    })
+  })
+})


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

We plastered a few versions of this behaviour in Contentful internal packages, so clearly there is a need for it. This is why we want to start having a single source of truth for it.

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

The introduced `fetchAll` method can handle offset-based and cursor-based endpoints by inspecting the initial response.

We have one caveat though: As we have inconsistent ways of handling how we pass down optional query parameters (sometimes as distinct `query` property, sometimes mingled with mandatory properties). I opted for the more explicit version of using a distinct property. In case there is a need downstream the endpoint method that can't be handled automatically simply need to be wrapped.

An example for the raw.get method looks like this:

```typescript
const items = await fetchAll(({ query }) => cmaClient.raw.get<CollectionProp<any>>(url, { params: query }), {})
```