### PR TITLE
test: [GROOT-1483] New integration tests for Taxonomy Assets and Entries

### DIFF
--- a/test/integration/asset-integration.ts
+++ b/test/integration/asset-integration.ts
@@ -351,7 +351,7 @@ describe('Asset api', function () {
         assetToDeleteConceptFrom.metadata.concepts = []
         const updatedAsset = await assetToDeleteConceptFrom.update()
 
-        expect(updatedAsset.metadata.concepts).lengthOf(0)
+        expect(updatedAsset.metadata.concepts).to.be.an('array').that.is.empty
       })
     })
   })

--- a/test/integration/asset-integration.ts
+++ b/test/integration/asset-integration.ts
@@ -229,7 +229,7 @@ describe('Asset api', function () {
         }
       })
 
-      test('should create asset with concepts assigned when metadata.concepts provided', async () => {
+      test('should create asset with concepts assigned when concepts provided', async () => {
         const newConcept = await client.concept.create(
           {},
           {
@@ -242,7 +242,9 @@ describe('Asset api', function () {
 
         const createdAsset = await environment.createAsset({
           fields: {
-            title: { 'en-US': 'this is the title of a created asset with a taxonomy assigned' },
+            title: {
+              'en-US': 'this is the title of a newly created asset with a concept assigned',
+            },
             file: {
               'en-US': {
                 contentType: 'image/jpeg',
@@ -269,7 +271,7 @@ describe('Asset api', function () {
         expect(createdAsset.metadata.concepts[0].sys.id).to.eq(newConcept.sys.id)
       })
 
-      test('should update asset with concepts assigned when metadata.concepts provided', async () => {
+      test('should update asset with concepts assigned when concepts are provided', async () => {
         const newConcept = await client.concept.create(
           {},
           {
@@ -282,7 +284,7 @@ describe('Asset api', function () {
 
         const assetToUpdate = await environment.createAsset({
           fields: {
-            title: { 'en-US': 'this asset should be updated with a taxonomy assigned' },
+            title: { 'en-US': 'this asset should be updated with a concept assigned' },
             file: {
               'en-US': {
                 contentType: 'image/jpeg',
@@ -312,7 +314,7 @@ describe('Asset api', function () {
         expect(updatedAsset.metadata.concepts[0].sys.id).to.eq(newConcept.sys.id)
       })
 
-      test('should update asset with concepts removed when metadata.concepts already exist', async () => {
+      test('should update asset with concepts removed when concepts already exist', async () => {
         const newConcept = await client.concept.create(
           {},
           {
@@ -324,7 +326,7 @@ describe('Asset api', function () {
         conceptsToCleanUp.push(newConcept)
         const assetToDeleteConceptFrom = await environment.createAsset({
           fields: {
-            title: { 'en-US': 'this is the title of a created asset with a taxonomy assigned' },
+            title: { 'en-US': 'this is the title of an asset with a concept already assigned' },
             file: {
               'en-US': {
                 contentType: 'image/jpeg',

--- a/test/integration/asset-integration.ts
+++ b/test/integration/asset-integration.ts
@@ -220,7 +220,7 @@ describe('Asset api', function () {
     describe('Taxonomy', () => {
       const conceptsToCleanUp: ConceptProps[] = []
 
-      afterEach(async () => {
+      after(async () => {
         for (const conceptToBeDeleted of conceptsToCleanUp) {
           await client.concept.delete({
             conceptId: conceptToBeDeleted.sys.id,

--- a/test/integration/asset-integration.ts
+++ b/test/integration/asset-integration.ts
@@ -312,9 +312,47 @@ describe('Asset api', function () {
         expect(updatedAsset.metadata.concepts[0].sys.id).to.eq(newConcept.sys.id)
       })
 
-      // test('should update asset with concepts removed when metadata.concepts already exist', () => {
+      test('should update asset with concepts removed when metadata.concepts already exist', async () => {
+        const newConcept = await client.concept.create(
+          {},
+          {
+            prefLabel: {
+              'en-US': 'Concept to be assigned',
+            },
+          }
+        )
+        conceptsToCleanUp.push(newConcept)
+        const assetToDeleteConceptFrom = await environment.createAsset({
+          fields: {
+            title: { 'en-US': 'this is the title of a created asset with a taxonomy assigned' },
+            file: {
+              'en-US': {
+                contentType: 'image/jpeg',
+                fileName: 'shiba-stuck.jpg',
+                upload: TEST_IMAGE_SOURCE_URL,
+              },
+            },
+          },
+          metadata: {
+            concepts: [
+              {
+                sys: {
+                  id: newConcept.sys.id,
+                  linkType: 'TaxonomyConcept',
+                  type: 'Link',
+                },
+              },
+            ],
+            tags: [],
+          },
+        })
+        expect(assetToDeleteConceptFrom.metadata.concepts).lengthOf(1)
 
-      // })
+        assetToDeleteConceptFrom.metadata.concepts = []
+        const updatedAsset = await assetToDeleteConceptFrom.update()
+
+        expect(updatedAsset.metadata.concepts).lengthOf(0)
+      })
     })
   })
 })

--- a/test/integration/entry-integration.ts
+++ b/test/integration/entry-integration.ts
@@ -421,7 +421,7 @@ describe('Entry Api', () => {
     describe('Taxonomy', () => {
       const conceptsToCleanUp: ConceptProps[] = []
 
-      afterEach(async () => {
+      after(async () => {
         for (const conceptToBeDeleted of conceptsToCleanUp) {
           await client.concept.delete({
             conceptId: conceptToBeDeleted.sys.id,

--- a/test/integration/entry-integration.ts
+++ b/test/integration/entry-integration.ts
@@ -430,7 +430,7 @@ describe('Entry Api', () => {
         }
       })
 
-      test('should create entry with concepts assigned when metadata.concepts provided', async () => {
+      test('should create entry with concepts assigned when concepts provided', async () => {
         const parentConcept = await client.concept.create(
           {},
           {
@@ -488,7 +488,7 @@ describe('Entry Api', () => {
           contentTypeWithTaxonomyValidation.sys.id,
           {
             fields: {
-              title: { 'en-US': 'this is the title of an entry with a taxonomy assigned' },
+              title: { 'en-US': 'this is the title of an entry with a concept assigned' },
             },
             metadata: {
               concepts: [
@@ -509,7 +509,7 @@ describe('Entry Api', () => {
         expect(createdEntry.metadata.concepts[0].sys.id).to.eq(childConcept.sys.id)
       })
 
-      test('should update entry with concepts assigned when metadata.concepts provided', async () => {
+      test('should update entry with concepts assigned when concepts are provided', async () => {
         const parentConcept = await client.concept.create(
           {},
           {
@@ -593,7 +593,7 @@ describe('Entry Api', () => {
         expect(updatedEntry.metadata.concepts[0].sys.id).to.eq(childConcept.sys.id)
       })
 
-      test('should update entry with concepts removed when metadata.concepts already exist', async () => {
+      test('should update entry with concepts removed when concepts already exist', async () => {
         const parentConcept = await client.concept.create(
           {},
           {

--- a/test/integration/entry-integration.ts
+++ b/test/integration/entry-integration.ts
@@ -432,7 +432,7 @@ describe('Entry Api', () => {
    * Content type with id stored in `TestDefaults.contentType.withCrossSpaceReferenceId` is deleted
    */
   describe.skip('write with x-space references', () => {
-    let contentTypeData = {
+    const contentTypeData = {
       name: 'testCTXSpace',
       fields: [
         {
@@ -459,7 +459,7 @@ describe('Entry Api', () => {
       ],
     }
 
-    let entryData = {
+    const entryData = {
       fields: {
         title: { 'en-US': 'this is the title' },
         multiRefXSpace: {
@@ -556,7 +556,7 @@ describe('Entry Api', () => {
         return xSpaceDisabledEnvironment
           .createEntry(xSpaceDisabledContentType.sys.id, entryData)
           .catch((accessDeniedError) => {
-            let errorMessage = JSON.parse(accessDeniedError.message)
+            const errorMessage = JSON.parse(accessDeniedError.message)
             expect(accessDeniedError.name).equals('AccessDenied', 'Access Denied Error')
             expect(errorMessage.status).equals(403, '403 forbidden status')
             expect(errorMessage.details.reasons).equals(


### PR DESCRIPTION
## Summary

Additional test coverage for assigning concepts to Assets and Entries.

Covers 3 main areas:
1. Creating an {entry/asset} with a new concept assigned
2. Updating an {entry/asset} with a new concept assigned
3. Deleting an assigned concept from an {entry/asset}

## Description

As per summary, but also migrated `entry-integration.js` to Typescript.

## Motivation and Context

The implementation was already functionally in place to assign a Concept to a Taxonomy, therefore this PR is just for some additional test coverage.

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] ~~Changes are reflected in the documentation~~
