### PR TITLE
[DO NOT MERGE] experiment: return custom error object with message code [UFO-1682]

### DIFF
--- a/lib/adapters/REST/endpoints/ui-config.ts
+++ b/lib/adapters/REST/endpoints/ui-config.ts
@@ -16,16 +16,29 @@ export const get: RestEndpoint<'UIConfig', 'get'> = (
   return raw.get<UIConfigProps>(http, getUrl(params))
 }
 
-export const update: RestEndpoint<'UIConfig', 'update'> = (
+export const update: RestEndpoint<'UIConfig', 'update'> = async(
   http: AxiosInstance,
   params: GetUIConfigParams,
   rawData: UIConfigProps
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys
-  return raw.put<UIConfigProps>(http, getUrl(params), data, {
-    headers: {
-      'X-Contentful-Version': rawData.sys.version ?? 0,
-    },
-  })
+  try{
+    return await raw.put<UIConfigProps>(http, getUrl(params), data, {
+      headers: {
+        'X-Contentful-Version': rawData.sys.version ?? 0,
+      },
+    })
+  } catch(error){
+    throw {
+      sys: {
+        type: 'Error',
+        id: 'Failed',
+      },
+      message: 'Update has failed',
+      details: 'Saved view could not be updated',
+      message_code: 'savedViews.update.Failed',
+    }
+  }
 }
+

--- a/test/unit/adapters/REST/endpoints/ui-config.test.ts
+++ b/test/unit/adapters/REST/endpoints/ui-config.test.ts
@@ -32,4 +32,25 @@ describe('Rest UIConfig', () => {
       }
     })
   })
-})
+
+  test('UIConfig update fails with custom error message', async () => {
+    const errorMessage = 'Network error';
+    const { adapterMock } = setup(Promise.reject(new Error(errorMessage)));
+    const entityMock = cloneMock('uiConfig');
+    const entity = wrapUIConfig((...args) => adapterMock.makeRequest(...args), entityMock);
+
+    try {
+      await entity.update();
+    } catch (error) {
+      expect(error).toEqual({
+        sys: {
+          type: 'Error',
+          id: 'Failed',
+        },
+        message: 'Update has failed',
+        details: 'Saved view could not be updated',
+        message_code: 'savedViews.update.Failed',
+      });
+    }
+  });
+});


### PR DESCRIPTION
experiment to return a custom error object that contains a translation message code.