### PR TITLE
fix(common-types): add back and deprecate status

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -246,6 +246,11 @@ export interface BasicMetaSysProps {
 
 export interface MetaSysProps extends BasicMetaSysProps {
   space?: SysLink
+  /**
+   * @deprecated `status` only exists on entities. Please refactor to use a
+   * type guard to get the correct `EntityMetaSysProps` type with this property.
+   */
+  status?: SysLink
   publishedVersion?: number
   archivedVersion?: number
   archivedBy?: SysLink


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/contentful/contentful-management.js/pull/2460, I missed the `status` property 😢 

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation
