### PR TITLE
feat: allow function logs to be queried by interval [EXT-6221]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -372,11 +372,22 @@ interface CursorPaginationNone extends CursorPaginationBase {
   pagePrev?: never
 }
 
-interface IntervalQueryOptions {
-  timeStart?: Date
-  timeEnd?: Date
-}
+type ComparisonOperator = 'gt' | 'gte' | 'lt' | 'lte'
+type StartOperators = 'gt' | 'gte'
+type EndOperators = 'lt' | 'lte'
 
+// Helper type for creating property paths with operators
+// For example "sys.createdAt[gte]", P = sys.createdAt, O = gte
+type WithOperator<P extends string, O extends ComparisonOperator> = `${P}[${O}]`
+
+// Type for valid date range combinations - only start, only end, or both
+type IntervalQuery<P extends string> =
+  | Partial<Record<WithOperator<P, StartOperators>, string | Date>>
+  | Partial<Record<WithOperator<P, EndOperators>, string | Date>>
+  | (Partial<Record<WithOperator<P, StartOperators>, string | Date>> & 
+     Partial<Record<WithOperator<P, EndOperators>, string | Date>>)
+
+export type CreatedAtIntervalQueryOptions = IntervalQuery<'sys.createdAt'>
 export interface AcceptsQueryOptions {
   'accepts[all]'?: string
 }
@@ -2238,7 +2249,7 @@ export type GetFunctionForEnvParams = AcceptsQueryParams &
     appInstallationId: string
   }
 export type GetManyFunctionLogParams = CursorBasedParams &
-  IntervalParams &
+  CreatedAtIntervalParams &
   GetFunctionForEnvParams & { functionId: string }
 export type GetFunctionLogParams = GetManyFunctionLogParams & { logId: string }
 export type GetOrganizationParams = { organizationId: string }
@@ -2314,7 +2325,7 @@ export type CursorPaginationXORParams = {
   }
 }
 export type CursorBasedParams = CursorPaginationXORParams
-export type IntervalParams = { query?: IntervalQueryOptions }
+export type CreatedAtIntervalParams = { query?: CreatedAtIntervalQueryOptions }
 export type AcceptsQueryParams = { query?: AcceptsQueryOptions }
 
 export type GetOAuthApplicationParams = { userId: string; oauthApplicationId: string }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -372,20 +372,32 @@ interface CursorPaginationNone extends CursorPaginationBase {
   pagePrev?: never
 }
 
-type ComparisonOperator = 'gt' | 'gte' | 'lt' | 'lte'
-type StartOperators = 'gt' | 'gte'
-type EndOperators = 'lt' | 'lte'
+type StartOperator = 'gt' | 'gte'
+type EndOperator = 'lt' | 'lte'
+type ComparisonOperator = StartOperator | EndOperator
 
-// Helper type for creating property paths with operators
+// Helper type for creating property paths with comparison operators
 // For example "sys.createdAt[gte]", P = sys.createdAt, O = gte
 type WithComparisonOperator<P extends string, O extends ComparisonOperator> = `${P}[${O}]`
 
+// Helper types to ensure only one start operator can be used and only one end operator can be used
+type WithOneOperator<P extends string, C extends ComparisonOperator, O extends C> = {
+  [K in WithComparisonOperator<P, O>]: string | Date
+} & {
+  [K in WithComparisonOperator<P, Exclude<C, O>>]?: never
+}
+type WithStartOperator<P extends string> =
+  | WithOneOperator<P, StartOperator, 'gt'>
+  | WithOneOperator<P, StartOperator, 'gte'>
+type WithEndOperator<P extends string> =
+  | WithOneOperator<P, EndOperator, 'lt'>
+  | WithOneOperator<P, EndOperator, 'lte'>
+
 // Type for valid date range combinations - only start, only end, or both
 type IntervalQuery<P extends string> =
