### PR TITLE
fix: ensure json is installed globally before running semantic-release []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,7 @@ jobs:
       - checkout
       - install-dependencies
       - use-vault
+      - run: npm install -g json
       - run: npm run semantic-release
 
 workflows:


### PR DESCRIPTION
## Summary

The `json` package is used by `contentful-sdk-jsdoc` here: https://github.com/contentful/contentful-sdk-jsdoc/blob/master/bin/publish-docs.sh#L15, so we need to make sure it is installed prior to running the release step 

