### PR TITLE
feat: add Resource Type to contentful-management [DANTE-1832]

### DIFF
--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -36,6 +36,7 @@ import * as PreviewApiKey from './preview-api-key'
 import * as Release from './release'
 import * as ReleaseAction from './release-action'
 import * as ResourceProvider from './resource-provider'
+import * as ResourceType from './resource-type'
 import * as Role from './role'
 import * as ScheduledAction from './scheduled-action'
 import * as Snapshot from './snapshot'
@@ -96,6 +97,7 @@ export default {
   Release,
   ReleaseAction,
   ResourceProvider,
+  ResourceType,
   Role,
   ScheduledAction,
   Snapshot,

--- a/lib/adapters/REST/endpoints/resource-type.ts
+++ b/lib/adapters/REST/endpoints/resource-type.ts
@@ -1,0 +1,35 @@
+import type { RawAxiosRequestHeaders } from 'axios'
+import type { AxiosInstance } from 'contentful-sdk-core'
+import * as raw from './raw'
+import copy from 'fast-copy'
+import type { GetResourceTypeParams } from '../../../common-types'
+import type { RestEndpoint } from '../types'
+import type { ResourceTypeProps, UpsertResourceTypeProps } from '../../../entities/resource-type'
+
+const getBaseUrl = (params: GetResourceTypeParams) =>
+  `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/resource_provider/resource_types/${params.resourceTypeId}`
+
+export const get: RestEndpoint<'ResourceType', 'get'> = (
+  http: AxiosInstance,
+  params: GetResourceTypeParams
+) => {
+  return raw.get<ResourceTypeProps>(http, getBaseUrl(params))
+}
+
+export const upsert: RestEndpoint<'ResourceType', 'upsert'> = (
+  http: AxiosInstance,
+  params: GetResourceTypeParams,
+  rawData: UpsertResourceTypeProps,
+  headers?: RawAxiosRequestHeaders
+) => {
+  const data = copy(rawData)
+
+  return raw.put<ResourceTypeProps>(http, getBaseUrl(params), data, { headers })
+}
+
+export const del: RestEndpoint<'ResourceType', 'delete'> = (
+  http: AxiosInstance,
+  params: GetResourceTypeParams
+) => {
+  return raw.del(http, getBaseUrl(params))
+}

--- a/lib/adapters/REST/endpoints/resource-type.ts
+++ b/lib/adapters/REST/endpoints/resource-type.ts
@@ -7,7 +7,9 @@ import { type GetResourceTypeParams } from '../../../common-types'
 import type { RestEndpoint } from '../types'
 import type { ResourceTypeProps, UpsertResourceTypeProps } from '../../../entities/resource-type'
 
-const getBaseUrl = (params: GetResourceTypeParams) =>
+const getBaseUrl = (
+  params: GetResourceTypeParams | Omit<GetResourceTypeParams, 'resourceTypeId'>
+) =>
   `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/resource_provider/resource_types`
 
 const getEntityUrl = (params: GetResourceTypeParams) =>
@@ -40,7 +42,7 @@ export const del: RestEndpoint<'ResourceType', 'delete'> = (
 
 export const getMany: RestEndpoint<'ResourceType', 'getMany'> = (
   http: AxiosInstance,
-  params: GetResourceTypeParams
+  params: Omit<GetResourceTypeParams, 'resourceTypeId'>
 ) => {
   return raw.get<CollectionProp<ResourceTypeProps>>(http, getBaseUrl(params))
 }

--- a/lib/adapters/REST/endpoints/resource-type.ts
+++ b/lib/adapters/REST/endpoints/resource-type.ts
@@ -2,7 +2,8 @@ import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import * as raw from './raw'
 import copy from 'fast-copy'
-import type { GetResourceTypeParams } from '../../../common-types'
+import type { CollectionProp } from '../../../common-types'
+import { type GetResourceProviderParams, type GetResourceTypeParams } from '../../../common-types'
 import type { RestEndpoint } from '../types'
 import type { ResourceTypeProps, UpsertResourceTypeProps } from '../../../entities/resource-type'
 
@@ -32,4 +33,14 @@ export const del: RestEndpoint<'ResourceType', 'delete'> = (
   params: GetResourceTypeParams
 ) => {
   return raw.del(http, getBaseUrl(params))
+}
+
+export const getMany: RestEndpoint<'ResourceType', 'getMany'> = (
+  http: AxiosInstance,
+  params: GetResourceProviderParams
+) => {
+  return raw.get<CollectionProp<ResourceTypeProps>>(
+    http,
+    `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/resource_provider/resource_types`
+  )
 }

--- a/lib/adapters/REST/endpoints/resource-type.ts
+++ b/lib/adapters/REST/endpoints/resource-type.ts
@@ -3,18 +3,21 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import * as raw from './raw'
 import copy from 'fast-copy'
 import type { CollectionProp } from '../../../common-types'
-import { type GetResourceProviderParams, type GetResourceTypeParams } from '../../../common-types'
+import { type GetResourceTypeParams } from '../../../common-types'
 import type { RestEndpoint } from '../types'
 import type { ResourceTypeProps, UpsertResourceTypeProps } from '../../../entities/resource-type'
 
 const getBaseUrl = (params: GetResourceTypeParams) =>
-  `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/resource_provider/resource_types/${params.resourceTypeId}`
+  `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/resource_provider/resource_types`
+
+const getEntityUrl = (params: GetResourceTypeParams) =>
+  `${getBaseUrl(params)}/${params.resourceTypeId}`
 
 export const get: RestEndpoint<'ResourceType', 'get'> = (
   http: AxiosInstance,
   params: GetResourceTypeParams
 ) => {
-  return raw.get<ResourceTypeProps>(http, getBaseUrl(params))
+  return raw.get<ResourceTypeProps>(http, getEntityUrl(params))
 }
 
 export const upsert: RestEndpoint<'ResourceType', 'upsert'> = (
@@ -25,22 +28,19 @@ export const upsert: RestEndpoint<'ResourceType', 'upsert'> = (
 ) => {
   const data = copy(rawData)
 
-  return raw.put<ResourceTypeProps>(http, getBaseUrl(params), data, { headers })
+  return raw.put<ResourceTypeProps>(http, getEntityUrl(params), data, { headers })
 }
 
 export const del: RestEndpoint<'ResourceType', 'delete'> = (
   http: AxiosInstance,
   params: GetResourceTypeParams
 ) => {
-  return raw.del(http, getBaseUrl(params))
+  return raw.del(http, getEntityUrl(params))
 }
 
 export const getMany: RestEndpoint<'ResourceType', 'getMany'> = (
   http: AxiosInstance,
-  params: GetResourceProviderParams
+  params: GetResourceTypeParams
 ) => {
-  return raw.get<CollectionProp<ResourceTypeProps>>(
-    http,
-    `/organizations/${params.organizationId}/app_definitions/${params.appDefinitionId}/resource_provider/resource_types`
-  )
+  return raw.get<CollectionProp<ResourceTypeProps>>(http, getBaseUrl(params))
 }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -788,7 +788,10 @@ export type MRActions = {
   }
   ResourceType: {
     get: { params: GetResourceTypeParams; return: ResourceTypeProps }
-    getMany: { params: GetResourceTypeParams; return: CollectionProp<ResourceTypeProps> }
+    getMany: {
+      params: Omit<GetResourceTypeParams, 'resourceTypeId'>
+      return: CollectionProp<ResourceTypeProps>
+    }
     upsert: {
       params: GetResourceTypeParams
       payload: UpsertResourceTypeProps

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -788,7 +788,7 @@ export type MRActions = {
   }
   ResourceType: {
     get: { params: GetResourceTypeParams; return: ResourceTypeProps }
-    getMany: { params: GetResourceProviderParams; return: CollectionProp<ResourceTypeProps> }
+    getMany: { params: GetResourceTypeParams; return: CollectionProp<ResourceTypeProps> }
     upsert: {
       params: GetResourceTypeParams
       payload: UpsertResourceTypeProps

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -165,6 +165,7 @@ import type {
   ResourceProviderProps,
   UpsertResourceProviderProps,
 } from './entities/resource-provider'
+import type { ResourceTypeProps, UpsertResourceTypeProps } from './entities/resource-type'
 
 export interface DefaultElements<TPlainObject extends object = object> {
   toPlainObject(): TPlainObject
@@ -598,6 +599,10 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'ResourceProvider', 'upsert', UA>): MRReturn<'ResourceProvider', 'upsert'>
   (opts: MROpts<'ResourceProvider', 'delete', UA>): MRReturn<'ResourceProvider', 'delete'>
 
+  (opts: MROpts<'ResourceType', 'get', UA>): MRReturn<'ResourceType', 'get'>
+  (opts: MROpts<'ResourceType', 'upsert', UA>): MRReturn<'ResourceType', 'upsert'>
+  (opts: MROpts<'ResourceType', 'delete', UA>): MRReturn<'ResourceType', 'delete'>
+
   (opts: MROpts<'Role', 'get', UA>): MRReturn<'Role', 'get'>
   (opts: MROpts<'Role', 'getMany', UA>): MRReturn<'Role', 'getMany'>
   (opts: MROpts<'Role', 'getManyForOrganization', UA>): MRReturn<'Role', 'getManyForOrganization'>
@@ -779,6 +784,16 @@ export type MRActions = {
       return: ResourceProviderProps
     }
     delete: { params: GetResourceProviderParams; return: any }
+  }
+  ResourceType: {
+    get: { params: GetResourceTypeParams; return: ResourceTypeProps }
+    upsert: {
+      params: GetResourceTypeParams
+      payload: UpsertResourceTypeProps
+      headers?: RawAxiosRequestHeaders
+      return: ResourceTypeProps
+    }
+    delete: { params: GetResourceTypeParams; return: any }
   }
   Http: {
     get: { params: { url: string; config?: RawAxiosRequestConfig }; return: any }
@@ -2095,6 +2110,8 @@ export type GetUIConfigParams = GetSpaceEnvironmentParams
 export type GetUserUIConfigParams = GetUIConfigParams
 
 export type GetResourceProviderParams = GetOrganizationParams & { appDefinitionId: string }
+
+export type GetResourceTypeParams = GetResourceProviderParams & { resourceTypeId: string }
 
 export type QueryParams = { query?: QueryOptions }
 export type SpaceQueryParams = { query?: SpaceQueryOptions }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -602,6 +602,7 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'ResourceType', 'get', UA>): MRReturn<'ResourceType', 'get'>
   (opts: MROpts<'ResourceType', 'upsert', UA>): MRReturn<'ResourceType', 'upsert'>
   (opts: MROpts<'ResourceType', 'delete', UA>): MRReturn<'ResourceType', 'delete'>
+  (opts: MROpts<'ResourceType', 'getMany', UA>): MRReturn<'ResourceType', 'getMany'>
 
   (opts: MROpts<'Role', 'get', UA>): MRReturn<'Role', 'get'>
   (opts: MROpts<'Role', 'getMany', UA>): MRReturn<'Role', 'getMany'>
@@ -787,6 +788,7 @@ export type MRActions = {
   }
   ResourceType: {
     get: { params: GetResourceTypeParams; return: ResourceTypeProps }
+    getMany: { params: GetResourceProviderParams; return: CollectionProp<ResourceTypeProps> }
     upsert: {
       params: GetResourceTypeParams
       payload: UpsertResourceTypeProps

--- a/lib/entities/index.ts
+++ b/lib/entities/index.ts
@@ -53,6 +53,7 @@ import * as workflowDefinition from './workflow-definition'
 import * as concept from './concept'
 import * as conceptScheme from './concept-scheme'
 import * as resourceProvider from './resource-provider'
+import * as resourceType from './resource-type'
 
 export default {
   accessToken,
@@ -92,6 +93,7 @@ export default {
   release,
   releaseAction,
   resourceProvider,
+  resourceType,
   role,
   scheduledAction,
   snapshot,

--- a/lib/entities/resource-provider.ts
+++ b/lib/entities/resource-provider.ts
@@ -2,6 +2,8 @@ import type { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '.
 import { toPlainObject, freezeSys } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import enhanceWithMethods from '../enhance-with-methods'
+import type { UpsertResourceTypeProps } from './resource-type'
+import { wrapResourceType } from './resource-type'
 
 export type ResourceProviderProps = {
   /**
@@ -91,6 +93,33 @@ function createResourceProviderApi(makeRequest: MakeRequest) {
         action: 'delete',
         params: getParams(data),
       })
+    },
+
+    getResourceType: function getResourceType(id: string) {
+      const data = this.toPlainObject() as ResourceProviderProps
+
+      return makeRequest({
+        entityType: 'ResourceType',
+        action: 'get',
+        params: {
+          organizationId: data.sys.organization.sys.id,
+          appDefinitionId: data.sys.appDefinition.sys.id,
+          resourceTypeId: id,
+        },
+      }).then((data) => wrapResourceType(makeRequest, data))
+    },
+    upsertResourceType: function upsertResourceType(data: UpsertResourceTypeProps) {
+      return makeRequest({
+        entityType: 'ResourceType',
+        action: 'upsert',
+        params: {
+          organizationId: this.sys.organization.sys.id,
+          appDefinitionId: this.sys.appDefinition.sys.id,
+          resourceTypeId: data.sys.id,
+        },
+        headers: {},
+        payload: data,
+      }).then((data) => wrapResourceType(makeRequest, data))
     },
   }
 }

--- a/lib/entities/resource-provider.ts
+++ b/lib/entities/resource-provider.ts
@@ -2,8 +2,8 @@ import type { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '.
 import { toPlainObject, freezeSys } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import enhanceWithMethods from '../enhance-with-methods'
-import type { UpsertResourceTypeProps } from './resource-type'
-import { wrapResourceType } from './resource-type'
+import type { ResourceType, UpsertResourceTypeProps } from './resource-type'
+import entities from '.'
 
 export type ResourceProviderProps = {
   /**
@@ -32,12 +32,16 @@ export interface ResourceProvider
     DefaultElements<ResourceProviderProps> {
   upsert(): Promise<ResourceProvider>
   delete(): Promise<void>
+  upsertResourceType(id: string, data: UpsertResourceTypeProps): Promise<ResourceType>
+  getResourceType(id: string): Promise<ResourceType>
 }
 
 /**
  * @private
  */
 function createResourceProviderApi(makeRequest: MakeRequest) {
+  const { wrapResourceType } = entities.resourceType
+
   return {
     /**
      * Sends an update to the server with any changes made to the object's properties
@@ -108,14 +112,14 @@ function createResourceProviderApi(makeRequest: MakeRequest) {
         },
       }).then((data) => wrapResourceType(makeRequest, data))
     },
-    upsertResourceType: function upsertResourceType(data: UpsertResourceTypeProps) {
+    upsertResourceType: function upsertResourceType(id: string, data: UpsertResourceTypeProps) {
       return makeRequest({
         entityType: 'ResourceType',
         action: 'upsert',
         params: {
           organizationId: this.sys.organization.sys.id,
           appDefinitionId: this.sys.appDefinition.sys.id,
-          resourceTypeId: data.sys.id,
+          resourceTypeId: id,
         },
         headers: {},
         payload: data,

--- a/lib/entities/resource-provider.ts
+++ b/lib/entities/resource-provider.ts
@@ -126,7 +126,6 @@ function createResourceProviderApi(makeRequest: MakeRequest) {
           appDefinitionId: this.sys.appDefinition.sys.id,
           resourceTypeId: id,
         },
-        headers: {},
         payload: data,
       }).then((data) => wrapResourceType(makeRequest, data))
     },

--- a/lib/entities/resource-type.ts
+++ b/lib/entities/resource-type.ts
@@ -19,11 +19,11 @@ export type ResourceTypeProps = {
     resourceProvider: SysLink
   }
   /**
-   * Resource Provider name, TODO
+   * Resource Type name
    */
   name: string
   /**
-   * Resource Provider defaultFieldMapping, TODO
+   * Resource Type defaultFieldMapping
    */
   defaultFieldMapping: {
     title: string
@@ -127,8 +127,8 @@ const getUpsertParams = (data: ResourceTypeProps): UpsertResourceTypeProps => ({
 /**
  * @private
  * @param makeRequest - function to make requests via an adapter
- * @param data - Raw Resource Provider data
- * @return Wrapped Resource Provider data
+ * @param data - Raw Resource Type data
+ * @return Wrapped Resource Type data
  */
 export function wrapResourceType(makeRequest: MakeRequest, data: ResourceTypeProps): ResourceType {
   const resourceType = toPlainObject(copy(data))

--- a/lib/entities/resource-type.ts
+++ b/lib/entities/resource-type.ts
@@ -14,7 +14,6 @@ export type ResourceTypeProps = {
    * System metadata
    */
   sys: Omit<BasicMetaSysProps, 'version'> & {
-    organization: SysLink
     appDefinition: SysLink
     resourceProvider: SysLink
   }
@@ -41,13 +40,11 @@ export type ResourceTypeProps = {
   }
 }
 
-export type UpsertResourceTypeProps = Omit<ResourceTypeProps, 'sys'> & {
-  sys: { id: string }
-}
+export type UpsertResourceTypeProps = Omit<ResourceTypeProps, 'sys'>
 
 export interface ResourceType extends ResourceTypeProps, DefaultElements<ResourceTypeProps> {
-  upsert(): Promise<ResourceType>
-  delete(): Promise<void>
+  upsert(organizationId: string): Promise<ResourceType>
+  delete(organizationId: string): Promise<void>
 }
 
 /**
@@ -75,12 +72,13 @@ function createResourceTypeApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    upsert: function upsert() {
+    upsert: function upsert(organizationId: string) {
       const data = this.toPlainObject() as ResourceTypeProps
+
       return makeRequest({
         entityType: 'ResourceType',
         action: 'upsert',
-        params: getParams(data),
+        params: getParams(organizationId, data),
         headers: {},
         payload: getUpsertParams(data),
       }).then((data) => wrapResourceType(makeRequest, data))
@@ -102,25 +100,25 @@ function createResourceTypeApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    delete: function del() {
+    delete: function del(organizationId: string) {
       const data = this.toPlainObject() as ResourceTypeProps
+
       return makeRequest({
         entityType: 'ResourceType',
         action: 'delete',
-        params: getParams(data),
+        params: getParams(organizationId, data),
       })
     },
   }
 }
 
-const getParams = (data: ResourceTypeProps): GetResourceTypeParams => ({
-  organizationId: data.sys.organization.sys.id,
+const getParams = (organizationId: string, data: ResourceTypeProps): GetResourceTypeParams => ({
+  organizationId,
   appDefinitionId: data.sys.appDefinition.sys.id,
   resourceTypeId: data.sys.id,
 })
 
 const getUpsertParams = (data: ResourceTypeProps): UpsertResourceTypeProps => ({
-  sys: { id: data.sys.id },
   name: data.name,
   defaultFieldMapping: data.defaultFieldMapping,
 })

--- a/lib/entities/resource-type.ts
+++ b/lib/entities/resource-type.ts
@@ -1,0 +1,141 @@
+import type {
+  BasicMetaSysProps,
+  DefaultElements,
+  GetResourceTypeParams,
+  MakeRequest,
+  SysLink,
+} from '../common-types'
+import { toPlainObject, freezeSys } from 'contentful-sdk-core'
+import copy from 'fast-copy'
+import enhanceWithMethods from '../enhance-with-methods'
+
+export type ResourceTypeProps = {
+  /**
+   * System metadata
+   */
+  sys: Omit<BasicMetaSysProps, 'version'> & {
+    organization: SysLink
+    appDefinition: SysLink
+    resourceProvider: SysLink
+  }
+  /**
+   * Resource Provider name, TODO
+   */
+  name: string
+  /**
+   * Resource Provider defaultFieldMapping, TODO
+   */
+  defaultFieldMapping: {
+    title: string
+    subtitle?: string
+    description?: string
+    externalUrl?: string
+    image?: {
+      url: string
+      altText?: string
+    }
+    badge?: {
+      label: string
+      variant: string
+    }
+  }
+}
+
+export type UpsertResourceTypeProps = Omit<ResourceTypeProps, 'sys'> & {
+  sys: { id: string }
+}
+
+export interface ResourceType extends ResourceTypeProps, DefaultElements<ResourceTypeProps> {
+  upsert(): Promise<ResourceType>
+  delete(): Promise<void>
+}
+
+/**
+ * @private
+ */
+function createResourceTypeApi(makeRequest: MakeRequest) {
+  return {
+    /**
+     * Sends an update to the server with any changes made to the object's properties
+     * @return Object returned from the server with updated changes.
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppDefinition('<app_def_id>'))
+     * .then((appDefinition) => appDefinition.getResourceType())
+     * .then((resourceType) => {
+     *    resourceType.name = '<new_name>'
+     *    return resourceType.upsert()
+     * })
+     * .catch(console.error)
+     * ```
+     */
+    upsert: function upsert() {
+      const data = this.toPlainObject() as ResourceTypeProps
+      return makeRequest({
+        entityType: 'ResourceType',
+        action: 'upsert',
+        params: getParams(data),
+        headers: {},
+        payload: getUpsertParams(data),
+      }).then((data) => wrapResourceType(makeRequest, data))
+    },
+    /**
+     * Deletes this object on the server.
+     * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<org_id>')
+     * .then((org) => org.getAppDefinition('<app_def_id>'))
+     * .then((appDefinition) => appDefinition.getResourceType())
+     * .then((resourceType) => resourceType.delete())
+     * .catch(console.error)
+     * ```
+     */
+    delete: function del() {
+      const data = this.toPlainObject() as ResourceTypeProps
+      return makeRequest({
+        entityType: 'ResourceType',
+        action: 'delete',
+        params: getParams(data),
+      })
+    },
+  }
+}
+
+const getParams = (data: ResourceTypeProps): GetResourceTypeParams => ({
+  organizationId: data.sys.organization.sys.id,
+  appDefinitionId: data.sys.appDefinition.sys.id,
+  resourceTypeId: data.sys.id,
+})
+
+const getUpsertParams = (data: ResourceTypeProps): UpsertResourceTypeProps => ({
+  sys: { id: data.sys.id },
+  name: data.name,
+  defaultFieldMapping: data.defaultFieldMapping,
+})
+
+/**
+ * @private
+ * @param makeRequest - function to make requests via an adapter
+ * @param data - Raw Resource Provider data
+ * @return Wrapped Resource Provider data
+ */
+export function wrapResourceType(makeRequest: MakeRequest, data: ResourceTypeProps): ResourceType {
+  const resourceType = toPlainObject(copy(data))
+  const ResourceTypeWithMethods = enhanceWithMethods(
+    resourceType,
+    createResourceTypeApi(makeRequest)
+  )
+  return freezeSys(ResourceTypeWithMethods)
+}

--- a/lib/entities/resource-type.ts
+++ b/lib/entities/resource-type.ts
@@ -15,6 +15,7 @@ export type ResourceTypeProps = {
    */
   sys: Omit<BasicMetaSysProps, 'version'> & {
     appDefinition: SysLink
+    organization: SysLink
     resourceProvider: SysLink
   }
   /**
@@ -43,8 +44,8 @@ export type ResourceTypeProps = {
 export type UpsertResourceTypeProps = Omit<ResourceTypeProps, 'sys'>
 
 export interface ResourceType extends ResourceTypeProps, DefaultElements<ResourceTypeProps> {
-  upsert(organizationId: string): Promise<ResourceType>
-  delete(organizationId: string): Promise<void>
+  upsert(): Promise<ResourceType>
+  delete(): Promise<void>
 }
 
 /**
@@ -72,13 +73,13 @@ function createResourceTypeApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    upsert: function upsert(organizationId: string) {
+    upsert: function upsert() {
       const data = this.toPlainObject() as ResourceTypeProps
 
       return makeRequest({
         entityType: 'ResourceType',
         action: 'upsert',
-        params: getParams(organizationId, data),
+        params: getParams(data),
         headers: {},
         payload: getUpsertParams(data),
       }).then((data) => wrapResourceType(makeRequest, data))
@@ -100,20 +101,20 @@ function createResourceTypeApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    delete: function del(organizationId: string) {
+    delete: function del() {
       const data = this.toPlainObject() as ResourceTypeProps
 
       return makeRequest({
         entityType: 'ResourceType',
         action: 'delete',
-        params: getParams(organizationId, data),
+        params: getParams(data),
       })
     },
   }
 }
 
-const getParams = (organizationId: string, data: ResourceTypeProps): GetResourceTypeParams => ({
-  organizationId,
+const getParams = (data: ResourceTypeProps): GetResourceTypeParams => ({
+  organizationId: data.sys.organization.sys.id,
   appDefinitionId: data.sys.appDefinition.sys.id,
   resourceTypeId: data.sys.id,
 })

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -287,3 +287,8 @@ export type {
   ResourceProviderProps,
   UpsertResourceProviderProps,
 } from './entities/resource-provider'
+export type {
+  ResourceType,
+  ResourceTypeProps,
+  UpsertResourceTypeProps,
+} from './entities/resource-type'

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -114,6 +114,7 @@ import type { AppAccessTokenPlainClientAPI } from './entities/app-access-token'
 import type { ConceptPlainClientAPI } from './entities/concept'
 import type { ConceptSchemePlainClientAPI } from './entities/concept-scheme'
 import type { ResourceProviderPlainClientAPI } from './entities/resource-provider'
+import type { ResourceTypePlainClientAPI } from './entities/resource-type'
 
 export type PlainClientAPI = {
   raw: {
@@ -505,6 +506,7 @@ export type PlainClientAPI = {
   appDefinition: AppDefinitionPlainClientAPI
   appInstallation: AppInstallationPlainClientAPI
   resourceProvider: ResourceProviderPlainClientAPI
+  resourceType: ResourceTypePlainClientAPI
   extension: ExtensionPlainClientAPI
   webhook: WebhookPlainClientAPI
   snapshot: {

--- a/lib/plain/entities/resource-type.ts
+++ b/lib/plain/entities/resource-type.ts
@@ -78,6 +78,6 @@ export type ResourceTypePlainClientAPI = {
    * ```
    */
   getMany(
-    params: OptionalDefaults<GetResourceTypeParams>
+    params: OptionalDefaults<Omit<GetResourceTypeParams, 'resourceTypeId'>>
   ): Promise<CollectionProp<ResourceTypeProps>>
 }

--- a/lib/plain/entities/resource-type.ts
+++ b/lib/plain/entities/resource-type.ts
@@ -1,7 +1,11 @@
 import type { RawAxiosRequestHeaders } from 'axios'
 
 import type { OptionalDefaults } from '../wrappers/wrap'
-import type { GetResourceTypeParams } from '../../common-types'
+import type {
+  CollectionProp,
+  GetResourceProviderParams,
+  GetResourceTypeParams,
+} from '../../common-types'
 import type { ResourceTypeProps, UpsertResourceTypeProps } from '../../export-types'
 
 export type ResourceTypePlainClientAPI = {
@@ -59,4 +63,21 @@ export type ResourceTypePlainClientAPI = {
    * ```
    */
   delete(params: OptionalDefaults<GetResourceTypeParams>): Promise<any>
+
+  /*
+   * Fetch all Resource Types
+   * @param params entity IDs to identify the Resource Type
+   * @returns all Resource Types
+   * @throws if the request fails, or the Resource Type is not found
+   * @example
+   * ```javascript
+   * const resourceTypes = await client.resourceType.getMany({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * });
+   * ```
+   */
+  getMany(
+    params: OptionalDefaults<GetResourceProviderParams>
+  ): Promise<CollectionProp<ResourceTypeProps>>
 }

--- a/lib/plain/entities/resource-type.ts
+++ b/lib/plain/entities/resource-type.ts
@@ -1,11 +1,7 @@
 import type { RawAxiosRequestHeaders } from 'axios'
 
 import type { OptionalDefaults } from '../wrappers/wrap'
-import type {
-  CollectionProp,
-  GetResourceProviderParams,
-  GetResourceTypeParams,
-} from '../../common-types'
+import type { CollectionProp, GetResourceTypeParams } from '../../common-types'
 import type { ResourceTypeProps, UpsertResourceTypeProps } from '../../export-types'
 
 export type ResourceTypePlainClientAPI = {
@@ -82,6 +78,6 @@ export type ResourceTypePlainClientAPI = {
    * ```
    */
   getMany(
-    params: OptionalDefaults<GetResourceProviderParams>
+    params: OptionalDefaults<GetResourceTypeParams>
   ): Promise<CollectionProp<ResourceTypeProps>>
 }

--- a/lib/plain/entities/resource-type.ts
+++ b/lib/plain/entities/resource-type.ts
@@ -1,0 +1,62 @@
+import type { RawAxiosRequestHeaders } from 'axios'
+
+import type { OptionalDefaults } from '../wrappers/wrap'
+import type { GetResourceTypeParams } from '../../common-types'
+import type { ResourceTypeProps, UpsertResourceTypeProps } from '../../export-types'
+
+export type ResourceTypePlainClientAPI = {
+  /*
+   * Fetch a Resource Type
+   * @param params entity IDs to identify the Resource Type
+   * @returns the Resource Type
+   * @throws if the request fails, or the Resource Type is not found
+   * @example
+   * ```javascript
+   * const resourceType = await client.resourceType.get({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   *   resourceTypeId: '<resource_type_id>',
+   * });
+   * ```
+   */
+  get(params: OptionalDefaults<GetResourceTypeParams>): Promise<ResourceTypeProps>
+
+  /*
+   * Creates or updates a Resource Type
+   * @param params entity IDs to identify the Resource Type
+   * @param rawData the ResourceType
+   * @returns the created or updated Resource Type
+   * @throws if the request fails, the App Definition or Resource Type is not found, or the payload is malformed
+   * @example
+   * ```javascript
+   * // You need a valid AppDefinition with an activated AppBundle that has a contentful function configured
+   * const resourceType = await client.resourceType.upsert(
+   *   {
+   *     organizationId: '<organization_id>',
+   *     appDefinitionId: '<app_definition_id>',
+   *     resourceTypeId: '<resource_type_id>',
+   *   }
+   * );
+   * ```
+   */
+  upsert(
+    params: OptionalDefaults<GetResourceTypeParams>,
+    rawData: UpsertResourceTypeProps,
+    headers?: RawAxiosRequestHeaders
+  ): Promise<ResourceTypeProps>
+
+  /*
+   * Delete a ResourceType
+   * @param params entity IDs to identify the Resource Type
+   * @throws if the request fails, or the Resource Type is not found
+   * @example
+   * ```javascript
+   * await client.resourceType.delete({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   *   resourceTypeId: '<resource_type_id>',
+   * });
+   * ```
+   */
+  delete(params: OptionalDefaults<GetResourceTypeParams>): Promise<any>
+}

--- a/lib/plain/entities/resource-type.ts
+++ b/lib/plain/entities/resource-type.ts
@@ -30,7 +30,7 @@ export type ResourceTypePlainClientAPI = {
    * @param params entity IDs to identify the Resource Type
    * @param rawData the ResourceType
    * @returns the created or updated Resource Type
-   * @throws if the request fails, the App Definition or Resource Type is not found, or the payload is malformed
+   * @throws if the request fails, the App Definition or Resource Provider is not found, or the payload is malformed
    * @example
    * ```javascript
    * // You need a valid AppDefinition with an activated AppBundle that has a contentful function configured
@@ -39,7 +39,13 @@ export type ResourceTypePlainClientAPI = {
    *     organizationId: '<organization_id>',
    *     appDefinitionId: '<app_definition_id>',
    *     resourceTypeId: '<resource_type_id>',
-   *   }
+   *   },
+   * rawData: {
+   *  name: '<resource_type_name>',
+   *  defaultFieldMapping: {
+   *    title: '<field_id>',
+   *  },
+   * }
    * );
    * ```
    */
@@ -66,9 +72,7 @@ export type ResourceTypePlainClientAPI = {
 
   /*
    * Fetch all Resource Types
-   * @param params entity IDs to identify the Resource Type
    * @returns all Resource Types
-   * @throws if the request fails, or the Resource Type is not found
    * @example
    * ```javascript
    * const resourceTypes = await client.resourceType.getMany({

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -378,6 +378,11 @@ export const createPlainClient = (
       upsert: wrap(wrapParams, 'ResourceProvider', 'upsert'),
       delete: wrap(wrapParams, 'ResourceProvider', 'delete'),
     },
+    resourceType: {
+      get: wrap(wrapParams, 'ResourceType', 'get'),
+      upsert: wrap(wrapParams, 'ResourceType', 'upsert'),
+      delete: wrap(wrapParams, 'ResourceType', 'delete'),
+    },
     extension: {
       get: wrap(wrapParams, 'Extension', 'get'),
       getMany: wrap(wrapParams, 'Extension', 'getMany'),

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -380,6 +380,7 @@ export const createPlainClient = (
     },
     resourceType: {
       get: wrap(wrapParams, 'ResourceType', 'get'),
+      getMany: wrap(wrapParams, 'ResourceType', 'getMany'),
       upsert: wrap(wrapParams, 'ResourceType', 'upsert'),
       delete: wrap(wrapParams, 'ResourceType', 'delete'),
     },

--- a/test/integration/resource-provider-integration.ts
+++ b/test/integration/resource-provider-integration.ts
@@ -122,6 +122,42 @@ describe('ResourceProvider API', () => {
     )
   })
 
+  test('upsertResourceType', async () => {
+    const resourceProvider = await appDefinition.upsertResourceProvider({
+      sys: { id: 'test' },
+      type: 'function',
+      function: { sys: { id: functionManifest.id, type: 'Link', linkType: 'Function' } },
+    })
+
+    const resourceType = await resourceProvider.upsertResourceType('test:resourceTypeId', {
+      name: 'resourceType',
+      defaultFieldMapping: {
+        title: 'title',
+      },
+    })
+
+    expect(resourceType.sys.id).to.equal('test:resourceTypeId')
+  })
+
+  test('getResourceType', async () => {
+    const resourceProvider = await appDefinition.upsertResourceProvider({
+      sys: { id: 'test' },
+      type: 'function',
+      function: { sys: { id: functionManifest.id, type: 'Link', linkType: 'Function' } },
+    })
+
+    await resourceProvider.upsertResourceType('test:resourceTypeId', {
+      name: 'resourceType',
+      defaultFieldMapping: {
+        title: 'title',
+      },
+    })
+
+    const resourceType = await resourceProvider.getResourceType('test:resourceTypeId')
+
+    expect(resourceType.name).to.equal('resourceType')
+  })
+
   describe('PlainClient', async () => {
     const plainClient = initPlainClient()
     test('create ResourceProvider', async () => {

--- a/test/integration/resource-type-integration.ts
+++ b/test/integration/resource-type-integration.ts
@@ -285,7 +285,6 @@ describe('ResourceType API', () => {
       const response = await plainClient.resourceType.getMany({
         organizationId: organization.sys.id,
         appDefinitionId: appDefinition.sys.id,
-        resourceTypeId: 'resourceProvider:resourceTypeId',
       })
 
       resourceTypePlain = response.items[0]
@@ -298,7 +297,6 @@ describe('ResourceType API', () => {
       const response = await plainClient.resourceType.getMany({
         organizationId: organization.sys.id,
         appDefinitionId: appDefinition.sys.id,
-        resourceTypeId: 'resourceProvider:resourceTypeId',
       })
 
       expect(response.items).to.be.an('array').that.is.empty

--- a/test/integration/resource-type-integration.ts
+++ b/test/integration/resource-type-integration.ts
@@ -73,6 +73,8 @@ describe('ResourceType API', () => {
     if (resourceTypePlain) {
       ;(await resourceProvider.getResourceType('resourceProvider:resourceTypeId')).delete()
     }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000))
   })
 
   after(async () => {

--- a/test/integration/resource-type-integration.ts
+++ b/test/integration/resource-type-integration.ts
@@ -1,0 +1,251 @@
+import { test } from 'mocha'
+import { readFileSync } from 'fs'
+import { expect } from 'chai'
+import { getTestOrganization, initPlainClient } from '../helpers'
+import type { Organization } from '../../lib/entities/organization'
+import type { AppDefinition } from '../../lib/entities/app-definition'
+import type { AppUpload } from '../../lib/entities/app-upload'
+import type { AppBundle } from '../../lib/entities/app-bundle'
+import type { ResourceProvider, ResourceType, ResourceTypeProps } from '../../lib/export-types'
+
+describe('ResourceType API', () => {
+  const functionManifest = {
+    id: 'tmdbMockFunction',
+    name: 'Mocked TMDB lookup function',
+    description: 'This is a mocked example to help test Apps with ERL.',
+    path: 'functions/index.js',
+    allowNetworks: ['api.themoviedb.org'],
+    accepts: ['resources.lookup', 'resources.search'],
+  }
+
+  let organization: Organization
+  let appDefinition: AppDefinition
+  let appUpload: AppUpload
+  let appBundle: AppBundle
+  let resourceProvider: ResourceProvider
+  let resourceType: ResourceType
+  let resourceTypePlain: ResourceTypeProps
+
+  before(async () => {
+    organization = (await getTestOrganization()) as Organization
+    appDefinition = await organization.createAppDefinition({
+      name: 'Test',
+      src: 'http://localhost:2222',
+      locations: [{ location: 'entry-sidebar' }],
+    })
+
+    appUpload = await organization.createAppUpload(readFileSync(`${__dirname}/fixtures/build.zip`))
+    appBundle = await appDefinition.createAppBundle({
+      appUploadId: appUpload.sys.id,
+      comment: 'Testing ResourceTypeCreation',
+      functions: [functionManifest],
+    })
+
+    appDefinition.bundle = { sys: { id: appBundle.sys.id, type: 'Link', linkType: 'AppBundle' } }
+    appDefinition.src = undefined
+
+    appDefinition = await appDefinition.update()
+
+    resourceProvider = await appDefinition.upsertResourceProvider({
+      sys: { id: 'resourceProvider' },
+      type: 'function',
+      function: { sys: { id: functionManifest.id, type: 'Link', linkType: 'Function' } },
+    })
+  })
+
+  afterEach(async () => {
+    if (resourceType) {
+      await resourceType.delete(organization.sys.id)
+    }
+
+    if (resourceTypePlain) {
+      ;(await resourceProvider.getResourceType('resourceProvider:resourceTypeId')).delete(
+        organization.sys.id
+      )
+    }
+  })
+
+  after(async () => {
+    if (resourceProvider) {
+      await resourceProvider.delete()
+    }
+
+    if (appUpload) {
+      await appUpload.delete()
+    }
+
+    if (appDefinition) {
+      await appDefinition.delete()
+    }
+  })
+
+  test('create ResourceType', async () => {
+    resourceType = await resourceProvider.upsertResourceType('resourceProvider:resourceTypeId', {
+      name: 'resourceType',
+      defaultFieldMapping: {
+        title: 'title',
+      },
+    })
+
+    expect(resourceType.sys.id).to.equal('resourceProvider:resourceTypeId')
+    expect(resourceType.name).to.equal('resourceType')
+  })
+
+  test('update ResourceType', async () => {
+    resourceType = await resourceProvider.upsertResourceType('resourceProvider:resourceTypeId', {
+      name: 'resourceType',
+      defaultFieldMapping: {
+        title: 'title',
+      },
+    })
+
+    resourceType.name = 'updatedResourceType'
+
+    const updatedResourceType = await resourceType.upsert(organization.sys.id)
+
+    expect(updatedResourceType.sys.id).to.equal('resourceProvider:resourceTypeId')
+    expect(updatedResourceType.name).to.equal('updatedResourceType')
+  })
+
+  test('get ResourceType', async () => {
+    await resourceProvider.upsertResourceType('resourceProvider:resourceTypeId', {
+      name: 'resourceType',
+      defaultFieldMapping: {
+        title: 'title',
+      },
+    })
+
+    resourceType = await resourceProvider.getResourceType('resourceProvider:resourceTypeId')
+
+    expect(resourceType.sys.id).to.equal('resourceProvider:resourceTypeId')
+    expect(resourceType.name).to.equal('resourceType')
+  })
+
+  test('delete ResourceType', async () => {
+    const resourceType = await resourceProvider.upsertResourceType(
+      'resourceProvider:resourceTypeId',
+      {
+        name: 'resourceType',
+        defaultFieldMapping: {
+          title: 'title',
+        },
+      }
+    )
+
+    await resourceType.delete(organization.sys.id)
+
+    await expect(
+      resourceProvider.getResourceType('resourceProvider:resourceTypeId')
+    ).to.be.rejectedWith('The resource could not be found')
+  })
+
+  describe('PlainClient', async () => {
+    const plainClient = initPlainClient()
+    test('create ResourceType', async () => {
+      resourceTypePlain = await plainClient.resourceType.upsert(
+        {
+          organizationId: organization.sys.id,
+          appDefinitionId: appDefinition.sys.id,
+          resourceTypeId: 'resourceProvider:resourceTypeId',
+        },
+        {
+          name: 'resourceType',
+          defaultFieldMapping: {
+            title: 'title',
+          },
+        }
+      )
+
+      expect(resourceTypePlain.sys.id).to.equal('resourceProvider:resourceTypeId')
+      expect(resourceTypePlain.name).to.equal('resourceType')
+    })
+
+    test('update ResourceType', async () => {
+      resourceTypePlain = await plainClient.resourceType.upsert(
+        {
+          organizationId: organization.sys.id,
+          appDefinitionId: appDefinition.sys.id,
+          resourceTypeId: 'resourceProvider:resourceTypeId',
+        },
+        {
+          name: 'resourceType',
+          defaultFieldMapping: {
+            title: 'title',
+          },
+        }
+      )
+
+      const updatedResourceType = await plainClient.resourceType.upsert(
+        {
+          organizationId: organization.sys.id,
+          appDefinitionId: appDefinition.sys.id,
+          resourceTypeId: 'resourceProvider:resourceTypeId',
+        },
+        {
+          name: 'updatedResourceType',
+          defaultFieldMapping: {
+            title: 'title',
+          },
+        }
+      )
+
+      expect(updatedResourceType.sys.id).to.equal('resourceProvider:resourceTypeId')
+      expect(updatedResourceType.name).to.equal('updatedResourceType')
+    })
+
+    test('get ResourceType', async () => {
+      await plainClient.resourceType.upsert(
+        {
+          organizationId: organization.sys.id,
+          appDefinitionId: appDefinition.sys.id,
+          resourceTypeId: 'resourceProvider:resourceTypeId',
+        },
+        {
+          name: 'resourceType',
+          defaultFieldMapping: {
+            title: 'title',
+          },
+        }
+      )
+
+      resourceTypePlain = await plainClient.resourceType.get({
+        organizationId: organization.sys.id,
+        appDefinitionId: appDefinition.sys.id,
+        resourceTypeId: 'resourceProvider:resourceTypeId',
+      })
+
+      expect(resourceTypePlain.sys.id).to.equal('resourceProvider:resourceTypeId')
+      expect(resourceTypePlain.name).to.equal('resourceType')
+    })
+
+    test('delete ResourceType', async () => {
+      await plainClient.resourceType.upsert(
+        {
+          organizationId: organization.sys.id,
+          appDefinitionId: appDefinition.sys.id,
+          resourceTypeId: 'resourceProvider:resourceTypeId',
+        },
+        {
+          name: 'resourceType',
+          defaultFieldMapping: {
+            title: 'title',
+          },
+        }
+      )
+
+      await plainClient.resourceType.delete({
+        organizationId: organization.sys.id,
+        appDefinitionId: appDefinition.sys.id,
+        resourceTypeId: 'resourceProvider:resourceTypeId',
+      })
+
+      await expect(
+        plainClient.resourceType.get({
+          organizationId: organization.sys.id,
+          appDefinitionId: appDefinition.sys.id,
+          resourceTypeId: 'resourceProvider:resourceTypeId',
+        })
+      ).to.be.rejectedWith('The resource could not be found')
+    })
+  })
+})

--- a/test/unit/entities/resource-provider-test.ts
+++ b/test/unit/entities/resource-provider-test.ts
@@ -1,5 +1,5 @@
 import type { ResourceProviderProps } from '../../../lib/entities/resource-provider'
-import { cloneMock } from '../mocks/entities'
+import { cloneMock, resourceTypeMock } from '../mocks/entities'
 import setupMakeRequest from '../mocks/makeRequest'
 import { wrapResourceProvider } from '../../../lib/entities/resource-provider'
 import {
@@ -8,11 +8,20 @@ import {
   entityDeleteTest,
 } from '../test-creators/instance-entity-methods'
 import { describe, test } from 'mocha'
+import { expect } from 'chai'
+import type { ResourceTypeProps } from '../../../lib/entities/resource-type'
 
 function setup(promise: Promise<ResourceProviderProps>) {
   return {
     makeRequest: setupMakeRequest(promise),
     entityMock: cloneMock('resourceProvider'),
+  }
+}
+
+function setupResourceType(promise: Promise<ResourceTypeProps>) {
+  return {
+    makeRequest: setupMakeRequest(promise),
+    entityMock: cloneMock('resourceType'),
   }
 }
 
@@ -32,5 +41,30 @@ describe('Entity ResourceProvider', () => {
     return entityDeleteTest(setup, {
       wrapperMethod: wrapResourceProvider,
     })
+  })
+
+  test('API call upsertResourceType', async () => {
+    const { makeRequest, entityMock } = setupResourceType(
+      new Promise((r) => r(resourceTypeMock as any))
+    )
+    const entity = wrapResourceProvider(makeRequest, entityMock)
+
+    const response = await entity['upsertResourceType'](
+      'resourceProvider:resourceTypeId',
+      resourceTypeMock
+    )
+    expect(response).to.deep.equal(resourceTypeMock)
+    expect(response.toPlainObject, 'response is wrapped').to.be.ok
+  })
+
+  test('API call getResourceType', async () => {
+    const { makeRequest, entityMock } = setupResourceType(
+      new Promise((r) => r(resourceTypeMock as any))
+    )
+    const entity = wrapResourceProvider(makeRequest, entityMock)
+
+    const response = await entity['getResourceType']('resourceTypeId')
+    expect(response).to.deep.equal(resourceTypeMock)
+    expect(response.toPlainObject, 'response is wrapped').to.be.ok
   })
 })

--- a/test/unit/entities/resource-provider-test.ts
+++ b/test/unit/entities/resource-provider-test.ts
@@ -76,7 +76,7 @@ describe('Entity ResourceProvider', () => {
     const entity = wrapResourceProvider(makeRequest, entityMock)
     const response = await entity['getResourceTypes']()
 
-    expect(response[0]).to.deep.equal(resourceTypeMock)
-    expect(response[0].toPlainObject, 'response is wrapped').to.be.ok
+    expect(response.items[0]).to.deep.equal(resourceTypeMock)
+    expect(response.items[0].toPlainObject, 'response is wrapped').to.be.ok
   })
 })

--- a/test/unit/entities/resource-provider-test.ts
+++ b/test/unit/entities/resource-provider-test.ts
@@ -10,6 +10,7 @@ import {
 import { describe, test } from 'mocha'
 import { expect } from 'chai'
 import type { ResourceTypeProps } from '../../../lib/entities/resource-type'
+import type { CollectionProp } from '../../../lib/common-types'
 
 function setup(promise: Promise<ResourceProviderProps>) {
   return {
@@ -18,7 +19,9 @@ function setup(promise: Promise<ResourceProviderProps>) {
   }
 }
 
-function setupResourceType(promise: Promise<ResourceTypeProps>) {
+function setupResourceType(
+  promise: Promise<ResourceTypeProps | CollectionProp<ResourceTypeProps>>
+) {
   return {
     makeRequest: setupMakeRequest(promise),
     entityMock: cloneMock('resourceType'),
@@ -44,9 +47,7 @@ describe('Entity ResourceProvider', () => {
   })
 
   test('API call upsertResourceType', async () => {
-    const { makeRequest, entityMock } = setupResourceType(
-      new Promise((r) => r(resourceTypeMock as any))
-    )
+    const { makeRequest, entityMock } = setupResourceType(new Promise((r) => r(resourceTypeMock)))
     const entity = wrapResourceProvider(makeRequest, entityMock)
 
     const response = await entity['upsertResourceType'](
@@ -58,13 +59,24 @@ describe('Entity ResourceProvider', () => {
   })
 
   test('API call getResourceType', async () => {
-    const { makeRequest, entityMock } = setupResourceType(
-      new Promise((r) => r(resourceTypeMock as any))
-    )
+    const { makeRequest, entityMock } = setupResourceType(new Promise((r) => r(resourceTypeMock)))
     const entity = wrapResourceProvider(makeRequest, entityMock)
 
     const response = await entity['getResourceType']('resourceTypeId')
     expect(response).to.deep.equal(resourceTypeMock)
     expect(response.toPlainObject, 'response is wrapped').to.be.ok
+  })
+
+  test('API call getResourceTypes', async () => {
+    const { makeRequest, entityMock } = setupResourceType(
+      new Promise((r) =>
+        r({ items: [resourceTypeMock], total: 1, skip: 0, limit: 100, sys: { type: 'Array' } })
+      )
+    )
+    const entity = wrapResourceProvider(makeRequest, entityMock)
+    const response = await entity['getResourceTypes']()
+
+    expect(response[0]).to.deep.equal(resourceTypeMock)
+    expect(response[0].toPlainObject, 'response is wrapped').to.be.ok
   })
 })

--- a/test/unit/entities/resource-type-test.ts
+++ b/test/unit/entities/resource-type-test.ts
@@ -1,0 +1,35 @@
+import { cloneMock } from '../mocks/entities'
+import setupMakeRequest from '../mocks/makeRequest'
+import {
+  entityActionTest,
+  entityWrappedTest,
+  entityDeleteTest,
+} from '../test-creators/instance-entity-methods'
+import { describe, test } from 'mocha'
+import { wrapResourceType, type ResourceTypeProps } from '../../../lib/entities/resource-type'
+
+function setup(promise: Promise<ResourceTypeProps>) {
+  return {
+    makeRequest: setupMakeRequest(promise),
+    entityMock: cloneMock('resourceType'),
+  }
+}
+
+describe('Entity ResourceType', () => {
+  test('ResourceType is wrapped', async () => {
+    return entityWrappedTest(setup, { wrapperMethod: wrapResourceType })
+  })
+
+  test('ResourceType upsert', async () => {
+    return entityActionTest(setup, {
+      wrapperMethod: wrapResourceType,
+      actionMethod: 'upsert',
+    })
+  })
+
+  test('ResourceType delete', async () => {
+    return entityDeleteTest(setup, {
+      wrapperMethod: wrapResourceType,
+    })
+  })
+})

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -1069,9 +1069,14 @@ const resourceTypeMock = {
       sys: { id: 'organization-id' },
     },
     appDefinition: { sys: { id: 'appDefinition-id' } },
+    resourceProvider: {
+      sys: { id: 'resourceProvider-id' },
+    },
   }),
-  type: 'function',
-  source: 'source',
+  name: 'resourceType',
+  defaultFieldMapping: {
+    title: 'title',
+  },
 }
 
 const mocks = {

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -1053,10 +1053,8 @@ export const userUIConfigMock = {
 const resourceProviderMock = {
   sys: Object.assign(cloneDeep(sysMock), {
     type: 'ResourceProvider',
-    organization: {
-      sys: { id: 'organization-id' },
-    },
-    appDefinition: { sys: { id: 'appDefinition-id' } },
+    appDefinition: { sys: { id: 'appDefinition-id', linkType: 'AppDefinition', type: 'Link' } },
+    organization: { sys: { id: 'organization-id', linkType: 'Organization', type: 'Link' } },
   }),
   type: 'function',
   function: { sys: { id: 'function-id' } },
@@ -1065,12 +1063,10 @@ const resourceProviderMock = {
 const resourceTypeMock = {
   sys: Object.assign(cloneDeep(sysMock), {
     type: 'ResourceType',
-    organization: {
-      sys: { id: 'organization-id' },
-    },
-    appDefinition: { sys: { id: 'appDefinition-id' } },
+    appDefinition: { sys: { id: 'appDefinition-id', linkType: 'AppDefinition', type: 'Link' } },
+    organization: { sys: { id: 'organization-id', linkType: 'Organization', type: 'Link' } },
     resourceProvider: {
-      sys: { id: 'resourceProvider-id' },
+      sys: { id: 'resourceProvider-id', linkType: 'ResourceProvider', type: 'Link' },
     },
   }),
   name: 'resourceType',

--- a/test/unit/mocks/entities.js
+++ b/test/unit/mocks/entities.js
@@ -1062,6 +1062,18 @@ const resourceProviderMock = {
   function: { sys: { id: 'function-id' } },
 }
 
+const resourceTypeMock = {
+  sys: Object.assign(cloneDeep(sysMock), {
+    type: 'ResourceType',
+    organization: {
+      sys: { id: 'organization-id' },
+    },
+    appDefinition: { sys: { id: 'appDefinition-id' } },
+  }),
+  type: 'function',
+  source: 'source',
+}
+
 const mocks = {
   apiKey: apiKeyMock,
   appAction: appActionMock,
@@ -1112,6 +1124,7 @@ const mocks = {
   releaseActionValidate: releaseActionValidateMock,
   releaseActionUnpublish: releaseActionUnpublishMock,
   resourceProvider: resourceProviderMock,
+  resourceType: resourceTypeMock,
   scheduledAction: scheduledActionMock,
   snapshot: snapShotMock,
   spaceMember: spaceMemberMock,
@@ -1267,6 +1280,9 @@ function setupEntitiesMock(rewiredModuleApi) {
     resourceProvider: {
       wrapResourceProvider: sinon.stub(),
     },
+    resourceType: {
+      wrapResourceType: sinon.stub(),
+    },
     apiKey: {
       wrapApiKey: sinon.stub(),
       wrapApiKeyCollection: sinon.stub(),
@@ -1414,4 +1430,5 @@ export {
   environmentTemplateValidationMock,
   taskMock,
   resourceProviderMock,
+  resourceTypeMock,
 }

--- a/test/unit/plain/resource-type-test.ts
+++ b/test/unit/plain/resource-type-test.ts
@@ -1,0 +1,61 @@
+import { expect } from 'chai'
+import { describe, test } from 'mocha'
+import sinon from 'sinon'
+import { createClient } from '../../../lib/contentful-management'
+import setupRestAdapter from '../adapters/REST/helpers/setupRestAdapter'
+import { resourceTypeMock } from '../mocks/entities'
+
+describe('ResourceType', () => {
+  const organizationId = 'organizationId'
+  const appDefinitionId = 'appDefinitionId'
+  const resourceTypeId = 'resourceTypeId'
+
+  test('get', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: resourceTypeMock }))
+    const plainClient = createClient({ apiAdapter: adapterMock }, { type: 'plain' })
+    const response = await plainClient.resourceType.get({
+      organizationId,
+      appDefinitionId,
+      resourceTypeId,
+    })
+
+    expect(response).to.be.an('object')
+    expect(response.sys.id).to.equal('id')
+
+    sinon.assert.calledWith(
+      httpMock.get,
+      `/organizations/organizationId/app_definitions/appDefinitionId/resource_provider/resource_types/resourceTypeId`
+    )
+  })
+
+  test('upsert', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: resourceTypeMock }))
+    const plainClient = createClient({ apiAdapter: adapterMock }, { type: 'plain' })
+    const response = await plainClient.resourceType.upsert(
+      { organizationId, appDefinitionId, resourceTypeId },
+      {
+        name: 'resourceType',
+        defaultFieldMapping: {
+          title: 'title',
+        },
+      }
+    )
+
+    expect(response).to.be.an('object')
+    expect(response.sys.id).to.equal('id')
+
+    sinon.assert.calledWith(
+      httpMock.put,
+      `/organizations/organizationId/app_definitions/appDefinitionId/resource_provider/resource_types/resourceTypeId`
+    )
+  })
+  test('delete', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: '' }))
+    const plainClient = createClient({ apiAdapter: adapterMock }, { type: 'plain' })
+    await plainClient.resourceType.delete({ organizationId, appDefinitionId, resourceTypeId })
+    sinon.assert.calledWith(
+      httpMock.delete,
+      `/organizations/organizationId/app_definitions/appDefinitionId/resource_provider/resource_types/resourceTypeId`
+    )
+  })
+})

--- a/test/unit/plain/resource-type-test.ts
+++ b/test/unit/plain/resource-type-test.ts
@@ -28,6 +28,26 @@ describe('ResourceType', () => {
     )
   })
 
+  test('getMany', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(
+      Promise.resolve({ data: { items: [resourceTypeMock] } })
+    )
+    const plainClient = createClient({ apiAdapter: adapterMock }, { type: 'plain' })
+    const response = await plainClient.resourceType.getMany({
+      organizationId,
+      appDefinitionId,
+      resourceTypeId,
+    })
+
+    expect(response).to.be.an('object')
+    expect(response.items[0].sys.id).to.equal('id')
+
+    sinon.assert.calledWith(
+      httpMock.get,
+      `/organizations/organizationId/app_definitions/appDefinitionId/resource_provider/resource_types`
+    )
+  })
+
   test('upsert', async () => {
     const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: resourceTypeMock }))
     const plainClient = createClient({ apiAdapter: adapterMock }, { type: 'plain' })

--- a/test/unit/plain/resource-type-test.ts
+++ b/test/unit/plain/resource-type-test.ts
@@ -36,7 +36,6 @@ describe('ResourceType', () => {
     const response = await plainClient.resourceType.getMany({
       organizationId,
       appDefinitionId,
-      resourceTypeId,
     })
 
     expect(response).to.be.an('object')


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Add Resource Type for Native External References

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [ ] The new method is added to the documentation
