### PR TITLE
fix: omit `sys` type property in fetchAll helper

### DIFF
--- a/lib/plain/pagination-helper.ts
+++ b/lib/plain/pagination-helper.ts
@@ -9,7 +9,11 @@ export type OffsetBasedParams = { query?: PaginationQueryOptions }
 export type CursorBasedParams = { query?: BasicCursorPaginationOptions }
 
 type ExpectedParams = OffsetBasedParams | CursorBasedParams
-type IterableCollection<T> = CollectionProp<T> | CursorPaginatedCollectionProp<T>
+/**
+ * `sys.type` tends to cause type clashes downstream because it more commonly types less strict
+ * as 'string'. Because we don't rely on it for this functionality, we are fine with omitting it.
+ */
+type IterableCollection<T> = Omit<CollectionProp<T> | CursorPaginatedCollectionProp<T>, 'sys'>
 export type FetchFn<P extends ExpectedParams, T = unknown> = (
   params: P
 ) => Promise<IterableCollection<T>>


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

As mentioned in the code, we loosely type `sys.type` of collections in our App SDK as string and therefore have problems using the convenience helper.