### PR TITLE
feat: export make request [EXT-6172]

### DIFF
--- a/lib/adapters/REST/make-request.ts
+++ b/lib/adapters/REST/make-request.ts
@@ -1,0 +1,41 @@
+import type { AxiosInstance } from "contentful-sdk-core"
+import type { MakeRequestOptions, MakeRequestPayload } from "../../common-types"
+import type { OpPatch } from 'json-patch'
+import type { RawAxiosRequestHeaders } from "axios"
+import endpoints from './endpoints'
+
+type makeAxiosRequest = MakeRequestOptions & {
+    axiosInstance: AxiosInstance
+}
+export const makeRequest = async <R>({
+    axiosInstance,
+    entityType,
+    action: actionInput,
+    params,
+    payload,
+    headers,
+    userAgent,
+  }: makeAxiosRequest): Promise<R> => {
+    // `delete` is a reserved keyword. Therefore, the methods are called `del`.
+    const action = actionInput === 'delete' ? 'del' : actionInput
+
+    const endpoint: (
+      http: AxiosInstance,
+      params?: Record<string, unknown>,
+      payload?: Record<string, unknown> | OpPatch[] | MakeRequestPayload,
+      headers?: RawAxiosRequestHeaders
+    ) => Promise<R> =
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      endpoints[entityType]?.[action]
+
+    if (endpoint === undefined) {
+      throw new Error('Unknown endpoint')
+    }
+
+    return await endpoint(axiosInstance, params, payload, {
+      ...headers,
+      // overwrite the userAgent with the one passed in the request
+      ...(userAgent ? { 'X-Contentful-User-Agent': userAgent } : {}),
+    })
+  }

--- a/lib/adapters/REST/make-request.ts
+++ b/lib/adapters/REST/make-request.ts
@@ -1,41 +1,41 @@
-import type { AxiosInstance } from "contentful-sdk-core"
-import type { MakeRequestOptions, MakeRequestPayload } from "../../common-types"
+import type { AxiosInstance } from 'contentful-sdk-core'
+import type { MakeRequestOptions, MakeRequestPayload } from '../../common-types'
 import type { OpPatch } from 'json-patch'
-import type { RawAxiosRequestHeaders } from "axios"
+import type { RawAxiosRequestHeaders } from 'axios'
 import endpoints from './endpoints'
 
 type makeAxiosRequest = MakeRequestOptions & {
-    axiosInstance: AxiosInstance
+  axiosInstance: AxiosInstance
 }
 export const makeRequest = async <R>({
-    axiosInstance,
-    entityType,
-    action: actionInput,
-    params,
-    payload,
-    headers,
-    userAgent,
-  }: makeAxiosRequest): Promise<R> => {
-    // `delete` is a reserved keyword. Therefore, the methods are called `del`.
-    const action = actionInput === 'delete' ? 'del' : actionInput
+  axiosInstance,
+  entityType,
+  action: actionInput,
+  params,
+  payload,
+  headers,
+  userAgent,
+}: makeAxiosRequest): Promise<R> => {
+  // `delete` is a reserved keyword. Therefore, the methods are called `del`.
+  const action = actionInput === 'delete' ? 'del' : actionInput
 
-    const endpoint: (
-      http: AxiosInstance,
-      params?: Record<string, unknown>,
-      payload?: Record<string, unknown> | OpPatch[] | MakeRequestPayload,
-      headers?: RawAxiosRequestHeaders
-    ) => Promise<R> =
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      endpoints[entityType]?.[action]
+  const endpoint: (
+    http: AxiosInstance,
+    params?: Record<string, unknown>,
+    payload?: Record<string, unknown> | OpPatch[] | MakeRequestPayload,
+    headers?: RawAxiosRequestHeaders
+  ) => Promise<R> =
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    endpoints[entityType]?.[action]
 
-    if (endpoint === undefined) {
-      throw new Error('Unknown endpoint')
-    }
-
-    return await endpoint(axiosInstance, params, payload, {
-      ...headers,
-      // overwrite the userAgent with the one passed in the request
-      ...(userAgent ? { 'X-Contentful-User-Agent': userAgent } : {}),
-    })
+  if (endpoint === undefined) {
+    throw new Error('Unknown endpoint')
   }
+
+  return await endpoint(axiosInstance, params, payload, {
+    ...headers,
+    // overwrite the userAgent with the one passed in the request
+    ...(userAgent ? { 'X-Contentful-User-Agent': userAgent } : {}),
+  })
+}

--- a/lib/adapters/REST/rest-adapter.ts
+++ b/lib/adapters/REST/rest-adapter.ts
@@ -1,11 +1,9 @@
-import type { RawAxiosRequestHeaders } from 'axios'
 import axios from 'axios'
 import type { AxiosInstance, CreateHttpClientParams } from 'contentful-sdk-core'
 import { createHttpClient } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type { OpPatch } from 'json-patch'
-import type { Adapter, MakeRequestOptions, MakeRequestPayload } from '../../common-types'
-import endpoints from './endpoints'
+import type { Adapter, MakeRequestOptions } from '../../common-types'
+import { makeRequest } from './make-request'
 
 export type RestAdapterParams = CreateHttpClientParams & {
   /**
@@ -65,35 +63,7 @@ export class RestAdapter implements Adapter {
     })
   }
 
-  public async makeRequest<R>({
-    entityType,
-    action: actionInput,
-    params,
-    payload,
-    headers,
-    userAgent,
-  }: MakeRequestOptions): Promise<R> {
-    // `delete` is a reserved keyword. Therefore, the methods are called `del`.
-    const action = actionInput === 'delete' ? 'del' : actionInput
-
-    const endpoint: (
-      http: AxiosInstance,
-      params?: Record<string, unknown>,
-      payload?: Record<string, unknown> | OpPatch[] | MakeRequestPayload,
-      headers?: RawAxiosRequestHeaders
-    ) => Promise<R> =
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      endpoints[entityType]?.[action]
-
-    if (endpoint === undefined) {
-      throw new Error('Unknown endpoint')
-    }
-
-    return await endpoint(this.axiosInstance, params, payload, {
-      ...headers,
-      // overwrite the userAgent with the one passed in the request
-      ...(userAgent ? { 'X-Contentful-User-Agent': userAgent } : {}),
-    })
+  public async makeRequest<R>(opts: MakeRequestOptions): Promise<R> {
+    return makeRequest({ ...opts, axiosInstance: this.axiosInstance })
   }
 }

--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -23,6 +23,7 @@ export { isDraft, isPublished, isUpdated } from './plain/checks'
 export type { PlainClientAPI } from './plain/common-types'
 export { createClient }
 export { RestAdapter } from './adapters/REST/rest-adapter'
+export { makeRequest } from './adapters/REST/make-request'
 export { editorInterfaceDefaults }
 export type PlainClientDefaultParams = DefaultParams
 export * from './export-types'

--- a/lib/contentful-management.ts
+++ b/lib/contentful-management.ts
@@ -23,6 +23,7 @@ export { isDraft, isPublished, isUpdated } from './plain/checks'
 export type { PlainClientAPI } from './plain/common-types'
 export { createClient }
 export { RestAdapter } from './adapters/REST/rest-adapter'
+export type { RestAdapterParams } from './adapters/REST/rest-adapter'
 export { makeRequest } from './adapters/REST/make-request'
 export { editorInterfaceDefaults }
 export type PlainClientDefaultParams = DefaultParams


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Extract make request to make adapter creation easier

## Description

Serverless execution environments will benefit from using an adapter that uses native fetch rather than axios.  This exports the helper makeRequest so we don't have to implement the entire interface

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
