### PR TITLE
chore: group dependency upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,20 @@ updates:
     commit-message:
       prefix: build
       include: scope
+    groups:
+      production-dependencies:
+        applies-to: version-updates
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+        patterns:
+          - '*'
+      dev-dependencies:
+        applies-to: version-updates
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+        patterns:
+          - '*'


### PR DESCRIPTION
fewer conflicting dependabot PRs, and fewer automatic version bumps of the contentful-management.js SDK