### PR TITLE
feat: allow for optional version

### DIFF
--- a/lib/adapters/REST/endpoints/concept-scheme.ts
+++ b/lib/adapters/REST/endpoints/concept-scheme.ts
@@ -58,6 +58,18 @@ export const create: RestEndpoint<'ConceptScheme', 'create'> = (
   return raw.post<ConceptSchemeProps>(http, basePath(params.organizationId), data)
 }
 
+export const createWithId: RestEndpoint<'ConceptScheme', 'createWithId'> = (
+  http: AxiosInstance,
+  params: GetConceptSchemeParams,
+  data: CreateConceptSchemeProps
+) => {
+  return raw.put<ConceptSchemeProps>(
+    http,
+    `${basePath(params.organizationId)}/${params.conceptSchemeId}`,
+    data
+  )
+}
+
 export const update: RestEndpoint<'ConceptScheme', 'update'> = (
   http: AxiosInstance,
   params: UpdateConceptSchemeParams,

--- a/lib/adapters/REST/endpoints/concept.ts
+++ b/lib/adapters/REST/endpoints/concept.ts
@@ -26,6 +26,14 @@ export const create: RestEndpoint<'Concept', 'create'> = (
   return raw.post<ConceptProps>(http, basePath(params.organizationId), data)
 }
 
+export const createWithId: RestEndpoint<'Concept', 'createWithId'> = (
+  http: AxiosInstance,
+  params: GetConceptParams,
+  data: CreateConceptProps
+) => {
+  return raw.put<ConceptProps>(http, `${basePath(params.organizationId)}/${params.conceptId}`, data)
+}
+
 export const update: RestEndpoint<'Concept', 'update'> = (
   http: AxiosInstance,
   params: UpdateConceptParams,

--- a/lib/adapters/REST/endpoints/concept.ts
+++ b/lib/adapters/REST/endpoints/concept.ts
@@ -2,6 +2,7 @@ import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import type { OpPatch } from 'json-patch'
 import type {
+  CreateConceptWithIdParams,
   CursorPaginatedCollectionProp,
   DeleteConceptParams,
   GetConceptDescendantsParams,
@@ -28,10 +29,21 @@ export const create: RestEndpoint<'Concept', 'create'> = (
 
 export const createWithId: RestEndpoint<'Concept', 'createWithId'> = (
   http: AxiosInstance,
-  params: GetConceptParams,
-  data: CreateConceptProps
+  params: CreateConceptWithIdParams,
+  data: CreateConceptProps,
+  headers?: RawAxiosRequestHeaders
 ) => {
-  return raw.put<ConceptProps>(http, `${basePath(params.organizationId)}/${params.conceptId}`, data)
+  return raw.put<ConceptProps>(
+    http,
+    `${basePath(params.organizationId)}/${params.conceptId}`,
+    data,
+    {
+      headers: {
+        'X-Contentful-Version': params.version ?? 1,
+        ...headers,
+      },
+    }
+  )
 }
 
 export const update: RestEndpoint<'Concept', 'update'> = (
@@ -66,7 +78,7 @@ export const del: RestEndpoint<'Concept', 'delete'> = (
 ) =>
   raw.del<void>(http, `${basePath(params.organizationId)}/${params.conceptId}`, {
     headers: {
-      'X-Contentful-Version': params.version ?? 0,
+      'X-Contentful-Version': params.version ?? 1,
       ...headers,
     },
   })

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -2118,6 +2118,10 @@ export type GetOrganizationMembershipParams = GetOrganizationParams & {
   organizationMembershipId: string
 }
 export type GetConceptParams = GetOrganizationParams & { conceptId: string }
+export type CreateConceptWithIdParams = GetOrganizationParams & {
+  conceptId: string
+  version?: number
+}
 export type UpdateConceptParams = GetOrganizationParams & { conceptId: string; version: number }
 export type DeleteConceptParams = GetOrganizationParams & { conceptId: string; version: number }
 export type GetConceptDescendantsParams = GetOrganizationParams & { conceptId: string } & {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -457,6 +457,7 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Concept', 'getTotal', UA>): MRReturn<'Concept', 'getTotal'>
   (opts: MROpts<'Concept', 'getDescendants', UA>): MRReturn<'Concept', 'getDescendants'>
   (opts: MROpts<'Concept', 'create', UA>): MRReturn<'Concept', 'create'>
+  (opts: MROpts<'Concept', 'createWithId', UA>): MRReturn<'Concept', 'createWithId'>
   (opts: MROpts<'Concept', 'update', UA>): MRReturn<'Concept', 'update'>
   (opts: MROpts<'Concept', 'delete', UA>): MRReturn<'Concept', 'delete'>
 
@@ -464,6 +465,7 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'ConceptScheme', 'getMany', UA>): MRReturn<'ConceptScheme', 'getMany'>
   (opts: MROpts<'ConceptScheme', 'getTotal', UA>): MRReturn<'ConceptScheme', 'getTotal'>
   (opts: MROpts<'ConceptScheme', 'create', UA>): MRReturn<'ConceptScheme', 'create'>
+  (opts: MROpts<'ConceptScheme', 'createWithId', UA>): MRReturn<'ConceptScheme', 'createWithId'>
   (opts: MROpts<'ConceptScheme', 'update', UA>): MRReturn<'ConceptScheme', 'update'>
   (opts: MROpts<'ConceptScheme', 'delete', UA>): MRReturn<'ConceptScheme', 'delete'>
 
@@ -1189,6 +1191,11 @@ export type MRActions = {
       payload: CreateConceptProps
       return: ConceptProps
     }
+    createWithId: {
+      params: GetConceptParams
+      payload: CreateConceptProps
+      return: ConceptProps
+    }
     update: {
       params: UpdateConceptParams
       payload: OpPatch[]
@@ -1222,6 +1229,11 @@ export type MRActions = {
   ConceptScheme: {
     create: {
       params: GetOrganizationParams
+      payload: CreateConceptSchemeProps
+      return: ConceptSchemeProps
+    }
+    createWithId: {
+      params: GetConceptSchemeParams
       payload: CreateConceptSchemeProps
       return: ConceptSchemeProps
     }

--- a/lib/plain/entities/concept-scheme.ts
+++ b/lib/plain/entities/concept-scheme.ts
@@ -29,6 +29,24 @@ export type ConceptSchemePlainClientAPI = {
   ): Promise<ConceptSchemeProps>
 
   /**
+   * Create Concept Scheme With Id
+   * @returns the created Concept Scheme
+   * @throws if the request fails
+   * @see {@link https://www.contentful.com/developers/docs/references/content-management-api/#/reference/taxonomy/create-a-concept-scheme-with-user-defined-id}
+   * @example
+   * ```javascript
+   * const concept = await client.conceptScheme.createWithId({
+   *   organizationId: '<organization_id>',
+   *   conceptSchemeId: '<concept_scheme_id>',
+   * }, conceptSchemeProps);
+   * ```
+   */
+  createWithId(
+    params: SetOptional<GetConceptSchemeParams, 'organizationId'>,
+    payload: CreateConceptSchemeProps
+  ): Promise<ConceptSchemeProps>
+
+  /**
    * Update Concept Scheme
    * @returns the updated Concept Scheme
    * @throws if the request fails

--- a/lib/plain/entities/concept.ts
+++ b/lib/plain/entities/concept.ts
@@ -30,6 +30,24 @@ export type ConceptPlainClientAPI = {
   ): Promise<ConceptProps>
 
   /**
+   * Create Concept With Id
+   * @returns ConceptProps
+   * @throws if the request fails
+   * @see {@link https://www.contentful.com/developers/docs/references/content-management-api/#/reference/taxonomy/create-a-concept-with-user-defined-id}
+   * @example
+   * ```javascript
+   * const concept = await client.concept.createWithId({
+   *   organizationId: '<organization_id>',
+   *   conceptId: '<concept_id>',
+   * }, conceptProps);
+   * ```
+   */
+  createWithId(
+    params: SetOptional<GetConceptParams, 'organizationId'>,
+    payload: CreateConceptProps
+  ): Promise<ConceptProps>
+
+  /**
    * Update Concept
    * @returns the updated Concept
    * @throws if the request fails

--- a/lib/plain/entities/concept.ts
+++ b/lib/plain/entities/concept.ts
@@ -1,4 +1,5 @@
 import type {
+  CreateConceptWithIdParams,
   CursorPaginatedCollectionProp,
   DeleteConceptParams,
   GetConceptDescendantsParams,
@@ -43,7 +44,7 @@ export type ConceptPlainClientAPI = {
    * ```
    */
   createWithId(
-    params: SetOptional<GetConceptParams, 'organizationId'>,
+    params: SetOptional<CreateConceptWithIdParams, 'organizationId'>,
     payload: CreateConceptProps
   ): Promise<ConceptProps>
 

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -106,6 +106,7 @@ export const createPlainClient = (
     },
     concept: {
       create: wrap(wrapParams, 'Concept', 'create'),
+      createWithId: wrap(wrapParams, 'Concept', 'createWithId'),
       get: wrap(wrapParams, 'Concept', 'get'),
       delete: wrap(wrapParams, 'Concept', 'delete'),
       update: wrap(wrapParams, 'Concept', 'update'),
@@ -120,6 +121,7 @@ export const createPlainClient = (
       getTotal: wrap(wrapParams, 'ConceptScheme', 'getTotal'),
       delete: wrap(wrapParams, 'ConceptScheme', 'delete'),
       create: wrap(wrapParams, 'ConceptScheme', 'create'),
+      createWithId: wrap(wrapParams, 'ConceptScheme', 'createWithId'),
       update: wrap(wrapParams, 'ConceptScheme', 'update'),
     },
     function: {

--- a/test/integration/taxonomy-integration.ts
+++ b/test/integration/taxonomy-integration.ts
@@ -78,6 +78,22 @@ describe('Taxonomy Integration', () => {
     expect(result.uri).to.null
   })
 
+  test('create a concept with id', async () => {
+    const concept: CreateConceptProps = {
+      prefLabel: {
+        'en-US': 'Test Concept',
+      },
+    }
+    const result = await client.concept.createWithId({ conceptId: 'test-concept-id' }, concept)
+
+    conceptsToDelete.push(result)
+
+    isConceptProps(result)
+    expect(result.prefLabel['en-US']).to.equal('Test Concept')
+    expect(result.uri).to.null
+    expect(result.sys.id).to.equal('test-concept-id')
+  })
+
   test('create a concept with all fields', async () => {
     const concept: CreateConceptProps = {
       uri: 'https://example.com/concept',
@@ -295,6 +311,25 @@ describe('Taxonomy Integration', () => {
     isConceptSchemeProps(result)
     expect(result.prefLabel['en-US']).to.equal('Test ConceptScheme')
     expect(result.uri).to.null
+  })
+
+  test('create a conceptScheme with id', async () => {
+    const conceptScheme: CreateConceptSchemeProps = {
+      prefLabel: {
+        'en-US': 'Test ConceptScheme',
+      },
+    }
+    const result = await client.conceptScheme.createWithId(
+      { conceptSchemeId: 'test-concept-scheme-id' },
+      conceptScheme
+    )
+
+    conceptSchemesToDelete.push(result)
+
+    isConceptSchemeProps(result)
+    expect(result.prefLabel['en-US']).to.equal('Test ConceptScheme')
+    expect(result.uri).to.null
+    expect(result.sys.id).to.equal('test-concept-scheme-id')
   })
 
   test('create a conceptScheme with all fields', async () => {

--- a/test/unit/adapters/REST/endpoints/concept-scheme-test.ts
+++ b/test/unit/adapters/REST/endpoints/concept-scheme-test.ts
@@ -71,6 +71,28 @@ describe('ConceptScheme', () => {
       })
   })
 
+  test('createWithId', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+    httpMock.put.returns(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ConceptScheme',
+        action: 'createWithId',
+        params: {
+          organizationId: 'organization-id',
+          conceptSchemeId: 'concept-scheme-id',
+        },
+        payload: entityMock,
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.put.args[0][0]).to.eql(
+          '/organizations/organization-id/taxonomy/concept-schemes/concept-scheme-id'
+        )
+      })
+  })
+
   test('update', async () => {
     const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
     httpMock.patch.returns(Promise.resolve({ data: entityMock }))

--- a/test/unit/adapters/REST/endpoints/concept-test.ts
+++ b/test/unit/adapters/REST/endpoints/concept-test.ts
@@ -119,6 +119,28 @@ describe('Concept', () => {
         expect(httpMock.post.args[0][0]).to.eql('/organizations/organization-id/taxonomy/concepts')
       })
   })
+  test('createWithId', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.put.returns(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Concept',
+        action: 'createWithId',
+        params: {
+          organizationId: 'organization-id',
+          conceptId: 'concept-id',
+        },
+        payload: entityMock,
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.put.args[0][0]).to.eql(
+          '/organizations/organization-id/taxonomy/concepts/concept-id'
+        )
+      })
+  })
   test('update', async () => {
     const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
 


### PR DESCRIPTION
* Add optional version parameter for concept `createWithId`, this is needed for PUT requests when do updates
* Should this method be called upsert?
* We need to do the same for concept schemes