### PR TITLE
feat: [GROOT-1605] add typing for required taxonomy on content types

### DIFF
--- a/lib/entities/content-type.ts
+++ b/lib/entities/content-type.ts
@@ -20,6 +20,9 @@ import type { Snapshot, SnapshotProps } from './snapshot'
 import { wrapSnapshot, wrapSnapshotCollection } from './snapshot'
 import { omitAndDeleteField } from '../methods/content-type'
 
+type TaxonomyConceptValidationLink = Link<'TaxonomyConcept'> & { required?: boolean }
+type TaxonomyConceptSchemeValidationLink = Link<'TaxonomyConceptScheme'> & { required?: boolean }
+
 export type ContentTypeMetadata = {
   annotations?: RequireAtLeastOne<
     {
@@ -28,7 +31,7 @@ export type ContentTypeMetadata = {
     },
     'ContentType' | 'ContentTypeField'
   >
-  taxonomy?: Array<Link<'TaxonomyConcept'> | Link<'TaxonomyConceptScheme'>>
+  taxonomy?: Array<TaxonomyConceptValidationLink | TaxonomyConceptSchemeValidationLink>
 }
 
 export type AnnotationAssignment = Link<'Annotation'> & {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

This PR seeks to introduce support for marking taxonomy concepts/schemes as required on content types in the CMA

## Description

For this PR, all that needed to be changed was the typings around the `ContentType` object

## Motivation and Context

This is a strategic feature for team Groot, as this is a heavily requested feature from our customers.

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
