### PR TITLE
fix: app installation parameter types [NONE]

### DIFF
--- a/lib/plain/entities/app-installation.ts
+++ b/lib/plain/entities/app-installation.ts
@@ -5,6 +5,7 @@ import type {
   GetAppInstallationParams,
   GetSpaceEnvironmentParams,
   PaginationQueryParams,
+  SpaceQueryParams,
 } from '../../common-types'
 import type { AppInstallationsForOrganizationProps } from '../../entities/app-definition'
 import type {
@@ -59,7 +60,7 @@ export type AppInstallationPlainClientAPI = {
    * ```
    */
   getForOrganization(
-    params: OptionalDefaults<GetAppDefinitionParams>
+    params: OptionalDefaults<GetAppDefinitionParams & SpaceQueryParams>
   ): Promise<AppInstallationsForOrganizationProps>
   /**
    * Creates or updates an App Installation


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

This changes adds partially missing types to align with the types defined [here](https://github.com/contentful/contentful-management.js/blob/master/lib/adapters/REST/endpoints/app-installation.ts). 

This allows for querying app installations by `spaceId`.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
