### PR TITLE
fix: update app event subscription to support functions [EXT-6289]

### DIFF
--- a/lib/entities/app-event-subscription.ts
+++ b/lib/entities/app-event-subscription.ts
@@ -1,7 +1,13 @@
 import copy from 'fast-copy'
 import { toPlainObject } from 'contentful-sdk-core'
 import type { Except } from 'type-fest'
-import type { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '../common-types'
+import type {
+  BasicMetaSysProps,
+  DefaultElements,
+  Link,
+  MakeRequest,
+  SysLink,
+} from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
 type AppEventSubscriptionSys = Except<BasicMetaSysProps, 'version' | 'id'> & {
@@ -15,9 +21,15 @@ export type AppEventSubscriptionProps = {
    */
   sys: AppEventSubscriptionSys
   /** Subscription url that will receive events */
-  targetUrl: string
+  targetUrl?: string
   /** List of topics to subscribe to */
   topics: string[]
+  /** Optional filter, transformation, or handler function */
+  functions?: {
+    filter?: Link<'Function'>
+    transformation?: Link<'Function'>
+    handler?: Link<'Function'>
+  }
 }
 
 export type CreateAppEventSubscriptionProps = Except<AppEventSubscriptionProps, 'sys'>

--- a/lib/plain/entities/app-event-subscription.ts
+++ b/lib/plain/entities/app-event-subscription.ts
@@ -14,11 +14,36 @@ export type AppEventSubscriptionPlainClientAPI = {
    * @throws if the request fails, the App or Event Subscription is not found, or the payload is malformed
    * @example
    * ```javascript
+   * // app event subscription that targets an endpoint url
    * const eventSubscription = await client.appEventSubscription.upsert({
    *   organizationId: '<organization_id>',
    *   appDefinitionId: '<app_definition_id>',
    * }, {
    *   targetUrl: `<target_url>`,
+   *   topics: ['<Topic>'],
+   * })
+   *
+   * // app event subscription that targets a function and have a filter function
+   * const eventSubscription = await client.appEventSubscription.upsert({
+   *   organizationId: '<organization_id>',
+   *   appDefinitionId: '<app_definition_id>',
+   * }, {
+   *   functions: {
+   *     handler: {
+   *       sys: {
+   *         type: 'Link',
+   *         linkType: 'Function',
+   *         id: '<function_id>',
+   *       },
+   *     },
+   *     filter: {
+   *       sys: {
+   *         type: 'Link',
+   *         linkType: 'Function',
+   *         id: '<function_id>',
+   *       },
+   *     },
+   *   },
    *   topics: ['<Topic>'],
    * })
    * ```


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

App Event Subscription types did not include the `functions` property that is needed to add a filter, transformation, or handler function to a subscription.

## Description

This PR adds a `functions` property to the `AppEventSubscriptionProps` type. This property accepts 3 different types of function links: filter, transformation, and handler. I also made the `targetUrl` property optional, because you can have an app event subscription that targets a handler function instead of a url. Finally, I updated the comments for the upsert function to show examples of targeting a url vs. targeting a function. I tested these changes in a script where I am upserting app event subscriptions that contain functions.

## Motivation and Context

This change will make it easier for developers looking to use App Event Functions.

## Checklist (check all before merging)

- [X] Both unit and integration tests are passing
- [X] There are no breaking changes
- [X] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
