### PR TITLE
feat: add `sys.organization` property to `AppInstallation` entity

### DIFF
--- a/lib/entities/app-installation.ts
+++ b/lib/entities/app-installation.ts
@@ -11,6 +11,7 @@ export type AppInstallationProps = {
     appDefinition: SysLink
     environment: SysLink
     space: SysLink
+    organization: SysLink
   }
   /**
    * Free-form installation parameters (API limits stringified length to 32KB)


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Adding `sys.organization` as a property to app installations.

## Motivation and Context

Make public types consistent with the adjusted payload.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

