### PR TITLE
fix: align types to API and normalize naming

### DIFF
--- a/lib/adapters/REST/endpoints/access-token.ts
+++ b/lib/adapters/REST/endpoints/access-token.ts
@@ -3,7 +3,7 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import type { CollectionProp, GetOrganizationParams, QueryParams } from '../../../common-types'
 import type {
   CreatePersonalAccessTokenProps,
-  AccessTokenProp,
+  AccessTokenProps,
 } from '../../../entities/access-token'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
@@ -14,7 +14,7 @@ import * as raw from './raw'
  * @param {AxiosInstance} http - An Axios HTTP client instance.
  * @param {Object} params - Parameters for the request.
  * @param {string} params.tokenId - The unique token ID of the access token to retrieve.
- * @returns {Promise<AccessTokenProp>} A Promise that resolves with the retrieved access token information.
+ * @returns {Promise<AccessTokenProps>} A Promise that resolves with the retrieved access token information.
  * @example ```javascript
  * const contentful = require('contentful-management')
  *
@@ -33,7 +33,7 @@ export const get: RestEndpoint<'AccessToken', 'get'> = (
   http: AxiosInstance,
   params: { tokenId: string }
 ) => {
-  return raw.get<AccessTokenProp>(http, `/users/me/access_tokens/${params.tokenId}`)
+  return raw.get<AccessTokenProps>(http, `/users/me/access_tokens/${params.tokenId}`)
 }
 
 /**
@@ -41,7 +41,7 @@ export const get: RestEndpoint<'AccessToken', 'get'> = (
  *
  * @param {AxiosInstance} http - An Axios HTTP client instance.
  * @param {QueryParams} params - Query parameters to filter and customize the request.
- * @returns {Promise<CollectionProp<AccessTokenProp>>} A Promise that resolves with a collection of access token properties.
+ * @returns {Promise<CollectionProp<AccessTokenProps>>} A Promise that resolves with a collection of access token properties.
  * @example ```javascript
  * const contentful = require('contentful-management')
  *
