### PR TITLE
chore: fix types & docs for upload credentials []

### DIFF
--- a/lib/entities/upload-credential.ts
+++ b/lib/entities/upload-credential.ts
@@ -14,8 +14,8 @@ export interface UploadCredential
   extends UploadCredentialProps,
     DefaultElements<UploadCredentialProps> {
   /**
-   * Deletes this object on the server.
-   * @return Promise for the deletion. It contains no data, but the Promise error case should be handled.
+   * creates the upload credentials.
+   * @return upload credentials for file uploads
    * @example
    * const contentful = require('contentful-management')
    *
@@ -23,12 +23,18 @@ export interface UploadCredential
    *   accessToken: '<content_management_api_key>'
    * })
    *
-   * client.getSpace('<space_id>')
-   * .then((space) => space.getEnvironment('<environment_id>'))
-   * .then((environment) => environment.getUpload('<upload_id>'))
-   * .then((upload) => upload.delete())
-   * .then((upload) => console.log(`upload ${upload.sys.id} updated.`))
-   * .catch(console.error)
+   * try {
+   *   const space = await client.getSpace('<space_id>')
+   *   const environment = await space.getEnvironment('<environment_id>')
+   *
+   *   const upload = await client.uploadCredential.create({
+   *     spaceId: space.sys.id,
+   *     environmentId: environment.sys.id
+   *   })
+   * } catch (error) {
+   *  console.error(error)
+   * }
+   *
    */
   create(): Promise<UploadCredentialProps>
 }

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -1,6 +1,15 @@
 export * from './common-types'
-export * from './plain/common-types'
+export type {
+  AccessToken,
+  AccessTokenProps as AccessTokenProp,
+  CreatePersonalAccessTokenProps as CreatePATProps,
+} from './entities/access-token'
 export type { ApiKey, ApiKeyProps, CreateApiKeyProps } from './entities/api-key'