-  | Partial<Record<WithComparisonOperator<P, StartOperators>, string | Date>>
-  | Partial<Record<WithComparisonOperator<P, EndOperators>, string | Date>>
-  | (Partial<Record<WithComparisonOperator<P, StartOperators>, string | Date>> &
-      Partial<Record<WithComparisonOperator<P, EndOperators>, string | Date>>)
+  | Partial<WithStartOperator<P>>
+  | Partial<WithEndOperator<P>>
+  | (Partial<WithStartOperator<P>> & Partial<WithEndOperator<P>>)
 
 export type CreatedAtIntervalQueryOptions = IntervalQuery<'sys.createdAt'>
 export interface AcceptsQueryOptions {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -372,6 +372,11 @@ interface CursorPaginationNone extends CursorPaginationBase {
   pagePrev?: never
 }
 
+interface IntervalQueryOptions {
+  timeStart?: string
+  timeEnd?: string
+}
+
 export interface AcceptsQueryOptions {
   'accepts[all]'?: string
 }
@@ -2233,6 +2238,7 @@ export type GetFunctionForEnvParams = AcceptsQueryParams &
     appInstallationId: string
   }
 export type GetManyFunctionLogParams = CursorBasedParams &
+  IntervalParams &
   GetFunctionForEnvParams & { functionId: string }
 export type GetFunctionLogParams = GetManyFunctionLogParams & { logId: string }
 export type GetOrganizationParams = { organizationId: string }
@@ -2308,6 +2314,7 @@ export type CursorPaginationXORParams = {
   }
 }
 export type CursorBasedParams = CursorPaginationXORParams
+export type IntervalParams = { query?: IntervalQueryOptions }
 export type AcceptsQueryParams = { query?: AcceptsQueryOptions }
 
 export type GetOAuthApplicationParams = { userId: string; oauthApplicationId: string }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -378,14 +378,14 @@ type EndOperators = 'lt' | 'lte'
 
 // Helper type for creating property paths with operators
 // For example "sys.createdAt[gte]", P = sys.createdAt, O = gte
-type WithOperator<P extends string, O extends ComparisonOperator> = `${P}[${O}]`
+type WithComparisonOperator<P extends string, O extends ComparisonOperator> = `${P}[${O}]`
 
 // Type for valid date range combinations - only start, only end, or both
 type IntervalQuery<P extends string> =
