### PR TITLE
fix: add `version` param to patch method of plain client

### DIFF
--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -283,7 +283,7 @@ export type PlainClientAPI = {
       headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>
     patch<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string, version: number }>,
       rawData: OpPatch[],
       headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -283,7 +283,7 @@ export type PlainClientAPI = {
       headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>
     patch<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string, version: number }>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string; version: number }>,
       rawData: OpPatch[],
       headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Adding missing `version` param to the plain client entry patch params

## Description

`client.entry.patch` expects `version` to be passed in, however `version` is currently not included in the TypeScript types.

## Motivation and Context

