### PR TITLE
feat: add optional functions property to AppBundleProps type [EXT-6304]

### DIFF
--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -54,6 +54,10 @@ export type AppBundleProps = {
    * A comment that describes this bundle
    */
   comment?: string
+  /**
+   * List of all functions in the bundle
+   */
+  functions?: FunctionManifestProps[]
 }
 
 export interface AppBundle extends AppBundleProps, DefaultElements<AppBundleProps> {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Since adding Contentful Functions as a capability, the `AppBundle` entity can now contain an optional `functions` property. This PR updates the `AppBundleProps` type to reflect this.

## Description

Added optional `functions` property to the `AppBundleProps` type. This property is an array of `FunctionManifestProps`. Note that the `CreateAppBundleProps` type already supports an optional `functions` property.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
