### PR TITLE
feat: allow locales to be paginated [ZEND-5557]

### DIFF
--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -1243,7 +1243,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    getLocales() {
+    getLocales(query: BasicQueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
       return makeRequest({
         entityType: 'Locale',
@@ -1251,6 +1251,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
         params: {
           spaceId: raw.sys.space.sys.id,
           environmentId: raw.sys.id,
+          query: createRequestConfig({ query }).params,
         },
       }).then((data) => wrapLocaleCollection(makeRequest, data))
     },

--- a/test/integration/locale-integration.js
+++ b/test/integration/locale-integration.js
@@ -70,9 +70,9 @@ describe('Locale Api', function () {
     })
     // wait for the locale to be created
     await new Promise((res) => setTimeout(res, 3000))
-    const pagedLocals = environment.getLocales({ limit: 1 })
-    expect(pagedLocals.items.length).equals(1)
-    expect(pagedLocals.total).equals(2)
+    const pagedLocales = await environment.getLocales({ limit: 1 })
+    expect(pagedLocales.items.length).equals(1)
+    expect(pagedLocales.total).equals(2)
     await createdLocal.delete()
   })
 })

--- a/test/integration/locale-integration.js
+++ b/test/integration/locale-integration.js
@@ -24,6 +24,12 @@ describe('Locale Api', function () {
     })
   })
 
+  test('Gets locales respects skip', async () => {
+    return environment.getLocales({ skip: 1 }).then((response) => {
+      expect(response.items.length).equals(0)
+    })
+  })
+
   test('Creates, gets, updates and deletes a locale', async () => {
     return environment
       .createLocale({
@@ -55,5 +61,18 @@ describe('Locale Api', function () {
           }, 3000)
         })
       })
+  })
+
+  test('Creates, gets page (respects limit), deletes a locale', async () => {
+    const createdLocal = await environment.createLocale({
+      name: 'Chinese (Simplified, China)',
+      code: 'zh-Hans-CN',
+    })
+    // wait for the locale to be created
+    await new Promise((res) => setTimeout(res, 3000))
+    const pagedLocals = environment.getLocales({ limit: 1 })
+    expect(pagedLocals.items.length).equals(1)
+    expect(pagedLocals.total).equals(2)
+    await createdLocal.delete()
   })
 })


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

Looks like locals only support max page size of 100.  So, if an env has more than 100 we cannot fetch them all using contentful-management

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
