### PR TITLE
chore: improve token length check in app-access-token-integration test

### DIFF
--- a/test/integration/app-access-token-integration.js
+++ b/test/integration/app-access-token-integration.js
@@ -69,6 +69,7 @@ describe('AppAccessToken api', function () {
       }
     )
 
-    expect(appAccessToken.token).to.have.lengthOf(292)
+    // Token length not deterministic, but should be within a certain range
+    expect(appAccessToken.token).to.have.length.within(285, 300)
   })
 })


### PR DESCRIPTION
JWT.sign is not guaranteed to be an exact length, so we need to give it some wiggle room.