@@ -60,7 +60,7 @@ export const getMany: RestEndpoint<'AccessToken', 'getMany'> = (
   http: AxiosInstance,
   params: QueryParams
 ) => {
-  return raw.get<CollectionProp<AccessTokenProp>>(http, '/users/me/access_tokens', {
+  return raw.get<CollectionProp<AccessTokenProps>>(http, '/users/me/access_tokens', {
     params: params.query,
   })
 }
@@ -72,7 +72,7 @@ export const getMany: RestEndpoint<'AccessToken', 'getMany'> = (
  * @param {Object} _params - Unused parameters (can be an empty object).
  * @param {CreatePersonalAccessTokenProps} rawData - Data for creating the personal access token.
  * @param {RawAxiosRequestHeaders} [headers] - Optional HTTP headers for the request.
- * @returns {Promise<AccessTokenProp>} A Promise that resolves with the created personal access token.
+ * @returns {Promise<AccessTokenProps>} A Promise that resolves with the created personal access token.
  * @example ```javascript
  * const contentful = require('contentful-management')
  *
@@ -93,7 +93,7 @@ export const createPersonalAccessToken: RestEndpoint<'AccessToken', 'createPerso
   rawData: CreatePersonalAccessTokenProps,
   headers?: RawAxiosRequestHeaders
 ) => {
-  return raw.post<AccessTokenProp>(http, '/users/me/access_tokens', rawData, {
+  return raw.post<AccessTokenProps>(http, '/users/me/access_tokens', rawData, {
     headers,
   })
 }
@@ -104,7 +104,7 @@ export const createPersonalAccessToken: RestEndpoint<'AccessToken', 'createPerso
  * @param {AxiosInstance} http - The Axios HTTP client instance.
  * @param {Object} params - The parameters for revoking the access token.
  * @param {string} params.tokenId - The unique identifier of the access token to revoke.
- * @returns {Promise<AccessTokenProp>} A Promise that resolves with the updated access token information after revocation.
+ * @returns {Promise<AccessTokenProps>} A Promise that resolves with the updated access token information after revocation.
  * @example ```javascript
  * const contentful = require('contentful-management')
  *
@@ -123,7 +123,7 @@ export const revoke: RestEndpoint<'AccessToken', 'revoke'> = (
   http: AxiosInstance,
   params: { tokenId: string }
 ) => {
-  return raw.put<AccessTokenProp>(http, `/users/me/access_tokens/${params.tokenId}/revoked`, null)
+  return raw.put<AccessTokenProps>(http, `/users/me/access_tokens/${params.tokenId}/revoked`, null)
 }
 
 /**
@@ -132,7 +132,7 @@ export const revoke: RestEndpoint<'AccessToken', 'revoke'> = (
  * @param {AxiosInstance} http - The Axios HTTP client instance.
  * @param {GetOrganizationParams & QueryParams} params - Parameters for the request, including organization ID and query parameters.
  * @param {string} params.organizationId - The unique identifier of the organization.
- * @returns {Promise<CollectionProp<AccessTokenProp>>} A promise that resolves to a collection of access tokens.
+ * @returns {Promise<CollectionProp<AccessTokenProps>>} A promise that resolves to a collection of access tokens.
  * @example ```javascript
  * const contentful = require('contentful-management')
  *
@@ -151,7 +151,7 @@ export const getManyForOrganization: RestEndpoint<'AccessToken', 'getManyForOrga
   http: AxiosInstance,
   params: GetOrganizationParams & QueryParams
 ) => {
-  return raw.get<CollectionProp<AccessTokenProp>>(
+  return raw.get<CollectionProp<AccessTokenProps>>(
     http,
     `/organizations/${params.organizationId}/access_tokens`,
     {

--- a/lib/adapters/REST/endpoints/organization.ts
+++ b/lib/adapters/REST/endpoints/organization.ts
@@ -4,7 +4,7 @@ import type {
   GetOrganizationParams,
   PaginationQueryParams,
 } from '../../../common-types'
-import type { OrganizationProp } from '../../../entities/organization'
+import type { OrganizationProps } from '../../../entities/organization'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
 
@@ -12,7 +12,7 @@ export const getMany: RestEndpoint<'Organization', 'getMany'> = (
   http: AxiosInstance,
   params?: PaginationQueryParams
 ) => {
-  return raw.get<CollectionProp<OrganizationProp>>(http, `/organizations`, {
+  return raw.get<CollectionProp<OrganizationProps>>(http, `/organizations`, {
     params: params?.query,
   })
 }

--- a/lib/adapters/REST/endpoints/personal-access-token.ts
+++ b/lib/adapters/REST/endpoints/personal-access-token.ts
@@ -3,7 +3,7 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import type { CollectionProp, QueryParams } from '../../../common-types'
 import type {
   CreatePersonalAccessTokenProps,
-  PersonalAccessTokenProp,
+  PersonalAccessTokenProps,
 } from '../../../entities/personal-access-token'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
@@ -15,7 +15,7 @@ export const get: RestEndpoint<'PersonalAccessToken', 'get'> = (
   http: AxiosInstance,
   params: { tokenId: string }
 ) => {
-  return raw.get<PersonalAccessTokenProp>(http, `/users/me/access_tokens/${params.tokenId}`)
+  return raw.get<PersonalAccessTokenProps>(http, `/users/me/access_tokens/${params.tokenId}`)
 }
 
 /**
@@ -25,7 +25,7 @@ export const getMany: RestEndpoint<'PersonalAccessToken', 'getMany'> = (
   http: AxiosInstance,
   params: QueryParams
 ) => {
-  return raw.get<CollectionProp<PersonalAccessTokenProp>>(http, '/users/me/access_tokens', {
+  return raw.get<CollectionProp<PersonalAccessTokenProps>>(http, '/users/me/access_tokens', {
     params: params.query,
   })
 }
@@ -39,7 +39,7 @@ export const create: RestEndpoint<'PersonalAccessToken', 'create'> = (
   rawData: CreatePersonalAccessTokenProps,
   headers?: RawAxiosRequestHeaders
 ) => {
-  return raw.post<PersonalAccessTokenProp>(http, '/users/me/access_tokens', rawData, {
+  return raw.post<PersonalAccessTokenProps>(http, '/users/me/access_tokens', rawData, {
     headers,
   })
 }
@@ -51,7 +51,7 @@ export const revoke: RestEndpoint<'PersonalAccessToken', 'revoke'> = (
   http: AxiosInstance,
   params: { tokenId: string }
 ) => {
-  return raw.put<PersonalAccessTokenProp>(
+  return raw.put<PersonalAccessTokenProps>(
     http,
     `/users/me/access_tokens/${params.tokenId}/revoked`,
     null

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -41,7 +41,7 @@ import type {
 } from './entities/environment-alias'
 import type { CreateLocaleProps, LocaleProps } from './entities/locale'
 import type { AppInstallationsForOrganizationProps } from './entities/app-definition'
-import type { OrganizationProp } from './entities/organization'
+import type { OrganizationProps } from './entities/organization'
 import type {
   CreateOrganizationInvitationProps,
   OrganizationInvitationProps,
@@ -49,10 +49,10 @@ import type {
 import type { OrganizationMembershipProps } from './entities/organization-membership'
 import type {
   CreatePersonalAccessTokenProps,
-  PersonalAccessTokenProp,
+  PersonalAccessTokenProps,
 } from './entities/personal-access-token'
 import type {
-  AccessTokenProp,
+  AccessTokenProps,
   CreatePersonalAccessTokenProps as CreatePATProps,
 } from './entities/access-token'
 import type { PreviewApiKeyProps } from './entities/preview-api-key'
@@ -246,7 +246,6 @@ export interface BasicMetaSysProps {
 
 export interface MetaSysProps extends BasicMetaSysProps {
   space?: SysLink
-  status?: SysLink
   publishedVersion?: number
   archivedVersion?: number
   archivedBy?: SysLink
@@ -258,7 +257,7 @@ export interface MetaSysProps extends BasicMetaSysProps {
 
 export interface EntityMetaSysProps extends MetaSysProps {
   space: SysLink
-  contentType: SysLink
+  status?: SysLink
   environment: SysLink
   publishedBy?: Link<'User'> | Link<'AppDefinition'>
   publishedAt?: string
@@ -268,6 +267,7 @@ export interface EntityMetaSysProps extends MetaSysProps {
 }
 
 export interface EntryMetaSysProps extends EntityMetaSysProps {
+  contentType: SysLink
   automationTags: Link<'Tag'>[]
 }
 
@@ -1515,8 +1515,8 @@ export type MRActions = {
     }
   }
   Organization: {
-    getMany: { params: PaginationQueryParams; return: CollectionProp<OrganizationProp> }
-    get: { params: GetOrganizationParams; return: OrganizationProp }
+    getMany: { params: PaginationQueryParams; return: CollectionProp<OrganizationProps> }
+    get: { params: GetOrganizationParams; return: OrganizationProps }
   }
   OrganizationInvitation: {
     get: {
@@ -1546,29 +1546,29 @@ export type MRActions = {
     delete: { params: GetOrganizationMembershipParams; return: any }
   }
   PersonalAccessToken: {
-    get: { params: { tokenId: string }; return: PersonalAccessTokenProp }
-    getMany: { params: QueryParams; return: CollectionProp<PersonalAccessTokenProp> }
+    get: { params: { tokenId: string }; return: PersonalAccessTokenProps }
+    getMany: { params: QueryParams; return: CollectionProp<PersonalAccessTokenProps> }
     create: {
       params: {}
       payload: CreatePersonalAccessTokenProps
       headers?: RawAxiosRequestHeaders
-      return: PersonalAccessTokenProp
+      return: PersonalAccessTokenProps
     }
-    revoke: { params: { tokenId: string }; return: PersonalAccessTokenProp }
+    revoke: { params: { tokenId: string }; return: PersonalAccessTokenProps }
   }
   AccessToken: {
-    get: { params: { tokenId: string }; return: AccessTokenProp }
-    getMany: { params: QueryParams; return: CollectionProp<AccessTokenProp> }
+    get: { params: { tokenId: string }; return: AccessTokenProps }
+    getMany: { params: QueryParams; return: CollectionProp<AccessTokenProps> }
     createPersonalAccessToken: {
       params: {}
       payload: CreatePATProps
       headers?: RawAxiosRequestHeaders
-      return: AccessTokenProp
+      return: AccessTokenProps
     }
-    revoke: { params: { tokenId: string }; return: AccessTokenProp }
+    revoke: { params: { tokenId: string }; return: AccessTokenProps }
     getManyForOrganization: {
       params: GetOrganizationParams & QueryParams
-      return: CollectionProp<AccessTokenProp>
+      return: CollectionProp<AccessTokenProps>
     }
   }
   PreviewApiKey: {

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -11,7 +11,7 @@ import type {
   BasicCursorPaginationOptions,
 } from './common-types'
 import entities from './entities'
-import type { Organization, OrganizationProp } from './entities/organization'
+import type { Organization, OrganizationProps } from './entities/organization'
 import type { CreatePersonalAccessTokenProps } from './entities/personal-access-token'
 import type { Space, SpaceProps } from './entities/space'
 import type { AppDefinition } from './entities/app-definition'
@@ -260,7 +260,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      */
     getOrganizations: function getOrganizations(
       query: PaginationQueryParams['query'] = {}
-    ): Promise<Collection<Organization, OrganizationProp>> {
+    ): Promise<Collection<Organization, OrganizationProps>> {
       return makeRequest({
         entityType: 'Organization',
         action: 'getMany',

--- a/lib/create-organization-api.ts
+++ b/lib/create-organization-api.ts
@@ -11,7 +11,7 @@ import type { CreateAppSigningSecretProps } from './entities/app-signing-secret'
 import type { CreateAppEventSubscriptionProps } from './entities/app-event-subscription'
 import type { CreateAppKeyProps } from './entities/app-key'
 import type { CreateAppDetailsProps } from './entities/app-details'
-import type { OrganizationProp } from './entities/organization'
+import type { OrganizationProps } from './entities/organization'
 
 /**
  * @private
@@ -62,7 +62,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getSpaces(query: QueryOptions = {}) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
       return makeRequest({
         entityType: 'Space',
         action: 'getManyForOrganization',
@@ -89,7 +89,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getUser(id: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
       return makeRequest({
         entityType: 'User',
         action: 'getForOrganization',
@@ -113,7 +113,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getUsers(query: QueryOptions = {}) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
       return makeRequest({
         entityType: 'User',
         action: 'getManyForOrganization',
@@ -140,7 +140,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getOrganizationMembership(id: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
       const organizationId = raw.sys.id
       return makeRequest({
         entityType: 'OrganizationMembership',
@@ -169,7 +169,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      */
 
     getOrganizationMemberships(params: QueryParams = {}) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
       return makeRequest({
         entityType: 'OrganizationMembership',
         action: 'getMany',
@@ -198,7 +198,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     createTeam(data: CreateTeamProps) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'Team',
@@ -222,7 +222,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getTeam(teamId: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'Team',
@@ -245,7 +245,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getTeams(query: QueryOptions = {}) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'Team',
@@ -277,7 +277,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     createTeamMembership(teamId: string, data: CreateTeamMembershipProps) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'TeamMembership',
@@ -302,7 +302,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getTeamMembership(teamId: string, teamMembershipId: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'TeamMembership',
@@ -327,7 +327,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      */
     getTeamMemberships(opts: { teamId?: string; query?: QueryOptions } = {}) {
       const { teamId, query = {} } = opts
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       if (teamId) {
         return makeRequest({
@@ -367,7 +367,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getTeamSpaceMemberships(opts: { teamId?: string; query?: QueryOptions } = {}) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
       return makeRequest({
         entityType: 'TeamSpaceMembership',
         action: 'getManyForOrganization',
@@ -395,7 +395,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getTeamSpaceMembership(teamSpaceMembershipId: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'TeamSpaceMembership',
@@ -423,7 +423,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getOrganizationSpaceMembership(id: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
       return makeRequest({
         entityType: 'SpaceMembership',
         action: 'getForOrganization',
@@ -450,7 +450,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getOrganizationSpaceMemberships(query: QueryOptions = {}) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
       return makeRequest({
         entityType: 'SpaceMembership',
         action: 'getManyForOrganization',
@@ -476,7 +476,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getOrganizationInvitation(invitationId: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
       return makeRequest({
         entityType: 'OrganizationInvitation',
         action: 'get',
@@ -506,7 +506,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     createOrganizationInvitation(data: CreateOrganizationInvitationProps) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
       return makeRequest({
         entityType: 'OrganizationInvitation',
         action: 'create',
@@ -533,7 +533,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getRoles(query: QueryOptions = {}) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
       return makeRequest({
         entityType: 'Role',
         action: 'getManyForOrganization',
@@ -561,7 +561,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     createAppDefinition(data: CreateAppDefinitionProps) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
       return makeRequest({
         entityType: 'AppDefinition',
         action: 'create',
@@ -585,7 +585,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getAppDefinitions(query: QueryOptions = {}) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
       return makeRequest({
         entityType: 'AppDefinition',
         action: 'getMany',
@@ -609,7 +609,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getAppDefinition(id: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
       return makeRequest({
         entityType: 'AppDefinition',
         action: 'get',
@@ -633,7 +633,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getAppUpload(appUploadId: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppUpload',
@@ -658,7 +658,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     createAppUpload(file: string | ArrayBuffer | Stream) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppUpload',
@@ -683,7 +683,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     upsertAppSigningSecret(appDefinitionId: string, data: CreateAppSigningSecretProps) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppSigningSecret',
@@ -708,7 +708,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getAppSigningSecret(appDefinitionId: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppSigningSecret',
@@ -732,7 +732,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     deleteAppSigningSecret(appDefinitionId: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppSigningSecret',
@@ -758,7 +758,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     upsertAppEventSubscription(appDefinitionId: string, data: CreateAppEventSubscriptionProps) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppEventSubscription',
@@ -783,7 +783,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getAppEventSubscription(appDefinitionId: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppEventSubscription',
@@ -807,7 +807,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     deleteAppEventSubscription(appDefinitionId: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppEventSubscription',
@@ -840,7 +840,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     createAppKey(appDefinitionId: string, data: CreateAppKeyProps) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppKey',
@@ -865,7 +865,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getAppKey(appDefinitionId: string, fingerprint: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppKey',
@@ -896,7 +896,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getAppKeys(appDefinitionId: string, query: BasicQueryOptions = {}) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppKey',
@@ -924,7 +924,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     deleteAppKey(appDefinitionId: string, fingerprint: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppKey',
@@ -952,7 +952,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     upsertAppDetails(appDefinitionId: string, data: CreateAppDetailsProps) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppDetails',
@@ -977,7 +977,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getAppDetails(appDefinitionId: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppDetails',
@@ -1001,7 +1001,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     deleteAppDetails(appDefinitionId: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppDetails',
@@ -1031,7 +1031,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     createAppAction(appDefinitionId: string, data: CreateAppActionProps) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppAction',
@@ -1060,7 +1060,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     updateAppAction(appDefinitionId: string, appActionId: string, data: CreateAppActionProps) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppAction',
@@ -1085,7 +1085,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     deleteAppAction(appDefinitionId: string, appActionId: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppAction',
@@ -1111,7 +1111,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getAppAction(appDefinitionId: string, appActionId: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppAction',
@@ -1135,7 +1135,7 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
      * ```
      */
     getAppActions(appDefinitionId: string) {
-      const raw = this.toPlainObject() as OrganizationProp
+      const raw = this.toPlainObject() as OrganizationProps
 
       return makeRequest({
         entityType: 'AppAction',

--- a/lib/entities/access-token.ts
+++ b/lib/entities/access-token.ts
@@ -17,7 +17,7 @@ type AccessTokenSysProps = BasicMetaSysProps & {
   redactedValue: string
 }
 
-export type AccessTokenProp = {
+export type AccessTokenProps = {
   sys: AccessTokenSysProps
   name: string
   scopes: 'content_management_manage'[]
@@ -29,7 +29,7 @@ export type CreatePersonalAccessTokenProps = Pick<AccessToken, 'name' | 'scopes'
   expiresIn: number
 }
 
-export interface AccessToken extends AccessTokenProp, DefaultElements<AccessTokenProp> {
+export interface AccessToken extends AccessTokenProps, DefaultElements<AccessTokenProps> {
   /**
    * Revokes access token
    * @return Object the revoked access token
@@ -56,7 +56,7 @@ export interface AccessToken extends AccessTokenProp, DefaultElements<AccessToke
  * @param data - Raw  access token data
  * @return Wrapped access token
  */
-export function wrapAccessToken(makeRequest: MakeRequest, data: AccessTokenProp): AccessToken {
+export function wrapAccessToken(makeRequest: MakeRequest, data: AccessTokenProps): AccessToken {
   const AccessToken = toPlainObject(copy(data))
   const accessTokenWithMethods = enhanceWithMethods(AccessToken, {
     revoke: function () {

--- a/lib/entities/organization.ts
+++ b/lib/entities/organization.ts
@@ -6,11 +6,11 @@ import createOrganizationApi from '../create-organization-api'
 import { wrapCollection } from '../common-utils'
 import type { MetaSysProps, DefaultElements, MakeRequest } from '../common-types'
 
-export type Organization = DefaultElements<OrganizationProp> &
-  OrganizationProp &
+export type Organization = DefaultElements<OrganizationProps> &
+  OrganizationProps &
   ContentfulOrganizationAPI
 
-export type OrganizationProp = {
+export type OrganizationProps = {
   /**
    * System metadata
    */
@@ -31,7 +31,7 @@ export type OrganizationProp = {
  * @param data - API response for an Organization
  * @return {Organization}
  */
-export function wrapOrganization(makeRequest: MakeRequest, data: OrganizationProp): Organization {
+export function wrapOrganization(makeRequest: MakeRequest, data: OrganizationProps): Organization {
   const org = toPlainObject(copy(data))
   const orgApi = createOrganizationApi(makeRequest)
   const enhancedOrganization = enhanceWithMethods(org, orgApi)

--- a/lib/entities/personal-access-token.ts
+++ b/lib/entities/personal-access-token.ts
@@ -4,7 +4,7 @@ import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
 import type { MetaSysProps, DefaultElements, MakeRequest } from '../common-types'
 
-export type PersonalAccessTokenProp = {
+export type PersonalAccessTokenProps = {
   sys: MetaSysProps & { expiresAt?: string }
   name: string
   scopes: 'content_management_manage'[]
@@ -17,8 +17,8 @@ export type CreatePersonalAccessTokenProps = Pick<PersonalAccessToken, 'name' | 
 }
 
 export interface PersonalAccessToken
-  extends PersonalAccessTokenProp,
-    DefaultElements<PersonalAccessTokenProp> {
+  extends PersonalAccessTokenProps,
+    DefaultElements<PersonalAccessTokenProps> {
   /**
    * Revokes a personal access token
    * @return Object the revoked personal access token
@@ -47,7 +47,7 @@ export interface PersonalAccessToken
  */
 export function wrapPersonalAccessToken(
   makeRequest: MakeRequest,
-  data: PersonalAccessTokenProp
+  data: PersonalAccessTokenProps
 ): PersonalAccessToken {
   const personalAccessToken = toPlainObject(copy(data))
   const personalAccessTokenWithMethods = enhanceWithMethods(personalAccessToken, {

--- a/lib/entities/release-action.ts
+++ b/lib/entities/release-action.ts
@@ -19,6 +19,7 @@ export type ReleaseActionSysProps = {
   status: ReleaseActionStatuses
   createdBy: Link<'User'>
   createdAt: ISO8601Timestamp
+  updatedBy: Link<'User'>
   updatedAt: ISO8601Timestamp
 }
 

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -17,7 +17,7 @@ import enhanceWithMethods from '../enhance-with-methods'
 /**
  * Represents that state of the scheduled action
  */
-enum ScheduledActionStatus {
+export enum ScheduledActionStatus {
   /** action is pending execution */
   scheduled = 'scheduled',
   /** action has been started and pending completion */

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -144,7 +144,7 @@ export type {
 } from './entities/extension'
 export type { FieldType } from './entities/field-type'
 export type { CreateLocaleProps, Locale, LocaleProps } from './entities/locale'
-export type { Organization, OrganizationProp } from './entities/organization'
+export type { Organization, OrganizationProps } from './entities/organization'
 export type {
   CreateOrganizationInvitationProps,
   OrganizationInvitation,
@@ -157,12 +157,12 @@ export type {
 export type {
   CreatePersonalAccessTokenProps,
   PersonalAccessToken,
-  PersonalAccessTokenProp,
+  PersonalAccessTokenProps as PersonalAccessTokenProp,
 } from './entities/personal-access-token'
 export type {
   CreatePersonalAccessTokenProps as CreatePATProps,
   AccessToken,
-  AccessTokenProp,
+  AccessTokenProps as AccessTokenProp,
 } from './entities/access-token'
 export type { PreviewApiKey, PreviewApiKeyProps } from './entities/preview-api-key'
 export type {

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -35,10 +35,10 @@ import type {
 import type { OrganizationMembershipProps } from '../entities/organization-membership'
 import type {
   CreatePersonalAccessTokenProps,
-  PersonalAccessTokenProp,
+  PersonalAccessTokenProps,
 } from '../entities/personal-access-token'
 import type {
-  AccessTokenProp,
+  AccessTokenProps,
   CreatePersonalAccessTokenProps as CreatePATProps,
 } from '../entities/access-token'
 import type { PreviewApiKeyProps } from '../entities/preview-api-key'
@@ -390,25 +390,27 @@ export type PlainClientAPI = {
   upload: UploadPlainClientAPI
   locale: LocalePlainClientAPI
   personalAccessToken: {
-    get(params: OptionalDefaults<{ tokenId: string }>): Promise<PersonalAccessTokenProp>
-    getMany(params: OptionalDefaults<QueryParams>): Promise<CollectionProp<PersonalAccessTokenProp>>
+    get(params: OptionalDefaults<{ tokenId: string }>): Promise<PersonalAccessTokenProps>
+    getMany(
+      params: OptionalDefaults<QueryParams>
+    ): Promise<CollectionProp<PersonalAccessTokenProps>>
     create(
       rawData: CreatePersonalAccessTokenProps,
       headers?: RawAxiosRequestHeaders
-    ): Promise<PersonalAccessTokenProp>
-    revoke(params: OptionalDefaults<{ tokenId: string }>): Promise<PersonalAccessTokenProp>
+    ): Promise<PersonalAccessTokenProps>
+    revoke(params: OptionalDefaults<{ tokenId: string }>): Promise<PersonalAccessTokenProps>
   }
   accessToken: {
-    get(params: OptionalDefaults<{ tokenId: string }>): Promise<AccessTokenProp>
-    getMany(params: OptionalDefaults<QueryParams>): Promise<CollectionProp<AccessTokenProp>>
+    get(params: OptionalDefaults<{ tokenId: string }>): Promise<AccessTokenProps>
+    getMany(params: OptionalDefaults<QueryParams>): Promise<CollectionProp<AccessTokenProps>>
     createPersonalAccessToken(
       rawData: CreatePATProps,
       headers?: RawAxiosRequestHeaders
-    ): Promise<AccessTokenProp>
-    revoke(params: OptionalDefaults<{ tokenId: string }>): Promise<AccessTokenProp>
+    ): Promise<AccessTokenProps>
+    revoke(params: OptionalDefaults<{ tokenId: string }>): Promise<AccessTokenProps>
     getManyForOrganization(
       params: OptionalDefaults<GetOrganizationParams & QueryParams>
-    ): Promise<CollectionProp<AccessTokenProp>>
+    ): Promise<CollectionProp<AccessTokenProps>>
   }
   usage: UsagePlainClientAPI
   release: {

--- a/lib/plain/entities/organization.ts
+++ b/lib/plain/entities/organization.ts
@@ -3,7 +3,7 @@ import type {
   CollectionProp,
   GetOrganizationParams,
 } from '../../common-types'
-import type { OrganizationProp } from '../../entities/organization'
+import type { OrganizationProps } from '../../entities/organization'
 import type { OptionalDefaults } from '../wrappers/wrap'
 
 export type OrganizationPlainClientAPI = {
@@ -23,7 +23,7 @@ export type OrganizationPlainClientAPI = {
    */
   getAll(
     params?: OptionalDefaults<PaginationQueryParams>
-  ): Promise<CollectionProp<OrganizationProp>>
+  ): Promise<CollectionProp<OrganizationProps>>
   /**
    * Fetch a single organization by its ID
    * @param params the organization ID
@@ -36,5 +36,5 @@ export type OrganizationPlainClientAPI = {
    * })
    * ```
    */
-  get(params: OptionalDefaults<GetOrganizationParams>): Promise<OrganizationProp>
+  get(params: OptionalDefaults<GetOrganizationParams>): Promise<OrganizationProps>
 }


### PR DESCRIPTION
While rewriting and typing tests to vitest, I found out that some types are not reflecting the actual Contentful API structure. 

https://github.com/contentful/contentful-management.js/pull/2328

* Ensure all prop interfaces are plural
  * `AccessTokenProp` -> `AccessTokenProps`
  * `PersonalAccessTokenProp` -> `OrganizationProps`
  * `OrganizationProp` -> `OrganizationProps`
* `EntityMetaSysProps`
  * Removed `contentType` (As its entry only)
  * Added `status?` (Some entity have it)
* `EntryMetaSysProps`
  * Added `contentType` (As assets & co don't have this prop -> https://www.contentful.com/developers/docs/references/content-management-api/#/reference/assets/asset)
* `ReleaseActionSysProps`
  * Added `updatedBy` (https://www.contentful.com/developers/docs/references/content-management-api/#/reference/releases/releases)