+export type {
+  AppAccessToken,
+  AppAccessTokenProps,
+  CreateAppAccessTokenProps,
+} from './entities/app-access-token'
 export type {
   AppAction,
   AppActionCategoryProps,
@@ -39,10 +48,16 @@ export type {
   IconType,
 } from './entities/app-details'
 export type {
+  AppEventSubscription,
+  AppEventSubscriptionProps,
+  CreateAppEventSubscriptionProps,
+} from './entities/app-event-subscription'
+export type {
   AppInstallation,
   AppInstallationProps,
   CreateAppInstallationProps,
 } from './entities/app-installation'
+export type { AppKey, AppKeyProps, CreateAppKeyProps } from './entities/app-key'
 export type {
   AppSignedRequest,
   AppSignedRequestProps,
@@ -53,17 +68,6 @@ export type {
   AppSigningSecretProps,
   CreateAppSigningSecretProps,
 } from './entities/app-signing-secret'
-export type {
-  AppEventSubscription,
-  AppEventSubscriptionProps,
-  CreateAppEventSubscriptionProps,
-} from './entities/app-event-subscription'
-export type { AppKey, AppKeyProps, CreateAppKeyProps } from './entities/app-key'
-export type {
-  AppAccessToken,
-  AppAccessTokenProps,
-  CreateAppAccessTokenProps,
-} from './entities/app-access-token'
 export type { AppUpload, AppUploadProps } from './entities/app-upload'
 export type { Asset, AssetFileProp, AssetProps, CreateAssetProps } from './entities/asset'
 export type { AssetKey, AssetKeyProps, CreateAssetKeyProps } from './entities/asset-key'
@@ -78,15 +82,15 @@ export type {
   BulkActionValidatePayload,
 } from './entities/bulk-action'
 export type {
-  RichTextCommentDocument,
-  RichTextCommentProps,
   Comment,
   CommentProps,
   CreateCommentProps,
-  UpdateCommentProps,
   DeleteCommentParams,
   GetCommentParentEntityParams,
   GetManyCommentsParams,
+  RichTextCommentDocument,
+  RichTextCommentProps,
+  UpdateCommentProps,
 } from './entities/comment'
 export type {
   AnnotationAssignment,
@@ -112,7 +116,6 @@ export type {
   GroupControl,
   SidebarItem,
 } from './entities/editor-interface'
-export type { FunctionProps } from './entities/function'
 export type { CreateEntryProps, Entry, EntryProps, WithResourceName } from './entities/entry'
 export type { CreateEnvironmentProps, Environment, EnvironmentProps } from './entities/environment'
 export type {
@@ -143,6 +146,7 @@ export type {
   ExtensionProps as UIExtensionProps,
 } from './entities/extension'
 export type { FieldType } from './entities/field-type'
+export type { FunctionProps } from './entities/function'
 export type { CreateLocaleProps, Locale, LocaleProps } from './entities/locale'
 export type { Organization, OrganizationProp, OrganizationProps } from './entities/organization'
 export type {
@@ -160,21 +164,16 @@ export type {
   PersonalAccessTokenProp,
   PersonalAccessTokenProps,
 } from './entities/personal-access-token'
-export type {
-  CreatePersonalAccessTokenProps as CreatePATProps,
-  AccessToken,
-  AccessTokenProps as AccessTokenProp,
-} from './entities/access-token'
 export type { PreviewApiKey, PreviewApiKeyProps } from './entities/preview-api-key'
 export type {
   Release,
+  ReleaseMetadata,
   ReleasePayload,
   ReleaseProps,
   ReleaseQueryOptions,
+  ReleaseReferenceFilters,
   ReleaseSysProps,
   ReleaseValidateOptions,
-  ReleaseMetadata,
-  ReleaseReferenceFilters,
 } from './entities/release'
 export type {
   ReleaseAction,
@@ -212,77 +211,59 @@ export type {
 } from './entities/team-space-membership'
 export type { UIConfig, UIConfigProps } from './entities/ui-config'
 export type { Upload, UploadProps } from './entities/upload'
+export type { UploadCredential, UploadCredentialProps } from './entities/upload-credential'
 export type { Usage, UsageProps } from './entities/usage'
 export type { User, UserProps } from './entities/user'
 export type { UserUIConfig, UserUIConfigProps } from './entities/user-ui-config'
 export type {
   CreateWebhooksProps,
   UpdateWebhookProps,
+  UpsertWebhookSigningSecretPayload,
+  WebHooks,
   WebhookCallRequest,
   WebhookFilter,
   WebhookProps,
-  WebHooks,
-  WebhookTransformation,
-  UpsertWebhookSigningSecretPayload,
   WebhookSigningSecretProps,
+  WebhookTransformation,
 } from './entities/webhook'
 export type {
+  CreateWorkflowDefinitionParams,
+  CreateWorkflowDefinitionProps,
+  CreateWorkflowStepProps,
+  DeleteWorkflowDefinitionParams,
+  UpdateWorkflowDefinitionParams,
+  UpdateWorkflowDefinitionProps,
+  UpdateWorkflowStepProps,
   // General typings (props, params, options)
   WorkflowDefinition,
-  WorkflowDefinitionSysProps,
   WorkflowDefinitionProps,
-  CreateWorkflowDefinitionProps,
-  UpdateWorkflowDefinitionProps,
-  CreateWorkflowDefinitionParams,
-  UpdateWorkflowDefinitionParams,
-  DeleteWorkflowDefinitionParams,
-  WorkflowStepProps,
-  UpdateWorkflowStepProps,
-  CreateWorkflowStepProps,
   WorkflowDefinitionQueryOptions,
+  WorkflowDefinitionSysProps,
   // Property: appliesTo
   WorkflowDefinitionValidationLink,
   // Property: step.actions
   WorkflowStepAction,
   WorkflowStepActionType,
+  WorkflowStepAppAction,
+  WorkflowStepEmailAction,
+  WorkflowStepEmailActionRecipient,
   // Property: step.permissions
   WorkflowStepPermission,
   WorkflowStepPermissionActors,
-  WorkflowStepEmailActionRecipient,
-  WorkflowStepEmailAction,
+  WorkflowStepProps,
   WorkflowStepTaskAction,
-  WorkflowStepAppAction,
 } from './entities/workflow-definition'
+export * from './plain/common-types'
 
 export {
-  WorkflowStepPermissionType,
   WorkflowStepPermissionAction,
   WorkflowStepPermissionEffect,
+  WorkflowStepPermissionType,
 } from './entities/workflow-definition'
 
-export type {
-  DefinedParameters,
-  FreeFormParameters,
-  ParameterDefinition,
-  ParameterOption,
-  ParameterType,
-  InstallationParameterType,
-} from './entities/widget-parameters'
-export type {
-  CreateWorkflowProps,
-  UpdateWorkflowProps,
-  DeleteWorkflowParams,
-  Workflow,
-  WorkflowProps,
-  WorkflowQueryOptions,
-} from './entities/workflow'
-export type {
-  WorkflowsChangelogEntry,
-  WorkflowsChangelogEntryProps,
-  WorkflowsChangelogQueryOptions,
-} from './entities/workflows-changelog-entry'
 export type { ConceptProps, CreateConceptProps } from './entities/concept'
 export type { ConceptSchemeProps, CreateConceptSchemeProps } from './entities/concept-scheme'
+export type { ResourceProps, ResourceQueryOptions } from './entities/resource'
 export type {
   ResourceProvider,
   ResourceProviderProps,
@@ -294,4 +275,24 @@ export type {
   SpaceEnvResourceTypeProps,
   UpsertResourceTypeProps,
 } from './entities/resource-type'
-export type { ResourceProps, ResourceQueryOptions } from './entities/resource'
+export type {
+  DefinedParameters,
+  FreeFormParameters,
+  InstallationParameterType,
+  ParameterDefinition,
+  ParameterOption,
+  ParameterType,
+} from './entities/widget-parameters'
+export type {
+  CreateWorkflowProps,
+  DeleteWorkflowParams,
+  UpdateWorkflowProps,
+  Workflow,
+  WorkflowProps,
+  WorkflowQueryOptions,
+} from './entities/workflow'
+export type {
+  WorkflowsChangelogEntry,
+  WorkflowsChangelogEntryProps,
+  WorkflowsChangelogQueryOptions,
+} from './entities/workflows-changelog-entry'


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

we were not exporting the types for the new upload credentials method. Our example for how to use the method was also out of date. This should be fixed now


## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
