### PR TITLE
fix: update app action types to support function-invocation [EXT-5873]

### DIFF
--- a/lib/entities/app-action.ts
+++ b/lib/entities/app-action.ts
@@ -2,7 +2,13 @@ import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { Except } from 'type-fest'
 import { wrapCollection } from '../common-utils'
-import type { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '../common-types'
+import type {
+  BasicMetaSysProps,
+  DefaultElements,
+  Link,
+  MakeRequest,
+  SysLink,
+} from '../common-types'
 import type { ParameterDefinition } from './widget-parameters'
 import enhanceWithMethods from '../enhance-with-methods'
 
@@ -42,24 +48,16 @@ type CustomAppActionProps = {
 type AppActionCategory = BuiltInCategoriesProps | CustomAppActionProps
 export type AppActionCategoryType = AppActionCategory['category']
 
+/**
+ * 'function' is deprecated, use 'function-invocation' instead
+ */
 export type AppActionType = 'endpoint' | 'function' | 'function-invocation'
 
-export type CreateAppActionProps = AppActionCategory & {
-  url: string
-  name: string
-  description?: string
-  type?: AppActionType
-}
-
-export type AppActionProps = AppActionCategory & {
+type BaseAppActionProps = AppActionCategory & {
   /**
    * System metadata
    */
   sys: AppActionSys
-  /**
-   * Url that will be called when the action is invoked
-   */
-  url: string
   /**
    * Human readable name for the action
    */
@@ -68,14 +66,74 @@ export type AppActionProps = AppActionCategory & {
    * Human readable description of the action
    */
   description?: string
+}
+
+type CreateEndpointAppActionProps = {
   /**
    * Type of the action, defaults to endpoint if not provided
    * endpoint: action is sent to specified URL
-   * function: deprecated, use function-invocation instead
+   */
+  type?: 'endpoint'
+  /**
+   * Url that will be called when the action is invoked
+   */
+  url: string
+}
+
+type EndpointAppActionProps = {
+  /**
+   * Type of the action
+   * endpoint: action is sent to specified URL
+   */
+  type: 'endpoint'
+  /**
+   * Url that will be called when the action is invoked
+   */
+  url: string
+}
+
+type CreateFunctionAppActionProps = {
+  /**
+   * Type of the action
    * function-invocation: action invokes a contentful function
    */
-  type?: AppActionType
+  type: 'function-invocation'
+  /**
+   * Link to a Function
+   */
+  function: Link<'Function'>
+  /**
+   * ID of the action
+   */
+  id?: string
 }
+
+type FunctionAppActionProps = {
+  /**
+   * Type of the action
+   * function-invocation: action invokes a contentful function
+   */
+  type: 'function-invocation'
+  /**
+   * Link to a Function
+   */
+  function: Link<'Function'>
+}
+
+/**
+ * @deprecated Use FunctionAppActionProps instead
+ */
+type LegacyFunctionAppActionProps = Record<string, unknown> & {
+  type: 'function'
+}
+
+export type CreateAppActionProps = AppActionCategory & {
+  name: string
+  description?: string
+} & (CreateEndpointAppActionProps | CreateFunctionAppActionProps | LegacyFunctionAppActionProps)
+
+export type AppActionProps = BaseAppActionProps &
+  (EndpointAppActionProps | FunctionAppActionProps | LegacyFunctionAppActionProps)
 
 export type AppAction = AppActionProps &
   DefaultElements<AppActionProps> & {

--- a/lib/plain/entities/app-action.ts
+++ b/lib/plain/entities/app-action.ts
@@ -79,6 +79,7 @@ export type AppActionPlainClientAPI = {
    * @throws if the request fails, an entity is not found, or the payload is malformed
    * @example
    * ```javascript
+   * // app action that targets an endpoint url
    * const appAction = await client.appAction.create(
    *   {
    *     organizationId: "<org_id>",
@@ -92,6 +93,28 @@ export type AppActionPlainClientAPI = {
    *     name: "My Notification",
    *   }
    * );
+   *
+   * // app action that invokes a Contentful Function
+   * const functionAppAction = await client.appAction.create(
+   *  {
+   *    organizationId: '<org_id>',
+   *    appDefinitionId: '<app_definition_id>',
+   *    appActionId: '<app_action_id>',
+   *  },
+   *  {
+   *   type: "function-invocation",
+   *   function: {
+   *     sys: {
+   *       type: "Link",
+   *       linkType: "Function",
+   *       id: '<function_id>'
+   *     }
+   *   },
+   *   category: "Notification.v1.0",
+   *   description: "sends a notification",
+   *   name: "Notification (Function Example)",
+   * }
+   *);
    * ```
    */
   create(
@@ -106,6 +129,7 @@ export type AppActionPlainClientAPI = {
    * @throws if the request fails, the App Action is not found, or the payload is malformed
    * @example
    * ```javascript
+   * // app action that targets an endpoint url
    * const appAction = await client.appAction.update(
    *   {
    *     organizationId: "<org_id>",
@@ -119,6 +143,28 @@ export type AppActionPlainClientAPI = {
    *     name: "My Notification",
    *   }
    * );
+   *
+   * // app action that invokes a Contentful Function
+   * const functionAppAction = await client.appAction.update(
+   *  {
+   *    organizationId: '<org_id>',
+   *    appDefinitionId: '<app_definition_id>',
+   *    appActionId: '<app_action_id>',
+   *  },
+   *  {
+   *   type: "function-invocation",
+   *   function: {
+   *     sys: {
+   *       type: "Link",
+   *       linkType: "Function",
+   *       id: '<function_id>'
+   *     }
+   *   },
+   *   category: "Notification.v1.0",
+   *   description: "sends a notification",
+   *   name: "Notification (Function Example)",
+   * }
+   *);
    * ```
    */
   update(


### PR DESCRIPTION
## Summary

App Action types did not have the correct properties for `function-invocation`. This PR corrects that, makes the types more specific for each of the app action types, and also updates the examples for create and update to show how to do it for an app action that targets a function.

## Description

Create base app action and type-specific types for endpoint, function-invocation, and function (deprecated) app actions. 

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
