### PR TITLE
fix: plain client method argument types for `params` with intersection types

### DIFF
--- a/lib/plain/wrappers/wrap.test-d.ts
+++ b/lib/plain/wrappers/wrap.test-d.ts
@@ -27,4 +27,22 @@ describe('OptionalDefaults', () => {
 
     expectTypeOf<Result>().toMatchTypeOf<Expected>()
   })
+
+  it('handles intersection types', () => {
+    type Result = OptionalDefaults<{ foo1: 'bar1' } | { foo2: 'bar2' }>
+
+    type Expected = { foo1: 'bar1' } | { foo2: 'bar2' }
+
+    expectTypeOf<Result>().toMatchTypeOf<Expected>()
+  })
+
+  it('handles union with intersection types', () => {
+    type Result = OptionalDefaults<{ spaceId: string } & ({ foo1: 'bar1' } | { foo2: 'bar2' })>
+
+    type Expected =
+      | { spaceId?: string | undefined; foo1: 'bar1' }
+      | { spaceId?: string | undefined; foo2: 'bar2' }
+
+    expectTypeOf<Result>().toMatchTypeOf<Expected>()
+  })
 })

--- a/lib/plain/wrappers/wrap.ts
+++ b/lib/plain/wrappers/wrap.ts
@@ -5,11 +5,15 @@ export type DefaultParams = {
   environmentId?: string
   organizationId?: string
 }
+/**
+ * @private
+ */
+type UnionOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never
 
 /**
  * @private
  */
-export type OptionalDefaults<T> = Omit<T, keyof DefaultParams> &
+export type OptionalDefaults<T> = UnionOmit<T, keyof DefaultParams> &
   Partial<Pick<T, Extract<keyof T, keyof DefaultParams>>>
 
 /**


### PR DESCRIPTION


## Summary

Fix `params` arguments of some plain client methods


## Description

The updated `OptionalDefaults` type introduced in https://github.com/contentful/contentful-management.js/pull/2491 causes issues for intersection types combined with union types.

![image](https://github.com/user-attachments/assets/83ee5083-96c9-4205-813f-029741730a8b)



This makes some plain client methods unusable

![image](https://github.com/user-attachments/assets/07023552-1c85-41df-a665-9a6b9c3617c1)


The issue is that the builtin `Omit` doesn't play well with intersections. This PR replaces that with a union-compatible `Omit`
