### PR TITLE
fix: delete space membership in integ tests

### DIFF
--- a/test/defaults.ts
+++ b/test/defaults.ts
@@ -16,6 +16,7 @@ export const TestDefaults = {
   },
   userId: '0DdCYLZI33Oe1uZ0FLpCzw',
   userEmail: 'for_tests_contentful-management.js@contentful.com',
+  userEmail2: 'for_tests_contentful-management2.js@contentful.com',
   teamId: '4XQ2AGpitUAECQf7EPP392',
   teamName: '[FOR TESTS] contentful-management.js',
   teamMembershipId: '6vuRqhFc875EEIJ50lSMYG',

--- a/test/integration/space-membership-integration.js
+++ b/test/integration/space-membership-integration.js
@@ -2,7 +2,7 @@
 import { initClient, createTestSpace, generateRandomId } from '../helpers'
 import { TestDefaults } from '../defaults'
 
-const { userEmail } = TestDefaults
+const { userEmail, userEmail2 } = TestDefaults
 
 import { after, before, describe, test } from 'mocha'
 import { expect } from 'chai'
@@ -47,10 +47,7 @@ describe('SpaceMembership Api', function () {
     expect(spaceMembership.user, 'user').ok
     expect(spaceMembership.admin, 'admin').not.ok
     expect(spaceMembership.sys.type).equal('SpaceMembership', 'type')
-    return await spaceMembership.delete({
-      spaceId: space.sys.id,
-      spaceMembershipId: spaceMembership.sys.id,
-    })
+    return spaceMembership.delete()
   })
 
   test('Create spaceMembership with explicit id', async () => {
@@ -59,7 +56,7 @@ describe('SpaceMembership Api', function () {
     const roleId = roles.items[0].sys.id
     const spaceMembership = await space.createSpaceMembershipWithId(id, {
       admin: false,
-      email: userEmail,
+      email: userEmail2,
       roles: [
         {
           sys: {
@@ -74,9 +71,6 @@ describe('SpaceMembership Api', function () {
     expect(spaceMembership.user, 'user').ok
     expect(spaceMembership.admin, 'admin').not.ok
     expect(spaceMembership.sys.id).equals(id, 'id')
-    return await spaceMembership.delete({
-      spaceId: space.sys.id,
-      spaceMembershipId: spaceMembership.sys.id,
-    })
+    return spaceMembership.delete()
   })
 })

--- a/test/integration/space-membership-integration.js
+++ b/test/integration/space-membership-integration.js
@@ -47,7 +47,10 @@ describe('SpaceMembership Api', function () {
     expect(spaceMembership.user, 'user').ok
     expect(spaceMembership.admin, 'admin').not.ok
     expect(spaceMembership.sys.type).equal('SpaceMembership', 'type')
-    return spaceMembership.delete()
+    return await spaceMembership.delete({
+      spaceId: space.sys.id,
+      spaceMembershipId: spaceMembership.sys.id,
+    })
   })
 
   test('Create spaceMembership with explicit id', async () => {
@@ -71,6 +74,9 @@ describe('SpaceMembership Api', function () {
     expect(spaceMembership.user, 'user').ok
     expect(spaceMembership.admin, 'admin').not.ok
     expect(spaceMembership.sys.id).equals(id, 'id')
-    return spaceMembership.delete()
+    return await spaceMembership.delete({
+      spaceId: space.sys.id,
+      spaceMembershipId: spaceMembership.sys.id,
+    })
   })
 })


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
