### PR TITLE
feat: client.publish payload

### DIFF
--- a/lib/adapters/REST/endpoints/ai-action.ts
+++ b/lib/adapters/REST/endpoints/ai-action.ts
@@ -74,6 +74,7 @@ export const del: RestEndpoint<'AiAction', 'delete'> = (
 export const publish: RestEndpoint<'AiAction', 'publish'> = (
   http: AxiosInstance,
   params: GetSpaceParams & { aiActionId: string; version: number },
+  rawData?: unknown,
   headers?: RawAxiosRequestHeaders
 ) => {
   return raw.put<AiActionProps>(

--- a/lib/adapters/REST/endpoints/ai-action.ts
+++ b/lib/adapters/REST/endpoints/ai-action.ts
@@ -50,6 +50,7 @@ export const update: RestEndpoint<'AiAction', 'update'> = (
 ) => {
   const data = copy(rawData)
   const { sys, ...payload } = data
+
   return raw.put<AiActionProps>(
     http,
     `/spaces/${params.spaceId}/ai/actions/${params.aiActionId}`,
@@ -73,8 +74,7 @@ export const del: RestEndpoint<'AiAction', 'delete'> = (
 
 export const publish: RestEndpoint<'AiAction', 'publish'> = (
   http: AxiosInstance,
-  params: GetSpaceParams & { aiActionId: string },
-  rawData: AiActionProps,
+  params: GetSpaceParams & { aiActionId: string, version: number },
   headers?: RawAxiosRequestHeaders
 ) => {
   return raw.put<AiActionProps>(
@@ -83,7 +83,7 @@ export const publish: RestEndpoint<'AiAction', 'publish'> = (
     null,
     {
       headers: {
-        'X-Contentful-Version': rawData.sys.version,
+        'X-Contentful-Version': params.version,
         ...headers,
       },
     }

--- a/lib/adapters/REST/endpoints/ai-action.ts
+++ b/lib/adapters/REST/endpoints/ai-action.ts
@@ -50,7 +50,6 @@ export const update: RestEndpoint<'AiAction', 'update'> = (
 ) => {
   const data = copy(rawData)
   const { sys, ...payload } = data
-
   return raw.put<AiActionProps>(
     http,
     `/spaces/${params.spaceId}/ai/actions/${params.aiActionId}`,
@@ -74,7 +73,7 @@ export const del: RestEndpoint<'AiAction', 'delete'> = (
 
 export const publish: RestEndpoint<'AiAction', 'publish'> = (
   http: AxiosInstance,
-  params: GetSpaceParams & { aiActionId: string, version: number },
+  params: GetSpaceParams & { aiActionId: string; version: number },
   headers?: RawAxiosRequestHeaders
 ) => {
   return raw.put<AiActionProps>(

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -965,7 +965,7 @@ export type MRActions = {
     }
     delete: { params: GetSpaceParams & { aiActionId: string }; return: any }
     publish: {
-      params: GetSpaceParams & { aiActionId: string, version: number }
+      params: GetSpaceParams & { aiActionId: string; version: number }
       headers?: RawAxiosRequestHeaders
       return: AiActionProps
     }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -965,8 +965,7 @@ export type MRActions = {
     }
     delete: { params: GetSpaceParams & { aiActionId: string }; return: any }
     publish: {
-      params: GetSpaceParams & { aiActionId: string }
-      payload: AiActionProps
+      params: GetSpaceParams & { aiActionId: string, version: number }
       headers?: RawAxiosRequestHeaders
       return: AiActionProps
     }

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -1608,14 +1608,12 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
      *   .catch(console.error)
      * ```
      */
-    publishAiAction(aiActionId: string, data: AiActionProps) {
+    publishAiAction(aiActionId: string, { version }: { version: number }) {
       const raw = this.toPlainObject() as SpaceProps
       return makeRequest({
         entityType: 'AiAction',
         action: 'publish',
-        params: { spaceId: raw.sys.id, aiActionId },
-        payload: data,
-        headers: { 'X-Contentful-Version': data.sys.version },
+        params: { spaceId: raw.sys.id, aiActionId, version },
       }).then((response) => wrapAiAction(makeRequest, response))
     },
 

--- a/lib/entities/ai-action.ts
+++ b/lib/entities/ai-action.ts
@@ -150,8 +150,11 @@ function createAiActionApi(makeRequest: MakeRequest) {
       return makeRequest({
         entityType: 'AiAction',
         action: 'publish',
-        params: getParams(self),
-        payload: self,
+        params: {
+          aiActionId: self.sys.id,
+          spaceId: self.sys.space.sys.id,
+          version: self.sys.version,
+        },
       }).then((data) => wrapAiAction(makeRequest, data))
     },
 

--- a/lib/plain/entities/ai-action.ts
+++ b/lib/plain/entities/ai-action.ts
@@ -71,6 +71,7 @@ export type AiActionPlainClientAPI = {
    */
   publish(
     params: OptionalDefaults<GetSpaceParams & { aiActionId: string; version: number }>,
+    payload: AiActionProps,
     headers?: Partial<RawAxiosRequestHeaders>
   ): Promise<AiActionProps>
   /**

--- a/lib/plain/entities/ai-action.ts
+++ b/lib/plain/entities/ai-action.ts
@@ -71,7 +71,7 @@ export type AiActionPlainClientAPI = {
    */
   publish(
     params: OptionalDefaults<GetSpaceParams & { aiActionId: string; version: number }>,
-    payload: AiActionProps,
+    payload?: unknown,
     headers?: Partial<RawAxiosRequestHeaders>
   ): Promise<AiActionProps>
   /**

--- a/lib/plain/entities/ai-action.ts
+++ b/lib/plain/entities/ai-action.ts
@@ -70,7 +70,7 @@ export type AiActionPlainClientAPI = {
    * @throws if the request fails or the payload is malformed.
    */
   publish(
-    params: OptionalDefaults<GetSpaceParams & { aiActionId: string, version: number }>,
+    params: OptionalDefaults<GetSpaceParams & { aiActionId: string; version: number }>,
     headers?: Partial<RawAxiosRequestHeaders>
   ): Promise<AiActionProps>
   /**

--- a/lib/plain/entities/ai-action.ts
+++ b/lib/plain/entities/ai-action.ts
@@ -65,14 +65,12 @@ export type AiActionPlainClientAPI = {
   /**
    * Publishes the AI Action.
    * @param params Entity IDs to identify the AI Action.
-   * @param payload The AI Action details.
    * @param headers Optional headers for the request.
    * @returns The published AI Action and its metadata.
    * @throws if the request fails or the payload is malformed.
    */
   publish(
-    params: OptionalDefaults<GetSpaceParams & { aiActionId: string }>,
-    payload: AiActionProps,
+    params: OptionalDefaults<GetSpaceParams & { aiActionId: string, version: number }>,
     headers?: Partial<RawAxiosRequestHeaders>
   ): Promise<AiActionProps>
   /**

--- a/test/integration/ai-action-integration.test.ts
+++ b/test/integration/ai-action-integration.test.ts
@@ -127,7 +127,7 @@ describe('AiAction api', { sequential: true }, () => {
       })
       .then((aiAction) => {
         return space
-          .publishAiAction(aiAction.sys.id, aiAction)
+          .publishAiAction(aiAction.sys.id, { version: aiAction.sys.version })
           .then((publishedAction) => {
             expect(publishedAction.sys.publishedVersion).to.be.ok
             return space.unpublishAiAction(publishedAction.sys.id)
@@ -164,7 +164,7 @@ describe('AiAction api', { sequential: true }, () => {
       })
       .then((aiAction) => {
         return space
-          .publishAiAction(aiAction.sys.id, aiAction)
+          .publishAiAction(aiAction.sys.id, { version: aiAction.sys.version })
           .then((publishedAction) =>
             environment.invokeAiAction(publishedAction.sys.id, {
               outputFormat: 'PlainText',

--- a/test/integration/ai-action-invocation-integration.test.ts
+++ b/test/integration/ai-action-invocation-integration.test.ts
@@ -67,7 +67,7 @@ describe('AiActionInvocation api', { sequential: true }, () => {
       testCases: [],
     })
 
-    await space.publishAiAction(aiAction.sys.id, aiAction)
+    await space.publishAiAction(aiAction.sys.id, { version: aiAction.sys.version })
 
     // First invoke the action
     invocation = await environment.invokeAiAction(aiAction.sys.id, {
@@ -144,7 +144,7 @@ describe('AiActionInvocation api', { sequential: true }, () => {
       testCases: [],
     })
 
-    await space.publishAiAction(otherAiAction.sys.id, otherAiAction)
+    await space.publishAiAction(otherAiAction.sys.id, { version: otherAiAction.sys.version })
 
     try {
       await environment.getAiActionInvocation({

--- a/test/unit/create-space-api.test.ts
+++ b/test/unit/create-space-api.test.ts
@@ -550,10 +550,11 @@ describe('A createSpaceApi', () => {
     const { api, makeRequest, entitiesMock } = setup(Promise.resolve(aiAction))
     entitiesMock.aiAction.wrapAiAction.mockReturnValue(aiAction)
 
-    await api.publishAiAction('aiActionId', aiAction).then((r) => {
+    await api.publishAiAction('aiActionId', { version: aiAction.sys.version }).then((r) => {
       expect(r).to.eql(aiAction)
-      expect(makeRequest.mock.calls[0][0].payload).to.eql(aiAction)
+
       expect(makeRequest.mock.calls[0][0].params.aiActionId).to.eql('aiActionId')
+      expect(makeRequest.mock.calls[0][0].params.version).to.eql(aiAction.sys.version)
       expect(makeRequest.mock.calls[0][0].action).to.eql('publish')
     })
   })
@@ -564,7 +565,7 @@ describe('A createSpaceApi', () => {
     const aiAction = cloneMock('aiAction')
 
     try {
-      await api.publishAiAction('aiActionId', aiAction)
+      await api.publishAiAction('aiActionId', { version: aiAction.sys.version })
     } catch (e) {
       expect(e).to.eq(error)
     }


### PR DESCRIPTION


<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

[Ticket](https://contentful.atlassian.net/browse/BBEE-1154)

## Description

Ai action publish method should be called as following:  `client.publishAiAction('space_id', { version: 4 })`

## Motivation and Context

We are not passing a payload to the publish function anymore. 

Space client call:

```
const space = await legacyClient.getSpace(process.env.SPACE_ID);
  const res =  await space.getAiAction(process.env.AI_ACTION_ID);
   
  const result = await space.publishAiAction(process.env.AI_ACTION_ID, {
    version: 4,
  });
 ```
 
 Legacy client call:
 
 ```
  const currentAction = await plainClient.aiAction.get({
      spaceId: process.env.SPACE_ID,
      aiActionId: process.env.AI_ACTION_ID,
    });

    const result = await plainClient.aiAction.publish(
      {
        spaceId: process.env.SPACE_ID,
        aiActionId: process.env.AI_ACTION_ID,
        version: 2
      },
    );
 ```
## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [x] The new method is added to the documentation
