### PR TITLE
feat: [] Locale-based publish support in CMA client

### DIFF
--- a/lib/adapters/REST/endpoints/asset.ts
+++ b/lib/adapters/REST/endpoints/asset.ts
@@ -97,13 +97,15 @@ export const del: RestEndpoint<'Asset', 'delete'> = (
 
 export const publish: RestEndpoint<'Asset', 'publish'> = (
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { assetId: string },
+  params: GetSpaceEnvironmentParams & { assetId: string; locales?: string[] },
   rawData: AssetProps
 ) => {
+  const payload = params.locales?.length ? { add: { fields: { '*': params.locales } } } : null
+
   return raw.put<AssetProps>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/assets/${params.assetId}/published`,
-    null,
+    payload,
     {
       headers: {
         'X-Contentful-Version': rawData.sys.version ?? 0,
@@ -114,12 +116,27 @@ export const publish: RestEndpoint<'Asset', 'publish'> = (
 
 export const unpublish: RestEndpoint<'Asset', 'unpublish'> = (
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { assetId: string }
+  params: GetSpaceEnvironmentParams & { assetId: string; locales?: string[] },
+  rawData?: AssetProps
 ) => {
-  return raw.del<AssetProps>(
-    http,
-    `/spaces/${params.spaceId}/environments/${params.environmentId}/assets/${params.assetId}/published`
-  )
+  if (params.locales?.length) {
+    const payload = { remove: { fields: { '*': params.locales } } }
+    return raw.put<AssetProps>(
+      http,
+      `/spaces/${params.spaceId}/environments/${params.environmentId}/assets/${params.assetId}/published`,
+      payload,
+      {
+        headers: {
+          'X-Contentful-Version': rawData?.sys.version,
+        },
+      }
+    )
+  } else {
+    return raw.del<AssetProps>(
+      http,
+      `/spaces/${params.spaceId}/environments/${params.environmentId}/assets/${params.assetId}/published`
+    )
+  }
 }
 
 export const archive: RestEndpoint<'Asset', 'archive'> = (

--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -117,13 +117,15 @@ export const del: RestEndpoint<'Entry', 'delete'> = (
 
 export const publish: RestEndpoint<'Entry', 'publish'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { entryId: string },
+  params: GetSpaceEnvironmentParams & { entryId: string; locales?: string[] },
   rawData: EntryProps<T>
 ) => {
+  const payload = params.locales?.length ? { add: { fields: { '*': params.locales } } } : null
+
   return raw.put<EntryProps<T>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}/published`,
-    null,
+    payload,
     {
       headers: {
         'X-Contentful-Version': rawData.sys.version,
@@ -134,12 +136,27 @@ export const publish: RestEndpoint<'Entry', 'publish'> = <T extends KeyValueMap 
 
 export const unpublish: RestEndpoint<'Entry', 'unpublish'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { entryId: string }
+  params: GetSpaceEnvironmentParams & { entryId: string; locales?: string[] },
+  rawData?: EntryProps<T>
 ) => {
-  return raw.del<EntryProps<T>>(
-    http,
-    `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}/published`
-  )
+  if (params.locales?.length) {
+    const payload = { remove: { fields: { '*': params.locales } } }
+    return raw.put<EntryProps<T>>(
+      http,
+      `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}/published`,
+      payload,
+      {
+        headers: {
+          'X-Contentful-Version': rawData?.sys.version,
+        },
+      }
+    )
+  } else {
+    return raw.del<EntryProps<T>>(
+      http,
+      `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}/published`
+    )
+  }
 }
 
 export const archive: RestEndpoint<'Entry', 'archive'> = <T extends KeyValueMap = KeyValueMap>(

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -277,6 +277,7 @@ export interface EntityMetaSysProps extends MetaSysProps {
   firstPublishedAt?: string
   publishedCounter?: number
   locale?: string
+  fieldStatus: { '*': Record<string, string> }
 }
 
 export interface EntryMetaSysProps extends EntityMetaSysProps {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -277,7 +277,7 @@ export interface EntityMetaSysProps extends MetaSysProps {
   firstPublishedAt?: string
   publishedCounter?: number
   locale?: string
-  fieldStatus: { '*': Record<string, string> }
+  fieldStatus: { '*': Record<string, 'draft' | 'changed' | 'published'> }
 }
 
 export interface EntryMetaSysProps extends EntityMetaSysProps {

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -291,11 +291,11 @@ export type PlainClientAPI = {
     ): Promise<EntryProps<T>>
     delete(params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>): Promise<any>
     publish<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string; locales?: string[] }>,
       rawData: EntryProps<T>
     ): Promise<EntryProps<T>>
     unpublish<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string; locales?: string[] }>
     ): Promise<EntryProps<T>>
     archive<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>
@@ -345,11 +345,11 @@ export type PlainClientAPI = {
     ): Promise<AssetProps>
     delete(params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string }>): Promise<any>
     publish(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string }>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string; locales?: string[] }>,
       rawData: AssetProps
     ): Promise<AssetProps>
     unpublish(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string }>
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string; locales?: string[] }>
     ): Promise<AssetProps>
     archive(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string }>


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary
Add extra param for passing locales to singular entity publish/unpublish method.

We are not adding this functionality to old (nested) client as it is soon to be deprecated.

## Description
With recent release of locale-based publishing, we add this functionality to public client. Adding `locales` param to publish/unpublish endpoints.

## Motivation and Context
Aligning with recent release of Locale-based publishing.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation