### PR TITLE
feat: exports field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13322,10 +13322,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/agent": {
-      "extraneous": true,
-      "inBundle": true
-    },
     "node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
       "version": "3.0.0",
       "dev": true,
@@ -13363,10 +13359,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/ssri": {
-      "extraneous": true,
-      "inBundle": true
-    },
     "node_modules/npm/node_modules/node-gyp/node_modules/tar": {
       "version": "7.4.3",
       "dev": true,
@@ -13383,14 +13375,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/unique-filename": {
-      "extraneous": true,
-      "inBundle": true
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/unique-slug": {
-      "extraneous": true,
-      "inBundle": true
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && npm run build:modules && npm run build:standalone && npm run build:types",
+    "postbuild": "npm run test:demo-projects",
     "build:modules": "BABEL_ENV=modules babel --extensions \".ts\" --extensions \".js\" lib -d dist/es-modules/",
     "build:standalone": "webpack && NODE_ENV=production webpack",
     "build:standalone:log": "NODE_ENV=production WEBPACK_MODE=log webpack --json --profile --progress > webpack-build-log.json && webpack-bundle-analyzer webpack-build-log.json",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,12 @@
     "node": ">=18"
   },
   "exports": {
-    "import": "./dist/es-modules/contentful-management.js",
-    "require": "./dist/contentful-management.node.js"
+    ".": {
+      "types": "./dist/typings/contentful-management.d.ts",
+      "browser": "./dist/contentful-management.browser.js",
+      "import": "./dist/es-modules/contentful-management.js",
+      "require": "./dist/contentful-management.node.js"
+    }
   },
   "browserslist": [
     ">0.3%",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   "engines": {
     "node": ">=18"
   },
+  "exports": {
+    "import": "./dist/es-modules/contentful-management.js",
+    "require": "./dist/contentful-management.node.js"
+  },
   "browserslist": [
     ">0.3%",
     "Chrome >= 75",
@@ -26,7 +30,6 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && npm run build:modules && npm run build:standalone && npm run build:types",
-    "postbuild": "npm run test:demo-projects",
     "build:modules": "BABEL_ENV=modules babel --extensions \".ts\" --extensions \".js\" lib -d dist/es-modules/",
     "build:standalone": "webpack && NODE_ENV=production webpack",
     "build:standalone:log": "NODE_ENV=production WEBPACK_MODE=log webpack --json --profile --progress > webpack-build-log.json && webpack-bundle-analyzer webpack-build-log.json",


### PR DESCRIPTION
## Summary

Add [`exports`](https://nodejs.org/api/packages.html#exports) field to package.json.

## Description
Add [`exports`](https://nodejs.org/api/packages.html#exports) field to package.json, to improve esm compatibility with modern tooling / projects.

This will cause a conflict with https://github.com/contentful/contentful-management.js/pull/2472 - but it should be fine - as its just the exports field.

## Motivation and Context

- Improves compatibility with ESM based projects
- Is a prerequisite for https://github.com/contentful/contentful-import/pull/1345

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation
