### PR TITLE
fix: replace `SysLink` & `MetaLinkProps` with `Link<T>` to improve type safety [CFISO-2344]

### DIFF
--- a/lib/adapters/REST/endpoints/asset.ts
+++ b/lib/adapters/REST/endpoints/asset.ts
@@ -190,7 +190,7 @@ export const createWithId: RestEndpoint<'Asset', 'createWithId'> = (
 export const createFromFiles: RestEndpoint<'Asset', 'createFromFiles'> = async (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { uploadTimeout?: number },
-  data: Omit<AssetFileProp, 'sys'>
+  data: AssetFileProp
 ) => {
   const httpUpload = getUploadHttpClient(http, { uploadTimeout: params.uploadTimeout })
 

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -243,17 +243,18 @@ export interface SpaceQueryOptions extends PaginationQueryOptions {
   spaceId?: string
 }
 
-export interface BasicMetaSysProps {
+export interface BasicMetaSysProps<TSubject extends string = string> {
   type: string
   id: string
   version: number
-  createdBy?: Link<'User'> | Link<'AppDefinition'>
+  createdBy?: { [Subject in TSubject]: Link<Subject> }
   createdAt: string
-  updatedBy?: Link<'User'> | Link<'AppDefinition'>
+  updatedBy?: { [Subject in TSubject]: Link<Subject> }
   updatedAt: string
 }
 
-export interface MetaSysProps extends BasicMetaSysProps {
+export interface MetaSysProps<TSubject extends string = string>
+  extends BasicMetaSysProps<TSubject> {
   space?: Link<'Space'>
   /**
    * @deprecated `status` only exists on entities. Please refactor to use a
@@ -262,14 +263,14 @@ export interface MetaSysProps extends BasicMetaSysProps {
   status?: Link<'Status'>
   publishedVersion?: number
   archivedVersion?: number
-  archivedBy?: Link<'User'> | Link<'AppDefinition'>
+  archivedBy?: { [Subject in TSubject]: Link<Subject> }
   archivedAt?: string
   deletedVersion?: number
-  deletedBy?: Link<'User'> | Link<'AppDefinition'>
+  deletedBy?: { [Subject in TSubject]: Link<Subject> }
   deletedAt?: string
 }
 
-export interface EntityMetaSysProps extends MetaSysProps {
+export interface EntityMetaSysProps extends MetaSysProps<'User' | 'AppDefinition'> {
   /**
    * @deprecated `contentType` only exists on entries. Please refactor to use a
    * type guard to get the correct `EntryMetaSysProps` type with this property.
@@ -283,11 +284,6 @@ export interface EntityMetaSysProps extends MetaSysProps {
   publishedCounter?: number
   locale?: string
   fieldStatus?: { '*': Record<string, 'draft' | 'changed' | 'published'> }
-}
-
-export interface EntryMetaSysProps extends EntityMetaSysProps {
-  contentType: Link<'ContentType'>
-  automationTags: Link<'Tag'>[]
 }
 
 /**
@@ -1178,7 +1174,7 @@ export type MRActions = {
     }
     createFromFiles: {
       params: GetSpaceEnvironmentParams & { uploadTimeout?: number }
-      payload: Omit<AssetFileProp, 'sys'>
+      payload: AssetFileProp
       return: AssetProps
     }
     processForAllLocales: {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -247,25 +247,25 @@ export interface BasicMetaSysProps {
   type: string
   id: string
   version: number
-  createdBy?: SysLink
+  createdBy?: Link<'User'> | Link<'AppDefinition'>
   createdAt: string
-  updatedBy?: SysLink
+  updatedBy?: Link<'User'> | Link<'AppDefinition'>
   updatedAt: string
 }
 
 export interface MetaSysProps extends BasicMetaSysProps {
-  space?: SysLink
+  space?: Link<'Space'>
   /**
    * @deprecated `status` only exists on entities. Please refactor to use a
    * type guard to get the correct `EntityMetaSysProps` type with this property.
    */
-  status?: SysLink
+  status?: Link<'Status'>
   publishedVersion?: number
   archivedVersion?: number
-  archivedBy?: SysLink
+  archivedBy?: Link<'User'> | Link<'AppDefinition'>
   archivedAt?: string
   deletedVersion?: number
-  deletedBy?: SysLink
+  deletedBy?: Link<'User'> | Link<'AppDefinition'>
   deletedAt?: string
 }
 
@@ -274,10 +274,9 @@ export interface EntityMetaSysProps extends MetaSysProps {
    * @deprecated `contentType` only exists on entries. Please refactor to use a
    * type guard to get the correct `EntryMetaSysProps` type with this property.
    */
-  contentType: SysLink
-  space: SysLink
-  status?: SysLink
-  environment: SysLink
+  contentType: Link<'ContentType'>
+  space: Link<'Space'>
+  environment: Link<'Environment'>
   publishedBy?: Link<'User'> | Link<'AppDefinition'>
   publishedAt?: string
   firstPublishedAt?: string
@@ -287,24 +286,24 @@ export interface EntityMetaSysProps extends MetaSysProps {
 }
 
 export interface EntryMetaSysProps extends EntityMetaSysProps {
-  contentType: SysLink
+  contentType: Link<'ContentType'>
   automationTags: Link<'Tag'>[]
 }
 
-export interface MetaLinkProps {
-  type: string
-  linkType: string
-  id: string
-}
+/**
+ * @deprecated Use more specific `Link<T>` instead
+ */
+export interface MetaLinkProps extends Link<string> {}
 
 export interface MetadataProps {
   tags: Link<'Tag'>[]
   concepts?: Link<'TaxonomyConcept'>[]
 }
 
-export interface SysLink {
-  sys: MetaLinkProps
-}
+/**
+ * @deprecated Use more specific `Link<T>` instead
+ */
+export interface SysLink extends Link<string> {}
 
 export interface CollectionProp<TObj> {
   sys: {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -291,20 +291,10 @@ export interface EntityMetaSysProps extends MetaSysProps<'User' | 'AppDefinition
   fieldStatus?: { '*': Record<string, 'draft' | 'changed' | 'published'> }
 }
 
-/**
- * @deprecated Use more specific `Link<T>` instead
- */
-export interface MetaLinkProps extends Link<string> {}
-
 export interface MetadataProps {
   tags: Link<'Tag'>[]
   concepts?: Link<'TaxonomyConcept'>[]
 }
-
-/**
- * @deprecated Use more specific `Link<T>` instead
- */
-export interface SysLink extends Link<string> {}
 
 export interface CollectionProp<TObj> {
   sys: {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -252,9 +252,9 @@ export interface BasicMetaSysProps<TSubject extends string = string> {
   type: string
   id: string
   version: number
-  createdBy?: { [Subject in TSubject]: Link<Subject> }
+  createdBy?: { [Subject in TSubject]: Link<Subject> }[TSubject]
   createdAt: string
-  updatedBy?: { [Subject in TSubject]: Link<Subject> }
+  updatedBy?: { [Subject in TSubject]: Link<Subject> }[TSubject]
   updatedAt: string
 }
 
@@ -268,10 +268,10 @@ export interface MetaSysProps<TSubject extends string = string>
   status?: Link<'Status'>
   publishedVersion?: number
   archivedVersion?: number
-  archivedBy?: { [Subject in TSubject]: Link<Subject> }
+  archivedBy?: { [Subject in TSubject]: Link<Subject> }[TSubject]
   archivedAt?: string
   deletedVersion?: number
-  deletedBy?: { [Subject in TSubject]: Link<Subject> }
+  deletedBy?: { [Subject in TSubject]: Link<Subject> }[TSubject]
   deletedAt?: string
 }
 

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -1098,7 +1098,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    createAssetFromFiles(data: Omit<AssetFileProp, 'sys'>, options?: CreateAssetFromFilesOptions) {
+    createAssetFromFiles(data: AssetFileProp, options?: CreateAssetFromFilesOptions) {
       const raw = this.toPlainObject() as EnvironmentProps
       return makeRequest({
         entityType: 'Asset',

--- a/lib/entities/access-token.ts
+++ b/lib/entities/access-token.ts
@@ -10,7 +10,7 @@ type Application = {
   sys: Link<'Application'>
 }
 
-type AccessTokenSysProps = BasicMetaSysProps & {
+type AccessTokenSysProps = BasicMetaSysProps<'User'> & {
   application: Application | null
   expiresAt: string | null
   lastUsedAt: string | null

--- a/lib/entities/access-token.ts
+++ b/lib/entities/access-token.ts
@@ -2,12 +2,12 @@ import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
-import type { DefaultElements, MakeRequest, BasicMetaSysProps, SysLink } from '../common-types'
+import type { DefaultElements, MakeRequest, BasicMetaSysProps, Link } from '../common-types'
 
 type Application = {
   id?: string
   name?: string
-  sys: SysLink
+  sys: Link<'Application'>
 }
 
 type AccessTokenSysProps = BasicMetaSysProps & {

--- a/lib/entities/ai-action-invocation.ts
+++ b/lib/entities/ai-action-invocation.ts
@@ -1,6 +1,6 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type { DefaultElements, Link, MakeRequest, SysLink } from '../common-types'
+import type { DefaultElements, Link, MakeRequest } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import type { Document as RichTextDocument } from '@contentful/rich-text-types'
 

--- a/lib/entities/ai-action-invocation.ts
+++ b/lib/entities/ai-action-invocation.ts
@@ -1,6 +1,6 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type { DefaultElements, MakeRequest, SysLink } from '../common-types'
+import type { DefaultElements, Link, MakeRequest, SysLink } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import type { Document as RichTextDocument } from '@contentful/rich-text-types'
 
@@ -48,9 +48,9 @@ export type AiActionInvocationProps = {
   sys: {
     id: string
     type: 'AiActionInvocation'
-    space: SysLink
-    environment: SysLink
-    aiAction: SysLink
+    space: Link<'Space'>
+    environment: Link<'Environment'>
+    aiAction: Link<'AiAction'>
     status: InvocationStatus
     errorCode?: string
   }

--- a/lib/entities/ai-action.ts
+++ b/lib/entities/ai-action.ts
@@ -1,6 +1,6 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type { DefaultElements, MakeRequest, MetaSysProps } from '../common-types'
+import type { DefaultElements, Link, MakeRequest, MetaSysProps } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 import {
@@ -71,14 +71,6 @@ export type AiActionTestCase =
       }
     }
 
-export type SysLinkUserOrApp = {
-  sys: {
-    id: string
-    linkType: 'User' | 'App'
-    type: 'Link'
-  }
-}
-
 export interface AiActionQueryOptions {
   limit?: number
   skip?: number
@@ -86,18 +78,12 @@ export interface AiActionQueryOptions {
 }
 
 export type AiActionProps = {
-  sys: MetaSysProps & {
+  sys: MetaSysProps<'User' | 'AppDefinition'> & {
     type: 'AiAction'
-    space: { sys: { id: string } }
-    publishedBy?: SysLinkUserOrApp
-    updatedBy: SysLinkUserOrApp
-    createdBy: SysLinkUserOrApp
-    publishedVersion?: number
+    space: Link<'Space'>
+    publishedBy?: Link<'User'> | Link<'AppDefinition'>
     version: number
     publishedAt?: string
-    updatedAt: string
-    createdAt: string
-    id: string
   }
   name: string
   description: string

--- a/lib/entities/api-key.ts
+++ b/lib/entities/api-key.ts
@@ -5,7 +5,7 @@ import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 
 export type ApiKeyProps = {
-  sys: MetaSysProps
+  sys: MetaSysProps<'User'>
   name: string
   accessToken: string
   environments: Link<'Environment'>[]

--- a/lib/entities/api-key.ts
+++ b/lib/entities/api-key.ts
@@ -1,6 +1,6 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type { DefaultElements, MakeRequest, MetaLinkProps, MetaSysProps } from '../common-types'
+import type { DefaultElements, Link, MakeRequest, MetaSysProps } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 
@@ -8,10 +8,8 @@ export type ApiKeyProps = {
   sys: MetaSysProps
   name: string
   accessToken: string
-  environments: {
-    sys: MetaLinkProps
-  }[]
-  preview_api_key: { sys: MetaLinkProps }
+  environments: Link<'Environment'>[]
+  preview_api_key: Link<'PreviewApiKey'>
   description?: string
   policies?: { effect: string; action: string }[]
 }

--- a/lib/entities/app-access-token.ts
+++ b/lib/entities/app-access-token.ts
@@ -3,7 +3,7 @@ import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import type { Except } from 'type-fest'
 import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 
-type AppAccessTokenSys = Except<BasicMetaSysProps, 'version' | 'id'> & {
+type AppAccessTokenSys = Except<BasicMetaSysProps<'User'>, 'version' | 'id'> & {
   space: Link<'Space'>
   environment: Link<'Environment'>
   appDefinition: Link<'AppDefinition'>

--- a/lib/entities/app-access-token.ts
+++ b/lib/entities/app-access-token.ts
@@ -1,12 +1,12 @@
 import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import type { Except } from 'type-fest'
-import type { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '../common-types'
+import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 
 type AppAccessTokenSys = Except<BasicMetaSysProps, 'version' | 'id'> & {
-  space: SysLink
-  environment: SysLink
-  appDefinition: SysLink
+  space: Link<'Space'>
+  environment: Link<'Environment'>
+  appDefinition: Link<'AppDefinition'>
   expiresAt: string
 }
 

--- a/lib/entities/app-action-call.ts
+++ b/lib/entities/app-action-call.ts
@@ -5,17 +5,17 @@ import type {
   BasicMetaSysProps,
   CreateWithResponseParams,
   DefaultElements,
+  Link,
   MakeRequest,
-  SysLink,
 } from '../common-types'
 import type { WebhookCallDetailsProps } from './webhook'
 import enhanceWithMethods from '../enhance-with-methods'
 
 type AppActionCallSys = Except<BasicMetaSysProps, 'version'> & {
-  appDefinition: SysLink
-  space: SysLink
-  environment: SysLink
-  action: SysLink
+  appDefinition: Link<'AppDefinition'>
+  space: Link<'Space'>
+  environment: Link<'Environment'>
+  action: Link<'AppAction'>
 }
 
 type RetryOptions = Pick<CreateWithResponseParams, 'retries' | 'retryInterval'>

--- a/lib/entities/app-action-call.ts
+++ b/lib/entities/app-action-call.ts
@@ -11,7 +11,7 @@ import type {
 import type { WebhookCallDetailsProps } from './webhook'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppActionCallSys = Except<BasicMetaSysProps, 'version'> & {
+type AppActionCallSys = Except<BasicMetaSysProps<'User'>, 'version'> & {
   appDefinition: Link<'AppDefinition'>
   space: Link<'Space'>
   environment: Link<'Environment'>

--- a/lib/entities/app-action.ts
+++ b/lib/entities/app-action.ts
@@ -2,12 +2,7 @@ import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { Except } from 'type-fest'
 import { wrapCollection } from '../common-utils'
-import type {
-  BasicMetaSysProps,
-  DefaultElements,
-  Link,
-  MakeRequest,
-} from '../common-types'
+import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import type { ParameterDefinition } from './widget-parameters'
 import enhanceWithMethods from '../enhance-with-methods'
 

--- a/lib/entities/app-action.ts
+++ b/lib/entities/app-action.ts
@@ -7,14 +7,13 @@ import type {
   DefaultElements,
   Link,
   MakeRequest,
-  SysLink,
 } from '../common-types'
 import type { ParameterDefinition } from './widget-parameters'
 import enhanceWithMethods from '../enhance-with-methods'
 
 type AppActionSys = Except<BasicMetaSysProps, 'version'> & {
-  appDefinition: SysLink
-  organization: SysLink
+  appDefinition: Link<'AppDefinition'>
+  organization: Link<'Organization'>
 }
 
 export type AppActionParameterDefinition = Omit<ParameterDefinition, 'labels'>

--- a/lib/entities/app-action.ts
+++ b/lib/entities/app-action.ts
@@ -6,7 +6,7 @@ import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../c
 import type { ParameterDefinition } from './widget-parameters'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppActionSys = Except<BasicMetaSysProps, 'version'> & {
+type AppActionSys = Except<BasicMetaSysProps<'User'>, 'version'> & {
   appDefinition: Link<'AppDefinition'>
   organization: Link<'Organization'>
 }

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -2,12 +2,12 @@ import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { Except } from 'type-fest'
 import { wrapCollection } from '../common-utils'
-import type { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '../common-types'
+import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
 type AppBundleSys = Except<BasicMetaSysProps, 'version'> & {
-  appDefinition: SysLink
-  organization: SysLink
+  appDefinition: Link<'AppDefinition'>
+  organization: Link<'Organization'>
 }
 
 interface ActionManifestProps {

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -5,7 +5,7 @@ import { wrapCollection } from '../common-utils'
 import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppBundleSys = Except<BasicMetaSysProps, 'version'> & {
+type AppBundleSys = Except<BasicMetaSysProps<'User'>, 'version'> & {
   appDefinition: Link<'AppDefinition'>
   organization: Link<'Organization'>
 }

--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -1,11 +1,6 @@
 import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
-import type {
-  DefaultElements,
-  BasicMetaSysProps,
-  MakeRequest,
-  Link,
-} from '../common-types'
+import type { DefaultElements, BasicMetaSysProps, MakeRequest, Link } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
 import type { ContentfulAppDefinitionAPI } from '../create-app-definition-api'

--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -38,7 +38,7 @@ export type AppDefinitionProps = {
   /**
    * System metadata
    */
-  sys: BasicMetaSysProps & {
+  sys: BasicMetaSysProps<'User'> & {
     organization: Link<'Organization'>
     shared: boolean
   }

--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -3,7 +3,6 @@ import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import type {
   DefaultElements,
   BasicMetaSysProps,
-  SysLink,
   MakeRequest,
   Link,
 } from '../common-types'
@@ -45,7 +44,7 @@ export type AppDefinitionProps = {
    * System metadata
    */
   sys: BasicMetaSysProps & {
-    organization: SysLink
+    organization: Link<'Organization'>
     shared: boolean
   }
   /**

--- a/lib/entities/app-details.ts
+++ b/lib/entities/app-details.ts
@@ -1,12 +1,12 @@
 import copy from 'fast-copy'
 import { toPlainObject } from 'contentful-sdk-core'
 import type { Except } from 'type-fest'
-import type { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '../common-types'
+import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
 type AppDetailsSys = Except<BasicMetaSysProps, 'version' | 'id'> & {
-  appDefinition: SysLink
-  organization: SysLink
+  appDefinition: Link<'AppDefinition'>
+  organization: Link<'Organization'>
 }
 
 export type IconType = 'base64'

--- a/lib/entities/app-details.ts
+++ b/lib/entities/app-details.ts
@@ -4,7 +4,7 @@ import type { Except } from 'type-fest'
 import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppDetailsSys = Except<BasicMetaSysProps, 'version' | 'id'> & {
+type AppDetailsSys = Except<BasicMetaSysProps<'User'>, 'version' | 'id'> & {
   appDefinition: Link<'AppDefinition'>
   organization: Link<'Organization'>
 }

--- a/lib/entities/app-event-subscription.ts
+++ b/lib/entities/app-event-subscription.ts
@@ -1,12 +1,7 @@
 import copy from 'fast-copy'
 import { toPlainObject } from 'contentful-sdk-core'
 import type { Except } from 'type-fest'
-import type {
-  BasicMetaSysProps,
-  DefaultElements,
-  Link,
-  MakeRequest,
-} from '../common-types'
+import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
 type AppEventSubscriptionSys = Except<BasicMetaSysProps, 'version' | 'id'> & {

--- a/lib/entities/app-event-subscription.ts
+++ b/lib/entities/app-event-subscription.ts
@@ -4,7 +4,7 @@ import type { Except } from 'type-fest'
 import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppEventSubscriptionSys = Except<BasicMetaSysProps, 'version' | 'id'> & {
+type AppEventSubscriptionSys = Except<BasicMetaSysProps<'User'>, 'version' | 'id'> & {
   appDefinition: Link<'AppDefinition'>
   organization: Link<'Organization'>
 }

--- a/lib/entities/app-event-subscription.ts
+++ b/lib/entities/app-event-subscription.ts
@@ -6,13 +6,12 @@ import type {
   DefaultElements,
   Link,
   MakeRequest,
-  SysLink,
 } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
 type AppEventSubscriptionSys = Except<BasicMetaSysProps, 'version' | 'id'> & {
-  appDefinition: SysLink
-  organization: SysLink
+  appDefinition: Link<'AppDefinition'>
+  organization: Link<'Organization'>
 }
 
 export type AppEventSubscriptionProps = {

--- a/lib/entities/app-installation.ts
+++ b/lib/entities/app-installation.ts
@@ -2,16 +2,16 @@ import { toPlainObject, freezeSys } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
-import type { DefaultElements, BasicMetaSysProps, SysLink, MakeRequest } from '../common-types'
+import type { DefaultElements, BasicMetaSysProps, MakeRequest, Link } from '../common-types'
 import type { Except } from 'type-fest'
 import type { FreeFormParameters } from './widget-parameters'
 
 export type AppInstallationProps = {
   sys: Omit<BasicMetaSysProps, 'id'> & {
-    appDefinition: SysLink
-    environment: SysLink
-    space: SysLink
-    organization: SysLink
+    appDefinition: Link<'AppDefinition'>
+    environment: Link<'Environment'>
+    space: Link<'Space'>
+    organization: Link<'Organization'>
   }
   /**
    * Free-form installation parameters (API limits stringified length to 32KB)

--- a/lib/entities/app-installation.ts
+++ b/lib/entities/app-installation.ts
@@ -7,7 +7,7 @@ import type { Except } from 'type-fest'
 import type { FreeFormParameters } from './widget-parameters'
 
 export type AppInstallationProps = {
-  sys: Omit<BasicMetaSysProps, 'id'> & {
+  sys: Omit<BasicMetaSysProps<'User'>, 'id'> & {
     appDefinition: Link<'AppDefinition'>
     environment: Link<'Environment'>
     space: Link<'Space'>

--- a/lib/entities/app-key.ts
+++ b/lib/entities/app-key.ts
@@ -5,7 +5,7 @@ import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../c
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
 
-type AppKeySys = Except<BasicMetaSysProps, 'version'> & {
+type AppKeySys = Except<BasicMetaSysProps<'User'>, 'version'> & {
   appDefinition: Link<'AppDefinition'>
   organization: Link<'Organization'>
 }

--- a/lib/entities/app-key.ts
+++ b/lib/entities/app-key.ts
@@ -1,13 +1,13 @@
 import copy from 'fast-copy'
 import { toPlainObject } from 'contentful-sdk-core'
 import type { Except } from 'type-fest'
-import type { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '../common-types'
+import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
 
 type AppKeySys = Except<BasicMetaSysProps, 'version'> & {
-  appDefinition: SysLink
-  organization: SysLink
+  appDefinition: Link<'AppDefinition'>
+  organization: Link<'Organization'>
 }
 
 export interface JWK {

--- a/lib/entities/app-signed-request.ts
+++ b/lib/entities/app-signed-request.ts
@@ -1,12 +1,12 @@
 import copy from 'fast-copy'
 import { toPlainObject } from 'contentful-sdk-core'
 import type { Except } from 'type-fest'
-import type { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '../common-types'
+import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 
 type AppSignedRequestSys = Except<BasicMetaSysProps, 'version' | 'id'> & {
-  appDefinition: SysLink
-  space: SysLink
-  environment: SysLink
+  appDefinition: Link<'AppDefinition'>
+  space: Link<'Space'>
+  environment: Link<'Environment'>
 }
 
 export type AppSignedRequestProps = {

--- a/lib/entities/app-signed-request.ts
+++ b/lib/entities/app-signed-request.ts
@@ -3,7 +3,7 @@ import { toPlainObject } from 'contentful-sdk-core'
 import type { Except } from 'type-fest'
 import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 
-type AppSignedRequestSys = Except<BasicMetaSysProps, 'version' | 'id'> & {
+type AppSignedRequestSys = Except<BasicMetaSysProps<'User'>, 'version' | 'id'> & {
   appDefinition: Link<'AppDefinition'>
   space: Link<'Space'>
   environment: Link<'Environment'>

--- a/lib/entities/app-signing-secret.ts
+++ b/lib/entities/app-signing-secret.ts
@@ -1,12 +1,12 @@
 import copy from 'fast-copy'
 import { toPlainObject } from 'contentful-sdk-core'
 import type { Except } from 'type-fest'
-import type { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '../common-types'
+import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
 type AppSigningSecretSys = Except<BasicMetaSysProps, 'version' | 'id'> & {
-  appDefinition: SysLink
-  organization: SysLink
+  appDefinition: Link<'AppDefinition'>
+  organization: Link<'Organization'>
 }
 
 export type AppSigningSecretProps = {

--- a/lib/entities/app-signing-secret.ts
+++ b/lib/entities/app-signing-secret.ts
@@ -4,7 +4,7 @@ import type { Except } from 'type-fest'
 import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppSigningSecretSys = Except<BasicMetaSysProps, 'version' | 'id'> & {
+type AppSigningSecretSys = Except<BasicMetaSysProps<'User'>, 'version' | 'id'> & {
   appDefinition: Link<'AppDefinition'>
   organization: Link<'Organization'>
 }

--- a/lib/entities/app-upload.ts
+++ b/lib/entities/app-upload.ts
@@ -5,7 +5,7 @@ import type { BasicMetaSysProps, DefaultElements, MakeRequest, Link } from '../c
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppUploadSys = Except<BasicMetaSysProps, 'version'>
+type AppUploadSys = Except<BasicMetaSysProps<'User'>, 'version'>
 
 export type AppUploadProps = {
   sys: AppUploadSys & {

--- a/lib/entities/app-upload.ts
+++ b/lib/entities/app-upload.ts
@@ -1,7 +1,7 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { Except } from 'type-fest'
-import type { BasicMetaSysProps, SysLink, DefaultElements, MakeRequest } from '../common-types'
+import type { BasicMetaSysProps, DefaultElements, MakeRequest, Link } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 
@@ -10,7 +10,7 @@ type AppUploadSys = Except<BasicMetaSysProps, 'version'>
 export type AppUploadProps = {
   sys: AppUploadSys & {
     expiresAt: string
-    organization: SysLink
+    organization: Link<'Organization'>
   }
 }
 

--- a/lib/entities/asset.ts
+++ b/lib/entities/asset.ts
@@ -42,7 +42,6 @@ export type CreateAssetProps = Omit<AssetProps, 'sys'>
 export type CreateAssetFromFilesOptions = { uploadTimeout?: number }
 
 export interface AssetFileProp {
-  sys: MetaSysProps
   fields: {
     title: { [key: string]: string }
     description: { [key: string]: string }

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -23,7 +23,7 @@ interface LinkWithReference<T extends string> extends Link<T> {
 }
 
 export type CommentSysProps = Pick<
-  BasicMetaSysProps,
+  BasicMetaSysProps<'User'>,
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
 > & {
   type: 'Comment'

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -9,7 +9,6 @@ import type {
   GetSpaceEnvironmentParams,
   Link,
   MakeRequest,
-  SysLink,
   VersionedLink,
 } from '../common-types'
 import { wrapCollection } from '../common-utils'
@@ -28,8 +27,8 @@ export type CommentSysProps = Pick<
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
 > & {
   type: 'Comment'
-  space: SysLink
-  environment: SysLink
+  space: Link<'Space'>
+  environment: Link<'Environment'>
   parentEntity:
     | Link<'ContentType'>
     | LinkWithReference<'ContentType'>

--- a/lib/entities/content-type.ts
+++ b/lib/entities/content-type.ts
@@ -8,7 +8,6 @@ import type {
   Link,
   MakeRequest,
   QueryOptions,
-  SysLink,
 } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -40,8 +39,8 @@ export type AnnotationAssignment = Link<'Annotation'> & {
 
 export type ContentTypeProps = {
   sys: BasicMetaSysProps & {
-    space: SysLink
-    environment: SysLink
+    space: Link<'Space'>
+    environment: Link<'Environment'>
     firstPublishedAt?: string
     publishedCounter?: number
     publishedVersion?: number

--- a/lib/entities/content-type.ts
+++ b/lib/entities/content-type.ts
@@ -38,7 +38,7 @@ export type AnnotationAssignment = Link<'Annotation'> & {
 }
 
 export type ContentTypeProps = {
-  sys: BasicMetaSysProps & {
+  sys: BasicMetaSysProps<'User' | 'AppDefinition'> & {
     space: Link<'Space'>
     environment: Link<'Environment'>
     firstPublishedAt?: string

--- a/lib/entities/editor-interface.ts
+++ b/lib/entities/editor-interface.ts
@@ -1,7 +1,7 @@
 import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
-import type { MetaSysProps, MetaLinkProps, DefaultElements, MakeRequest } from '../common-types'
+import type { MetaSysProps, DefaultElements, MakeRequest, Link } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import type { DefinedParameters } from './widget-parameters'
 
@@ -86,9 +86,9 @@ export interface SidebarItem {
 
 export type EditorInterfaceProps = {
   sys: MetaSysProps & {
-    space: { sys: MetaLinkProps }
-    environment: { sys: MetaLinkProps }
-    contentType: { sys: MetaLinkProps }
+    space: Link<'Space'>
+    environment: Link<'Environment'>
+    contentType: Link<'ContentType'>
   }
   /**
    * Array of fields and their associated widgetId

--- a/lib/entities/editor-interface.ts
+++ b/lib/entities/editor-interface.ts
@@ -85,7 +85,7 @@ export interface SidebarItem {
 }
 
 export type EditorInterfaceProps = {
-  sys: MetaSysProps & {
+  sys: MetaSysProps<'User' | 'AppDefinition'> & {
     space: Link<'Space'>
     environment: Link<'Environment'>
     contentType: Link<'ContentType'>

--- a/lib/entities/entry.ts
+++ b/lib/entities/entry.ts
@@ -3,8 +3,9 @@ import copy from 'fast-copy'
 import type {
   CollectionProp,
   DefaultElements,
-  EntryMetaSysProps,
+  EntityMetaSysProps,
   KeyValueMap,
+  Link,
   MakeRequest,
   MetadataProps,
 } from '../common-types'
@@ -13,6 +14,11 @@ import type { ContentfulEntryApi } from '../create-entry-api'
 import createEntryApi from '../create-entry-api'
 import enhanceWithMethods from '../enhance-with-methods'
 import type { AssetProps } from './asset'
+
+export interface EntryMetaSysProps extends EntityMetaSysProps {
+  contentType: Link<'ContentType'>
+  automationTags: Link<'Tag'>[]
+}
 
 export type EntryProps<T = KeyValueMap> = {
   sys: EntryMetaSysProps

--- a/lib/entities/environment-alias.ts
+++ b/lib/entities/environment-alias.ts
@@ -8,7 +8,7 @@ export type EnvironmentAliasProps = {
   /**
    * System meta data
    */
-  sys: BasicMetaSysProps & { space: Link<'Space'> }
+  sys: BasicMetaSysProps<'User'> & { space: Link<'Space'> }
   environment: Link<'Environment'>
 }
 

--- a/lib/entities/environment-alias.ts
+++ b/lib/entities/environment-alias.ts
@@ -4,18 +4,17 @@ import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
 import type {
   DefaultElements,
-  MetaLinkProps,
   BasicMetaSysProps,
-  SysLink,
   MakeRequest,
+  Link,
 } from '../common-types'
 
 export type EnvironmentAliasProps = {
   /**
    * System meta data
    */
-  sys: BasicMetaSysProps & { space: SysLink }
-  environment: { sys: MetaLinkProps }
+  sys: BasicMetaSysProps & { space: Link<'Space'> }
+  environment: Link<'Environment'>
 }
 
 export type CreateEnvironmentAliasProps = Omit<EnvironmentAliasProps, 'sys'>

--- a/lib/entities/environment-alias.ts
+++ b/lib/entities/environment-alias.ts
@@ -2,12 +2,7 @@ import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
-import type {
-  DefaultElements,
-  BasicMetaSysProps,
-  MakeRequest,
-  Link,
-} from '../common-types'
+import type { DefaultElements, BasicMetaSysProps, MakeRequest, Link } from '../common-types'
 
 export type EnvironmentAliasProps = {
   /**

--- a/lib/entities/environment-template-installation.ts
+++ b/lib/entities/environment-template-installation.ts
@@ -27,7 +27,7 @@ export type EnvironmentTemplateInstallationStatus =
   keyof typeof EnvironmentTemplateInstallationStatuses
 
 export type EnvironmentTemplateInstallationProps = {
-  sys: BasicMetaSysProps & {
+  sys: BasicMetaSysProps<'User'> & {
     type: 'EnvironmentTemplateInstallation'
     space: Link<'Space'>
     template: VersionedLink<'Template'>

--- a/lib/entities/environment-template.ts
+++ b/lib/entities/environment-template.ts
@@ -29,7 +29,7 @@ export interface ContentTypeTemplateProps extends Omit<ContentTypeProps, 'sys'> 
 }
 
 export type EnvironmentTemplateProps = {
-  sys: BasicMetaSysProps & { version: number; organization: Link<'Organization'> }
+  sys: BasicMetaSysProps<'User'> & { version: number; organization: Link<'Organization'> }
   name: string
   description?: string
   versionName: string

--- a/lib/entities/environment.ts
+++ b/lib/entities/environment.ts
@@ -4,13 +4,13 @@ import enhanceWithMethods from '../enhance-with-methods'
 import type { ContentfulEnvironmentAPI } from '../create-environment-api'
 import createEnvironmentApi from '../create-environment-api'
 import { wrapCollection } from '../common-utils'
-import type { DefaultElements, SysLink, BasicMetaSysProps, MakeRequest } from '../common-types'
+import type { DefaultElements, BasicMetaSysProps, MakeRequest, Link } from '../common-types'
 
 type EnvironmentMetaSys = BasicMetaSysProps & {
-  status: SysLink
-  space: SysLink
-  aliases?: Array<SysLink>
-  aliasedEnvironment?: SysLink
+  status: Link<'Status'>
+  space: Link<'Space'>
+  aliases?: Array<Link<'EnvironmentAlias'>>
+  aliasedEnvironment?: Link<'Environment'>
 }
 
 export type EnvironmentProps = {

--- a/lib/entities/environment.ts
+++ b/lib/entities/environment.ts
@@ -6,7 +6,7 @@ import createEnvironmentApi from '../create-environment-api'
 import { wrapCollection } from '../common-utils'
 import type { DefaultElements, BasicMetaSysProps, MakeRequest, Link } from '../common-types'
 
-type EnvironmentMetaSys = BasicMetaSysProps & {
+type EnvironmentMetaSys = BasicMetaSysProps<'User'> & {
   status: Link<'Status'>
   space: Link<'Space'>
   aliases?: Array<Link<'EnvironmentAlias'>>

--- a/lib/entities/extension.ts
+++ b/lib/entities/extension.ts
@@ -11,7 +11,7 @@ import { wrapCollection } from '../common-utils'
 import type { DefaultElements, BasicMetaSysProps, MakeRequest, Link } from '../common-types'
 import type { SetRequired, RequireExactlyOne } from 'type-fest'
 
-type ExtensionSysProps = BasicMetaSysProps & {
+type ExtensionSysProps = BasicMetaSysProps<'User'> & {
   space: Link<'Space'>
   environment: Link<'Environment'>
   srcdocSha256?: string

--- a/lib/entities/extension.ts
+++ b/lib/entities/extension.ts
@@ -8,12 +8,12 @@ import type {
   ParameterDefinition,
 } from './widget-parameters'
 import { wrapCollection } from '../common-utils'
-import type { DefaultElements, BasicMetaSysProps, SysLink, MakeRequest } from '../common-types'
+import type { DefaultElements, BasicMetaSysProps, MakeRequest, Link } from '../common-types'
 import type { SetRequired, RequireExactlyOne } from 'type-fest'
 
 type ExtensionSysProps = BasicMetaSysProps & {
-  space: SysLink
-  environment: SysLink
+  space: Link<'Space'>
+  environment: Link<'Environment'>
   srcdocSha256?: string
 }
 

--- a/lib/entities/locale.ts
+++ b/lib/entities/locale.ts
@@ -6,7 +6,10 @@ import { wrapCollection } from '../common-utils'
 import type { BasicMetaSysProps, DefaultElements, MakeRequest, Link } from '../common-types'
 
 export type LocaleProps = {
-  sys: BasicMetaSysProps & { space: Link<'Space'>; environment: Link<'Environment'> }
+  sys: BasicMetaSysProps<'User' | 'AppDefinition'> & {
+    space: Link<'Space'>
+    environment: Link<'Environment'>
+  }
   /**
    * Locale name
    */

--- a/lib/entities/locale.ts
+++ b/lib/entities/locale.ts
@@ -3,10 +3,10 @@ import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import type { Except, SetOptional } from 'type-fest'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
-import type { BasicMetaSysProps, SysLink, DefaultElements, MakeRequest } from '../common-types'
+import type { BasicMetaSysProps, DefaultElements, MakeRequest, Link } from '../common-types'
 
 export type LocaleProps = {
-  sys: BasicMetaSysProps & { space: SysLink; environment: SysLink }
+  sys: BasicMetaSysProps & { space: Link<'Space'>; environment: Link<'Environment'> }
   /**
    * Locale name
    */

--- a/lib/entities/oauth-application.ts
+++ b/lib/entities/oauth-application.ts
@@ -4,7 +4,7 @@ import enhanceWithMethods from '../enhance-with-methods'
 import copy from 'fast-copy'
 import { wrapCursorPaginatedCollection } from '../common-utils'
 
-type OAuthApplicationSysProps = BasicMetaSysProps & {
+type OAuthApplicationSysProps = BasicMetaSysProps<'User'> & {
   lastUsedAt: string | null
 }
 

--- a/lib/entities/organization-invitation.ts
+++ b/lib/entities/organization-invitation.ts
@@ -1,10 +1,10 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type { DefaultElements, MakeRequest, MetaLinkProps, MetaSysProps } from '../common-types'
+import type { DefaultElements, Link, MakeRequest, MetaSysProps } from '../common-types'
 
 export type OrganizationInvitationProps = {
   sys: MetaSysProps & {
-    organizationMembership: { sys: MetaLinkProps }
+    organizationMembership: Link<'OrganizationMembership'>
     user: Record<string, any> | null
     invitationUrl: string
     status: string

--- a/lib/entities/organization-invitation.ts
+++ b/lib/entities/organization-invitation.ts
@@ -3,7 +3,7 @@ import copy from 'fast-copy'
 import type { DefaultElements, Link, MakeRequest, MetaSysProps } from '../common-types'
 
 export type OrganizationInvitationProps = {
-  sys: MetaSysProps & {
+  sys: MetaSysProps<'User'> & {
     organizationMembership: Link<'OrganizationMembership'>
     user: Record<string, any> | null
     invitationUrl: string

--- a/lib/entities/organization-membership.ts
+++ b/lib/entities/organization-membership.ts
@@ -2,13 +2,13 @@ import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
-import type { MetaSysProps, DefaultElements, MetaLinkProps, MakeRequest } from '../common-types'
+import type { MetaSysProps, DefaultElements, MakeRequest, Link } from '../common-types'
 
 export type OrganizationMembershipProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { user: { sys: MetaLinkProps } }
+  sys: MetaSysProps & { user: Link<'User'> }
 
   /**
    * Role

--- a/lib/entities/organization-membership.ts
+++ b/lib/entities/organization-membership.ts
@@ -8,7 +8,7 @@ export type OrganizationMembershipProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { user: Link<'User'> }
+  sys: MetaSysProps<'User'> & { user: Link<'User'> }
 
   /**
    * Role

--- a/lib/entities/organization.ts
+++ b/lib/entities/organization.ts
@@ -14,7 +14,7 @@ export type OrganizationProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps
+  sys: MetaSysProps<'User'>
   /**
    * Name
    */

--- a/lib/entities/personal-access-token.ts
+++ b/lib/entities/personal-access-token.ts
@@ -5,7 +5,7 @@ import { wrapCollection } from '../common-utils'
 import type { MetaSysProps, DefaultElements, MakeRequest } from '../common-types'
 
 export type PersonalAccessTokenProps = {
-  sys: MetaSysProps & { expiresAt?: string }
+  sys: MetaSysProps<'User'> & { expiresAt?: string }
   name: string
   scopes: 'content_management_manage'[]
   revokedAt: null | string

--- a/lib/entities/preview-api-key.ts
+++ b/lib/entities/preview-api-key.ts
@@ -5,7 +5,7 @@ import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 
 export type PreviewApiKeyProps = {
-  sys: MetaSysProps
+  sys: MetaSysProps<'User'>
   name: string
   description: string
   accessToken: string

--- a/lib/entities/resource-provider.ts
+++ b/lib/entities/resource-provider.ts
@@ -2,8 +2,8 @@ import type {
   BasicMetaSysProps,
   CollectionProp,
   DefaultElements,
+  Link,
   MakeRequest,
-  SysLink,
 } from '../common-types'
 import { toPlainObject, freezeSys } from 'contentful-sdk-core'
 import copy from 'fast-copy'
@@ -16,8 +16,8 @@ export type ResourceProviderProps = {
    * System metadata
    */
   sys: Omit<BasicMetaSysProps, 'version'> & {
-    organization: SysLink
-    appDefinition: SysLink
+    organization: Link<'Organization'>
+    appDefinition: Link<'AppDefinition'>
   }
   /**
    * Resource Provider type, value is 'function'
@@ -26,7 +26,7 @@ export type ResourceProviderProps = {
   /**
    * Link to a Contentful function
    */
-  function: SysLink
+  function: Link<'Function'>
 }
 
 export type UpsertResourceProviderProps = Omit<ResourceProviderProps, 'sys'> & {

--- a/lib/entities/resource-provider.ts
+++ b/lib/entities/resource-provider.ts
@@ -15,7 +15,7 @@ export type ResourceProviderProps = {
   /**
    * System metadata
    */
-  sys: Omit<BasicMetaSysProps, 'version'> & {
+  sys: Omit<BasicMetaSysProps<'User'>, 'version'> & {
     organization: Link<'Organization'>
     appDefinition: Link<'AppDefinition'>
   }

--- a/lib/entities/resource-type.ts
+++ b/lib/entities/resource-type.ts
@@ -15,7 +15,7 @@ export type ResourceTypeProps = {
   /**
    * System metadata
    */
-  sys: Omit<BasicMetaSysProps, 'version'> & {
+  sys: Omit<BasicMetaSysProps<'User'>, 'version'> & {
     appDefinition: Link<'AppDefinition'>
     resourceProvider: Link<'ResourceProvider'>
     organization: Link<'Organization'>

--- a/lib/entities/resource-type.ts
+++ b/lib/entities/resource-type.ts
@@ -3,8 +3,8 @@ import type {
   CursorPaginatedCollectionProp,
   DefaultElements,
   GetResourceTypeParams,
+  Link,
   MakeRequest,
-  SysLink,
 } from '../common-types'
 import { toPlainObject, freezeSys } from 'contentful-sdk-core'
 import copy from 'fast-copy'
@@ -16,9 +16,9 @@ export type ResourceTypeProps = {
    * System metadata
    */
   sys: Omit<BasicMetaSysProps, 'version'> & {
-    appDefinition: SysLink
-    resourceProvider: SysLink
-    organization: SysLink
+    appDefinition: Link<'AppDefinition'>
+    resourceProvider: Link<'ResourceProvider'>
+    organization: Link<'Organization'>
   }
   /**
    * Resource Type name

--- a/lib/entities/resource.ts
+++ b/lib/entities/resource.ts
@@ -1,8 +1,8 @@
 import type {
   BasicCursorPaginationOptions,
   CursorPaginatedCollectionProp,
+  Link,
   MakeRequest,
-  SysLink,
 } from '../common-types'
 import { wrapCursorPaginatedCollection } from '../common-utils'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
@@ -23,9 +23,9 @@ export type ResourceProps = {
   sys: {
     type: 'Resource'
     urn: string
-    resourceType: SysLink
-    resourceProvider: SysLink
-    appDefinition: SysLink
+    resourceType: Link<'ResourceType'>
+    resourceProvider: Link<'ResourceProvider'>
+    appDefinition: Link<'AppDefinition'>
   }
   fields: {
     title: string

--- a/lib/entities/role.ts
+++ b/lib/entities/role.ts
@@ -20,7 +20,7 @@ export type ConstraintType = {
 }
 
 export type RoleProps = {
-  sys: BasicMetaSysProps & { space: Link<'Space'> }
+  sys: BasicMetaSysProps<'User'> & { space: Link<'Space'> }
   name: string
   description?: string
   /**

--- a/lib/entities/role.ts
+++ b/lib/entities/role.ts
@@ -2,7 +2,7 @@ import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
-import type { DefaultElements, BasicMetaSysProps, SysLink, MakeRequest } from '../common-types'
+import type { DefaultElements, BasicMetaSysProps, MakeRequest, Link } from '../common-types'
 
 export type ActionType =
   | 'read'
@@ -20,7 +20,7 @@ export type ConstraintType = {
 }
 
 export type RoleProps = {
-  sys: BasicMetaSysProps & { space: SysLink }
+  sys: BasicMetaSysProps & { space: Link<'Space'> }
   name: string
   description?: string
   /**

--- a/lib/entities/scheduled-action.ts
+++ b/lib/entities/scheduled-action.ts
@@ -3,10 +3,8 @@ import copy from 'fast-copy'
 import type {
   DefaultElements,
   ISO8601Timestamp,
-  MetaLinkProps,
   Link,
   MakeRequest,
-  SysLink,
   ScheduledActionReferenceFilters,
   BasicCursorPaginationOptions,
   CollectionProp,
@@ -52,7 +50,7 @@ export type ScheduledActionSysProps = {
   id: string
   type: 'ScheduledAction'
   version: number
-  space: SysLink
+  space: Link<'Space'>
   status: ScheduledActionStatus
   createdAt: ISO8601Timestamp
   createdBy: Link<'User'> | Link<'AppDefinition'>
@@ -72,7 +70,7 @@ export type ScheduledActionProps = {
   sys: ScheduledActionSysProps
   action: SchedulableActionType
   entity: Link<SchedulableEntityType>
-  environment?: { sys: MetaLinkProps }
+  environment?: Link<'Environment'>
   scheduledFor: {
     datetime: ISO8601Timestamp
     /**

--- a/lib/entities/snapshot.ts
+++ b/lib/entities/snapshot.ts
@@ -5,7 +5,7 @@ import { wrapCollection } from '../common-utils'
 import type { MetaSysProps, DefaultElements, MakeRequest } from '../common-types'
 
 export type SnapshotProps<T> = {
-  sys: MetaSysProps<'User' | 'AppDefinition'> & {
+  sys: MetaSysProps<'User'> & {
     snapshotType: string
     snapshotEntityType: string
   }

--- a/lib/entities/snapshot.ts
+++ b/lib/entities/snapshot.ts
@@ -5,7 +5,7 @@ import { wrapCollection } from '../common-utils'
 import type { MetaSysProps, DefaultElements, MakeRequest } from '../common-types'
 
 export type SnapshotProps<T> = {
-  sys: MetaSysProps & {
+  sys: MetaSysProps<'User' | 'AppDefinition'> & {
     snapshotType: string
     snapshotEntityType: string
   }

--- a/lib/entities/space-member.ts
+++ b/lib/entities/space-member.ts
@@ -4,7 +4,7 @@ import type { DefaultElements, Link, MakeRequest, MetaSysProps } from '../common
 import { wrapCollection } from '../common-utils'
 
 export type SpaceMemberProps = {
-  sys: MetaSysProps
+  sys: MetaSysProps<'User'>
   /**
    * User is an admin
    */

--- a/lib/entities/space-member.ts
+++ b/lib/entities/space-member.ts
@@ -1,6 +1,6 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type { DefaultElements, MakeRequest, MetaLinkProps, MetaSysProps } from '../common-types'
+import type { DefaultElements, Link, MakeRequest, MetaSysProps } from '../common-types'
 import { wrapCollection } from '../common-utils'
 
 export type SpaceMemberProps = {
@@ -12,7 +12,7 @@ export type SpaceMemberProps = {
   /**
    * Array of Role Links
    */
-  roles: { sys: MetaLinkProps }[]
+  roles: Link<'Role'>[]
 }
 
 export interface SpaceMember extends SpaceMemberProps, DefaultElements<SpaceMemberProps> {}

--- a/lib/entities/space-membership.ts
+++ b/lib/entities/space-membership.ts
@@ -2,13 +2,13 @@ import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
-import type { SysLink, MetaSysProps, DefaultElements, MakeRequest } from '../common-types'
+import type { MetaSysProps, DefaultElements, MakeRequest, Link } from '../common-types'
 
 export type SpaceMembershipProps = {
-  sys: MetaSysProps & { space: SysLink; user: SysLink }
-  user: SysLink
+  sys: MetaSysProps & { space: Link<'Space'>; user: Link<'User'> }
+  user: Link<'User'>
   admin: boolean
-  roles: SysLink[]
+  roles: Link<'Role'>[]
 }
 
 export type CreateSpaceMembershipProps = Omit<SpaceMembershipProps, 'sys' | 'user'> & {

--- a/lib/entities/space-membership.ts
+++ b/lib/entities/space-membership.ts
@@ -5,7 +5,7 @@ import { wrapCollection } from '../common-utils'
 import type { MetaSysProps, DefaultElements, MakeRequest, Link } from '../common-types'
 
 export type SpaceMembershipProps = {
-  sys: MetaSysProps & { space: Link<'Space'>; user: Link<'User'> }
+  sys: MetaSysProps<'User'> & { space: Link<'Space'>; user: Link<'User'> }
   user: Link<'User'>
   admin: boolean
   roles: Link<'Role'>[]

--- a/lib/entities/space.ts
+++ b/lib/entities/space.ts
@@ -7,7 +7,7 @@ import createSpaceApi from '../create-space-api'
 import enhanceWithMethods from '../enhance-with-methods'
 
 export type SpaceProps = {
-  sys: BasicMetaSysProps & { organization: { sys: { id: string } }; archivedAt?: string }
+  sys: BasicMetaSysProps<'User'> & { organization: { sys: { id: string } }; archivedAt?: string }
   name: string
 }
 

--- a/lib/entities/tag.ts
+++ b/lib/entities/tag.ts
@@ -13,7 +13,7 @@ import enhanceWithMethods from '../enhance-with-methods'
 export type TagVisibility = 'private' | 'public'
 
 export type TagSysProps = Pick<
-  MetaSysProps,
+  MetaSysProps<'User'>,
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
 > & {
   type: 'Tag'

--- a/lib/entities/tag.ts
+++ b/lib/entities/tag.ts
@@ -3,9 +3,9 @@ import copy from 'fast-copy'
 import type {
   DefaultElements,
   GetTagParams,
+  Link,
   MakeRequest,
   MetaSysProps,
-  SysLink,
 } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -18,8 +18,8 @@ export type TagSysProps = Pick<
 > & {
   type: 'Tag'
   visibility: TagVisibility
-  space: SysLink
-  environment: SysLink
+  space: Link<'Space'>
+  environment: Link<'Environment'>
 }
 
 export type TagProps = {

--- a/lib/entities/task.ts
+++ b/lib/entities/task.ts
@@ -14,7 +14,7 @@ import enhanceWithMethods from '../enhance-with-methods'
 export type TaskStatus = 'active' | 'resolved'
 
 export type TaskSysProps = Pick<
-  BasicMetaSysProps,
+  BasicMetaSysProps<'User' | 'AppDefinition'>,
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
 > & {
   type: 'Task'

--- a/lib/entities/task.ts
+++ b/lib/entities/task.ts
@@ -7,7 +7,6 @@ import type {
   GetTaskParams,
   Link,
   MakeRequest,
-  SysLink,
 } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -19,8 +18,8 @@ export type TaskSysProps = Pick<
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
 > & {
   type: 'Task'
-  space: SysLink
-  environment: SysLink
+  space: Link<'Space'>
+  environment: Link<'Environment'>
   parentEntity: Link<'Entry'>
 }
 

--- a/lib/entities/team-membership.ts
+++ b/lib/entities/team-membership.ts
@@ -2,12 +2,7 @@ import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
-import type {
-  DefaultElements,
-  MetaSysProps,
-  MakeRequest,
-  Link,
-} from '../common-types'
+import type { DefaultElements, MetaSysProps, MakeRequest, Link } from '../common-types'
 
 export type TeamMembershipProps = {
   /**

--- a/lib/entities/team-membership.ts
+++ b/lib/entities/team-membership.ts
@@ -8,7 +8,7 @@ export type TeamMembershipProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & {
+  sys: MetaSysProps<'User'> & {
     team: Link<'Team'>
     organization: Link<'Organization'>
     organizationMembership: Link<'OrganizationMembership'>

--- a/lib/entities/team-membership.ts
+++ b/lib/entities/team-membership.ts
@@ -2,16 +2,21 @@ import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
-import type { DefaultElements, MetaSysProps, MetaLinkProps, MakeRequest } from '../common-types'
+import type {
+  DefaultElements,
+  MetaSysProps,
+  MakeRequest,
+  Link,
+} from '../common-types'
 
 export type TeamMembershipProps = {
   /**
    * System metadata
    */
   sys: MetaSysProps & {
-    team: { sys: MetaLinkProps }
-    organization: { sys: MetaLinkProps }
-    organizationMembership: { sys: MetaLinkProps }
+    team: Link<'Team'>
+    organization: Link<'Organization'>
+    organizationMembership: Link<'OrganizationMembership'>
   }
 
   /**

--- a/lib/entities/team-space-membership.ts
+++ b/lib/entities/team-space-membership.ts
@@ -19,7 +19,7 @@ export type TeamSpaceMembershipProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { team: Link<'Team'>; space: Link<'Space'> }
+  sys: MetaSysProps<'User'> & { team: Link<'Team'>; space: Link<'Space'> }
 
   /**
    * Is admin

--- a/lib/entities/team-space-membership.ts
+++ b/lib/entities/team-space-membership.ts
@@ -4,8 +4,8 @@ import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
 import type {
   DefaultElements,
+  Link,
   MakeRequest,
-  MetaLinkProps,
   MetaSysProps,
   QueryOptions,
 } from '../common-types'
@@ -19,7 +19,7 @@ export type TeamSpaceMembershipProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { team: { sys: MetaLinkProps }; space: { sys: MetaLinkProps } }
+  sys: MetaSysProps & { team: Link<'Team'>; space: Link<'Space'> }
 
   /**
    * Is admin
@@ -29,7 +29,7 @@ export type TeamSpaceMembershipProps = {
   /**
    * Roles
    */
-  roles: { sys: MetaLinkProps }[]
+  roles: Link<'Role'>[]
 }
 
 export type CreateTeamSpaceMembershipProps = Omit<TeamSpaceMembershipProps, 'sys'>

--- a/lib/entities/team.ts
+++ b/lib/entities/team.ts
@@ -2,13 +2,13 @@ import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
-import type { DefaultElements, MetaSysProps, MetaLinkProps, MakeRequest } from '../common-types'
+import type { DefaultElements, MetaSysProps, MakeRequest, Link } from '../common-types'
 
 export type TeamProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { memberCount: number; organization: { sys: MetaLinkProps } }
+  sys: MetaSysProps & { memberCount: number; organization: Link<'Organization'> }
 
   /**
    * Name of the team

--- a/lib/entities/team.ts
+++ b/lib/entities/team.ts
@@ -8,7 +8,7 @@ export type TeamProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { memberCount: number; organization: Link<'Organization'> }
+  sys: MetaSysProps<'User'> & { memberCount: number; organization: Link<'Organization'> }
 
   /**
    * Name of the team

--- a/lib/entities/ui-config.ts
+++ b/lib/entities/ui-config.ts
@@ -1,6 +1,6 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '../common-types'
+import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import createUIConfigApi from '../create-ui-config-api'
 import enhanceWithMethods from '../enhance-with-methods'
 
@@ -18,8 +18,8 @@ export type UIConfigProps = {
 }
 
 export interface UIConfigSysProps extends BasicMetaSysProps {
-  space: SysLink
-  environment: SysLink
+  space: Link<'Space'>
+  environment: Link<'Environment'>
 }
 
 interface HomeView {

--- a/lib/entities/ui-config.ts
+++ b/lib/entities/ui-config.ts
@@ -17,7 +17,7 @@ export type UIConfigProps = {
   publish?: { publishMode: 'entryPublishing' | 'localePublishing' }
 }
 
-export interface UIConfigSysProps extends BasicMetaSysProps {
+export interface UIConfigSysProps extends BasicMetaSysProps<'User' | 'AppDefinition'> {
   space: Link<'Space'>
   environment: Link<'Environment'>
 }

--- a/lib/entities/upload-credential.ts
+++ b/lib/entities/upload-credential.ts
@@ -1,13 +1,13 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type { DefaultElements, MakeRequest, MetaSysProps, SysLink } from '../common-types'
+import type { DefaultElements, Link, MakeRequest, MetaSysProps } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
 export type UploadCredentialProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { space: SysLink; environment?: SysLink }
+  sys: MetaSysProps & { space: Link<'Space'>; environment?: Link<'Environment'> }
 }
 
 export interface UploadCredential

--- a/lib/entities/upload-credential.ts
+++ b/lib/entities/upload-credential.ts
@@ -7,7 +7,7 @@ export type UploadCredentialProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { space: Link<'Space'>; environment?: Link<'Environment'> }
+  sys: MetaSysProps<'User'> & { space: Link<'Space'>; environment?: Link<'Environment'> }
 }
 
 export interface UploadCredential

--- a/lib/entities/upload.ts
+++ b/lib/entities/upload.ts
@@ -7,7 +7,10 @@ export type UploadProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { space: Link<'Space'>; environment?: Link<'Environment'> }
+  sys: MetaSysProps<'User' | 'AppDefinition'> & {
+    space: Link<'Space'>
+    environment?: Link<'Environment'>
+  }
 }
 
 export interface Upload extends UploadProps, DefaultElements<UploadProps> {

--- a/lib/entities/upload.ts
+++ b/lib/entities/upload.ts
@@ -1,13 +1,13 @@
 import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
-import type { DefaultElements, MakeRequest, MetaSysProps, SysLink } from '../common-types'
+import type { DefaultElements, Link, MakeRequest, MetaSysProps } from '../common-types'
 
 export type UploadProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & { space: SysLink; environment?: SysLink }
+  sys: MetaSysProps & { space: Link<'Space'>; environment?: Link<'Environment'> }
 }
 
 export interface Upload extends UploadProps, DefaultElements<UploadProps> {

--- a/lib/entities/usage.ts
+++ b/lib/entities/usage.ts
@@ -2,8 +2,8 @@ import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type {
   DefaultElements,
+  Link,
   MakeRequest,
-  MetaLinkProps,
   MetaSysProps,
   QueryOptions,
 } from '../common-types'
@@ -23,7 +23,7 @@ export type UsageProps = {
    * System metadata
    */
   sys: MetaSysProps & {
-    organization?: { sys: MetaLinkProps }
+    organization?: Link<'Organization'>
   }
 
   /**

--- a/lib/entities/usage.ts
+++ b/lib/entities/usage.ts
@@ -1,12 +1,6 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type {
-  DefaultElements,
-  Link,
-  MakeRequest,
-  MetaSysProps,
-  QueryOptions,
-} from '../common-types'
+import type { DefaultElements, Link, MakeRequest, QueryOptions } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 
@@ -22,7 +16,9 @@ export type UsageProps = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & {
+  sys: {
+    id: string
+    type: string
     organization?: Link<'Organization'>
   }
 

--- a/lib/entities/user-ui-config.ts
+++ b/lib/entities/user-ui-config.ts
@@ -14,7 +14,7 @@ export type UserUIConfigProps = {
   entryListViews: ViewFolder[]
 }
 
-export interface UserUIConfigSysProps extends BasicMetaSysProps {
+export interface UserUIConfigSysProps extends BasicMetaSysProps<'User' | 'AppDefinition'> {
   space: Link<'Space'>
   environment: Link<'Environment'>
 }

--- a/lib/entities/user-ui-config.ts
+++ b/lib/entities/user-ui-config.ts
@@ -1,6 +1,6 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type { BasicMetaSysProps, DefaultElements, MakeRequest, SysLink } from '../common-types'
+import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import createUserUIConfigApi from '../create-user-ui-config-api'
 import enhanceWithMethods from '../enhance-with-methods'
 
@@ -15,8 +15,8 @@ export type UserUIConfigProps = {
 }
 
 export interface UserUIConfigSysProps extends BasicMetaSysProps {
-  space: SysLink
-  environment: SysLink
+  space: Link<'Space'>
+  environment: Link<'Environment'>
 }
 
 interface ViewFolder {

--- a/lib/entities/user.ts
+++ b/lib/entities/user.ts
@@ -8,7 +8,7 @@ export type UserProps = {
   /**
    * System metadata
    */
-  sys: BasicMetaSysProps
+  sys: BasicMetaSysProps<'User'>
 
   /**
    * First name of the user

--- a/lib/entities/webhook.ts
+++ b/lib/entities/webhook.ts
@@ -48,7 +48,7 @@ export type WebhookCallRequest = {
 export type WebhookCallResponse = WebhookCallRequest & { statusCode: number }
 
 export type WebhookHealthSys = Except<
-  BasicMetaSysProps<'User'>,
+  BasicMetaSysProps<'WebhookDefinition'>,
   'version' | 'updatedAt' | 'updatedBy' | 'createdAt'
 >
 

--- a/lib/entities/webhook.ts
+++ b/lib/entities/webhook.ts
@@ -48,11 +48,11 @@ export type WebhookCallRequest = {
 export type WebhookCallResponse = WebhookCallRequest & { statusCode: number }
 
 export type WebhookHealthSys = Except<
-  BasicMetaSysProps,
+  BasicMetaSysProps<'User'>,
   'version' | 'updatedAt' | 'updatedBy' | 'createdAt'
 >
 
-export type WebhookCallDetailsSys = Except<BasicMetaSysProps, 'version' | 'updatedAt' | 'updatedBy'>
+export type WebhookCallDetailsSys = Except<BasicMetaSysProps<'User'>, 'version' | 'updatedAt' | 'updatedBy'>
 
 export type WebhookHeader = { key: string; value: string; secret?: boolean }
 
@@ -140,7 +140,7 @@ export type WebhookHealthProps = {
   calls: WebhookCalls
 }
 
-export type WebhookSigningSecretSys = Except<BasicMetaSysProps, 'version'>
+export type WebhookSigningSecretSys = Except<BasicMetaSysProps<'User'>, 'version'>
 
 export type WebhookSigningSecretProps = {
   sys: WebhookSigningSecretSys & { space: Link<'Space'> }
@@ -151,7 +151,7 @@ export type WebhookRetryPolicyPayload = {
   maxRetries: number
 }
 
-export type WebhookRetryPolicySys = Except<BasicMetaSysProps, 'version'>
+export type WebhookRetryPolicySys = Except<BasicMetaSysProps<'User'>, 'version'>
 
 export type WebhookRetryPolicyProps = {
   sys: WebhookRetryPolicySys & { space: Link<'Space'> }
@@ -162,7 +162,7 @@ export type WebhookProps = {
   /**
    * System metadata
    */
-  sys: BasicMetaSysProps & { space: Link<'Space'> }
+  sys: BasicMetaSysProps<'User'> & { space: Link<'Space'> }
 
   /**
    * Webhook name

--- a/lib/entities/webhook.ts
+++ b/lib/entities/webhook.ts
@@ -5,9 +5,8 @@ import type {
   BasicMetaSysProps,
   CollectionProp,
   DefaultElements,
+  Link,
   MakeRequest,
-  MetaLinkProps,
-  SysLink,
 } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -133,7 +132,7 @@ export type WebhookHealthProps = {
   /**
    * System metadata
    */
-  sys: WebhookHealthSys & { space: { sys: MetaLinkProps } }
+  sys: WebhookHealthSys & { space: Link<'Space'> }
 
   /**
    * Webhook call statistics
@@ -144,7 +143,7 @@ export type WebhookHealthProps = {
 export type WebhookSigningSecretSys = Except<BasicMetaSysProps, 'version'>
 
 export type WebhookSigningSecretProps = {
-  sys: WebhookSigningSecretSys & { space: { sys: MetaLinkProps } }
+  sys: WebhookSigningSecretSys & { space: Link<'Space'> }
   redactedValue: string
 }
 
@@ -155,7 +154,7 @@ export type WebhookRetryPolicyPayload = {
 export type WebhookRetryPolicySys = Except<BasicMetaSysProps, 'version'>
 
 export type WebhookRetryPolicyProps = {
-  sys: WebhookRetryPolicySys & { space: { sys: MetaLinkProps } }
+  sys: WebhookRetryPolicySys & { space: Link<'Space'> }
   maxRetries: number
 }
 
@@ -163,7 +162,7 @@ export type WebhookProps = {
   /**
    * System metadata
    */
-  sys: BasicMetaSysProps & { space: SysLink }
+  sys: BasicMetaSysProps & { space: Link<'Space'> }
 
   /**
    * Webhook name

--- a/lib/entities/webhook.ts
+++ b/lib/entities/webhook.ts
@@ -52,7 +52,10 @@ export type WebhookHealthSys = Except<
   'version' | 'updatedAt' | 'updatedBy' | 'createdAt'
 >
 
-export type WebhookCallDetailsSys = Except<BasicMetaSysProps<'WebhookDefinition'>, 'version' | 'updatedAt' | 'updatedBy'>
+export type WebhookCallDetailsSys = Except<
+  BasicMetaSysProps<'WebhookDefinition'>,
+  'version' | 'updatedAt' | 'updatedBy'
+>
 
 export type WebhookHeader = { key: string; value: string; secret?: boolean }
 

--- a/lib/entities/webhook.ts
+++ b/lib/entities/webhook.ts
@@ -52,7 +52,7 @@ export type WebhookHealthSys = Except<
   'version' | 'updatedAt' | 'updatedBy' | 'createdAt'
 >
 
-export type WebhookCallDetailsSys = Except<BasicMetaSysProps<'User'>, 'version' | 'updatedAt' | 'updatedBy'>
+export type WebhookCallDetailsSys = Except<BasicMetaSysProps<'WebhookDefinition'>, 'version' | 'updatedAt' | 'updatedBy'>
 
 export type WebhookHeader = { key: string; value: string; secret?: boolean }
 

--- a/lib/entities/workflow-definition.ts
+++ b/lib/entities/workflow-definition.ts
@@ -8,7 +8,6 @@ import type {
   Link,
   MakeRequest,
   PaginationQueryOptions,
-  SysLink,
 } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -101,8 +100,8 @@ export type WorkflowDefinitionSysProps = Pick<
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
 > & {
   type: 'WorkflowDefinition'
-  space: SysLink
-  environment: SysLink
+  space: Link<'Space'>
+  environment: Link<'Environment'>
   isLocked: boolean
 }
 

--- a/lib/entities/workflow-definition.ts
+++ b/lib/entities/workflow-definition.ts
@@ -96,7 +96,7 @@ export type CreateWorkflowStepProps = Omit<WorkflowStepProps, 'id'>
 /* Workflow Definition */
 
 export type WorkflowDefinitionSysProps = Pick<
-  BasicMetaSysProps,
+  BasicMetaSysProps<'User'>,
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
 > & {
   type: 'WorkflowDefinition'

--- a/lib/entities/workflow.ts
+++ b/lib/entities/workflow.ts
@@ -13,7 +13,7 @@ import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 
 export type WorkflowSysProps = Pick<
-  BasicMetaSysProps,
+  BasicMetaSysProps<'User' | 'AppDefinition'>,
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
 > & {
   type: 'Workflow'

--- a/lib/entities/workflow.ts
+++ b/lib/entities/workflow.ts
@@ -8,7 +8,6 @@ import type {
   Link,
   MakeRequest,
   PaginationQueryOptions,
-  SysLink,
 } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -18,11 +17,11 @@ export type WorkflowSysProps = Pick<
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
 > & {
   type: 'Workflow'
-  space: SysLink
-  environment: SysLink
-  completedBy?: SysLink
+  space: Link<'Space'>
+  environment: Link<'Environment'>
+  completedBy?: Link<'User'> | Link<'AppDefinition'>
   completedAt?: string
-  deletedBy?: SysLink
+  deletedBy?: Link<'User'> | Link<'AppDefinition'>
   deletedAt?: string
   entity: Link<'Entry'>
   workflowDefinition: Link<'WorkflowDefinition'>

--- a/lib/entities/workflows-changelog-entry.ts
+++ b/lib/entities/workflows-changelog-entry.ts
@@ -5,7 +5,6 @@ import type {
   Link,
   MakeRequest,
   PaginationQueryOptions,
-  SysLink,
   VersionedLink,
 } from '../common-types'
 import { wrapCollection } from '../common-utils'
@@ -25,7 +24,7 @@ export type WorkflowsChangelogQueryOptions = Omit<PaginationQueryOptions, 'order
 
 export type WorkflowsChangelogEntryProps = {
   event: string
-  eventBy: SysLink
+  eventBy: Link<'User'> | Link<'AppDefinition'>
   eventAt: string
   workflow: VersionedLink<'Workflow'>
   workflowDefinition: Link<'WorkflowDefinition'>

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -118,7 +118,13 @@ export type {
   GroupControl,
   SidebarItem,
 } from './entities/editor-interface'
-export type { CreateEntryProps, Entry, EntryProps, WithResourceName, EntryMetaSysProps } from './entities/entry'
+export type {
+  CreateEntryProps,
+  Entry,
+  EntryProps,
+  WithResourceName,
+  EntryMetaSysProps,
+} from './entities/entry'
 export type { CreateEnvironmentProps, Environment, EnvironmentProps } from './entities/environment'
 export type {
   CreateEnvironmentAliasProps,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -116,7 +116,7 @@ export type {
   GroupControl,
   SidebarItem,
 } from './entities/editor-interface'
-export type { CreateEntryProps, Entry, EntryProps, WithResourceName } from './entities/entry'
+export type { CreateEntryProps, Entry, EntryProps, WithResourceName, EntryMetaSysProps } from './entities/entry'
 export type { CreateEnvironmentProps, Environment, EnvironmentProps } from './entities/environment'
 export type {
   CreateEnvironmentAliasProps,

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -367,7 +367,7 @@ export type PlainClientAPI = {
     ): Promise<AssetProps>
     createFromFiles(
       params: OptionalDefaults<GetSpaceEnvironmentParams>,
-      data: Omit<AssetFileProp, 'sys'>
+      data: AssetFileProp
     ): Promise<AssetProps>
     processForAllLocales(
       params: OptionalDefaults<GetSpaceEnvironmentParams>,

--- a/lib/plain/entities/upload-credential.ts
+++ b/lib/plain/entities/upload-credential.ts
@@ -5,7 +5,7 @@ export type UploadCredential = {
   /**
    * System metadata
    */
-  sys: MetaSysProps & {
+  sys: MetaSysProps<'User'> & {
     type: 'UploadCredential'
   }
 


### PR DESCRIPTION
`SysLink` is a frequently used type within CMA.js. Unfortunately, `sys.type` and `sys.linkType` are typed as `string` instead of `"Link"` and the expected entity name.

In this PR, `SysLink` is replaced with `Link<T>`. `MetaLinkProps` is adjusted accordingly. I also added a generic to `MetaSysProps` and `BasicMetaSysProps` to clearly define whether `createdBy` etc is only a user or could also be an app.

With `Link<T>` we gain additional type safety as `sys.type` is typed as `"Link"` and `sys.linkType` is typed as `T`.

`SysLink` and `MetaLinkProps` are ~deprecated and it's recommended to always use `Link<T>`.~

I am not 100% confident on all link types. After an initial reviewed, I'd share this PR internally in case a team spots an inconsistency.

Open questions:
- Should we make all links to a subject (e.g. `sys.createdBy`) `Link<'User'> | Link<'AppDefinition'>`? Or check one by one whether that entity can be accessed by an app?
- Should we write `Link<'User'> | Link<'AppDefinition'>` or `Link<'User' | 'AppDefinition'>`? The result of the type checking should be identical.

This will be released as a breaking change in CMA.js v12