-  | Partial<Record<WithOperator<P, StartOperators>, string | Date>>
-  | Partial<Record<WithOperator<P, EndOperators>, string | Date>>
-  | (Partial<Record<WithOperator<P, StartOperators>, string | Date>> & 
-     Partial<Record<WithOperator<P, EndOperators>, string | Date>>)
+  | Partial<Record<WithComparisonOperator<P, StartOperators>, string | Date>>
+  | Partial<Record<WithComparisonOperator<P, EndOperators>, string | Date>>
+  | (Partial<Record<WithComparisonOperator<P, StartOperators>, string | Date>> &
+      Partial<Record<WithComparisonOperator<P, EndOperators>, string | Date>>)
 
 export type CreatedAtIntervalQueryOptions = IntervalQuery<'sys.createdAt'>
 export interface AcceptsQueryOptions {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -373,8 +373,8 @@ interface CursorPaginationNone extends CursorPaginationBase {
 }
 
 interface IntervalQueryOptions {
-  timeStart?: string
-  timeEnd?: string
+  timeStart?: Date
+  timeEnd?: Date
 }
 
 export interface AcceptsQueryOptions {

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -3,6 +3,7 @@ import { createRequestConfig } from 'contentful-sdk-core'
 import type {
   AcceptsQueryOptions,
   BasicCursorPaginationOptions,
+  CreatedAtIntervalParams,
   CursorBasedParams,
   QueryOptions,
 } from './common-types'
@@ -1727,14 +1728,28 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *       environment.getFunctionLogs(
      *          '<app-installation-id>',
      *          '<function-id>',
-     *          { limit: 10 },
+     *          {
+     *            query: {
+     *              // optional limit
+     *              limit: 10,
+     *              // optional interval query
+     *              'sys.createdAt[gte]': start,
+     *              'sys.createdAt[lt]': end,
+     *              // optional cursor based pagination parameters
+     *              pagePrev: '<page_prev>',
+     *            },
+     *          },
      *       )
      *     )
      *     .then((functionLogs) => console.log(functionLog.items))
      *     .catch(console.error)
      * ```
      */
-    getFunctionLogs(appInstallationId: string, functionId: string, query?: CursorBasedParams) {
+    getFunctionLogs(
+      appInstallationId: string,
+      functionId: string,
+      query?: CursorBasedParams & CreatedAtIntervalParams
+    ) {
       const raw: EnvironmentProps = this.toPlainObject()
 
       return makeRequest({

--- a/lib/plain/entities/function-log.ts
+++ b/lib/plain/entities/function-log.ts
@@ -35,17 +35,20 @@ export type FunctionLogPlainClientAPI = {
    * const start = new Date()
    * const end = new Date()
    * start.setHours(start.getHours() - 1)
-   * 
+   *
    * const functionLogs = await client.functionLog.getMany({
    *    spaceId: '<space_id>',
    *    environmentId: '<environment_id>',
    *    appInstallationId: '<app_installation_id>',
    *    functionId: '<function_id>',
-   *    query: { 
-   *      limit: 100,
+   *    query: {
+   *      // optional limit
+   *      limit: 10,
    *      // optional interval query
    *      'sys.createdAt[gte]': start,
-   *      'sys.createdAt[lte]': end,
+   *      'sys.createdAt[lt]': end,
+   *      // optional cursor based pagination parameters
+   *      pageNext: '<page_next>',
    *    }
    * });
    * ```

--- a/lib/plain/entities/function-log.ts
+++ b/lib/plain/entities/function-log.ts
@@ -32,12 +32,21 @@ export type FunctionLogPlainClientAPI = {
    * @throws if the request fails, or the FunctionLogs are not found
    * @example
    * ```javascript
-   * const functionLogs = await client.functionLog.getAll({
+   * const start = new Date()
+   * const end = new Date()
+   * start.setHours(start.getHours() - 1)
+   * 
+   * const functionLogs = await client.functionLog.getMany({
    *    spaceId: '<space_id>',
    *    environmentId: '<environment_id>',
    *    appInstallationId: '<app_installation_id>',
    *    functionId: '<function_id>',
-   *    query: { limit: 100 }
+   *    query: { 
+   *      limit: 100,
+   *      // optional interval query
+   *      'sys.createdAt[gte]': start,
+   *      'sys.createdAt[lte]': end,
+   *    }
    * });
    * ```
    */


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

Function logs can now be queried by interval, using either Date objects or ISO strings

## Description

<!-- Describe your changes in detail -->

For example:
```typescript
const timeStart = new Date()
const timeEnd = new Date()
timeEnd.setHours(then.getHours() - 1)

// Plain Client:
const functionLogs = await plainClient.functionLogs.getMany({
  spaceId: '<space_id>',
  environmentId: '<environment_id>',
  appInstallationId: '<app_installation_id>',
  functionId: '<function_id>',
  query: {
    'sys.createdAt[gte]': timeStart,
    'sys.createdAt[lt]': timeEnd
  }
})

// Legacy client:
client.getSpace('<space_id>')
    .then((space) => space.getEnvironment('<environment_id>'))
    .then((environment) =>
      environment.getFunctionLogs(
        '<app_installation_id>',
        '<function_id>',
        {
          query: {
            'sys.createdAt[gte]': new Date("2025-03-03T16:29:15.165Z"),
            'sys.createdAt[lt]': "2025-03-03T17:29:15.165Z",
          }
        }
      )
```

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation
