### PR TITLE
fix: make version param required for entry patch method of plain client [DX-34]

### DIFF
--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -287,7 +287,7 @@ export type PlainClientAPI = {
       headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>
     patch<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string; version?: number }>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string; version: number }>,
       rawData: OpPatch[],
       headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

As a follow up to this PR (https://github.com/contentful/contentful-management.js/pull/2609) we are making the version param required for the entry patch method of the plain client. 

## Description

`client.entry.patch` expects version to be passed in, however `version` is currently not included in the TypeScript types. This param was made optional, and now we are making this required. This will be released as a breaking change in CMA.js v12.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- ✅ Both unit and integration tests are passing
- ❌ There are no breaking changes
- ✅ Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
