### PR TITLE
feat: narrow `sys.type` to a string literal type for better type safety

### DIFF
--- a/lib/adapters/REST/endpoints/usage.ts
+++ b/lib/adapters/REST/endpoints/usage.ts
@@ -8,7 +8,7 @@ export const getManyForSpace: RestEndpoint<'Usage', 'getManyForSpace'> = (
   http: AxiosInstance,
   params: { organizationId: string } & QueryParams
 ) => {
-  return raw.get<CollectionProp<UsageProps>>(
+  return raw.get<CollectionProp<UsageProps<'SpacePeriodicUsage'>>>(
     http,
     `/organizations/${params.organizationId}/space_periodic_usages`,
     {
@@ -21,7 +21,7 @@ export const getManyForOrganization: RestEndpoint<'Usage', 'getManyForOrganizati
   http: AxiosInstance,
   params: { organizationId: string } & QueryParams
 ) => {
-  return raw.get<CollectionProp<UsageProps>>(
+  return raw.get<CollectionProp<UsageProps<'OrganizationPeriodicUsage'>>>(
     http,
     `/organizations/${params.organizationId}/organization_periodic_usages`,
     {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -248,8 +248,8 @@ export interface SpaceQueryOptions extends PaginationQueryOptions {
   spaceId?: string
 }
 
-export interface BasicMetaSysProps<TSubject extends string = string> {
-  type: string
+export interface BasicMetaSysProps<TType extends string, TSubject extends string = string> {
+  type: TType
   id: string
   version: number
   createdBy?: { [Subject in TSubject]: Link<Subject> }[TSubject]
@@ -258,8 +258,8 @@ export interface BasicMetaSysProps<TSubject extends string = string> {
   updatedAt: string
 }
 
-export interface MetaSysProps<TSubject extends string = string>
-  extends BasicMetaSysProps<TSubject> {
+export interface MetaSysProps<TType extends string, TSubject extends string = string>
+  extends BasicMetaSysProps<TType, TSubject> {
   space?: Link<'Space'>
   /**
    * @deprecated `status` only exists on entities. Please refactor to use a

--- a/lib/entities/access-token.ts
+++ b/lib/entities/access-token.ts
@@ -10,7 +10,7 @@ type Application = {
   sys: Link<'Application'>
 }
 
-type AccessTokenSysProps = BasicMetaSysProps<'User'> & {
+type AccessTokenSysProps = BasicMetaSysProps<'PersonalAccessToken', 'User'> & {
   application: Application | null
   expiresAt: string | null
   lastUsedAt: string | null

--- a/lib/entities/ai-action.ts
+++ b/lib/entities/ai-action.ts
@@ -78,7 +78,7 @@ export interface AiActionQueryOptions {
 }
 
 export type AiActionProps = {
-  sys: MetaSysProps<'User' | 'AppDefinition'> & {
+  sys: MetaSysProps<'AiAction', 'User' | 'AppDefinition'> & {
     type: 'AiAction'
     space: Link<'Space'>
     publishedBy?: Link<'User'> | Link<'AppDefinition'>

--- a/lib/entities/app-access-token.ts
+++ b/lib/entities/app-access-token.ts
@@ -3,7 +3,7 @@ import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import type { Except } from 'type-fest'
 import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 
-type AppAccessTokenSys = Except<BasicMetaSysProps<'User'>, 'version' | 'id'> & {
+type AppAccessTokenSys = Except<BasicMetaSysProps<'AppAccessToken', 'User'>, 'version' | 'id'> & {
   space: Link<'Space'>
   environment: Link<'Environment'>
   appDefinition: Link<'AppDefinition'>

--- a/lib/entities/app-action-call.ts
+++ b/lib/entities/app-action-call.ts
@@ -11,7 +11,7 @@ import type {
 import type { WebhookCallDetailsProps } from './webhook'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppActionCallSys = Except<BasicMetaSysProps< 'AppActionCall', 'User'>, 'version'> & {
+type AppActionCallSys = Except<BasicMetaSysProps<'AppActionCall', 'User'>, 'version'> & {
   appDefinition: Link<'AppDefinition'>
   space: Link<'Space'>
   environment: Link<'Environment'>

--- a/lib/entities/app-action-call.ts
+++ b/lib/entities/app-action-call.ts
@@ -11,7 +11,7 @@ import type {
 import type { WebhookCallDetailsProps } from './webhook'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppActionCallSys = Except<BasicMetaSysProps<'User'>, 'version'> & {
+type AppActionCallSys = Except<BasicMetaSysProps< 'AppActionCall', 'User'>, 'version'> & {
   appDefinition: Link<'AppDefinition'>
   space: Link<'Space'>
   environment: Link<'Environment'>

--- a/lib/entities/app-action.ts
+++ b/lib/entities/app-action.ts
@@ -6,7 +6,7 @@ import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../c
 import type { ParameterDefinition } from './widget-parameters'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppActionSys = Except<BasicMetaSysProps<'User'>, 'version'> & {
+type AppActionSys = Except<BasicMetaSysProps<'AppAction', 'User'>, 'version'> & {
   appDefinition: Link<'AppDefinition'>
   organization: Link<'Organization'>
 }

--- a/lib/entities/app-bundle.ts
+++ b/lib/entities/app-bundle.ts
@@ -5,7 +5,7 @@ import { wrapCollection } from '../common-utils'
 import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppBundleSys = Except<BasicMetaSysProps<'User'>, 'version'> & {
+type AppBundleSys = Except<BasicMetaSysProps<'AppBundle', 'User'>, 'version'> & {
   appDefinition: Link<'AppDefinition'>
   organization: Link<'Organization'>
 }

--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -38,7 +38,7 @@ export type AppDefinitionProps = {
   /**
    * System metadata
    */
-  sys: BasicMetaSysProps<'User'> & {
+  sys: BasicMetaSysProps<'AppDefinition', 'User'> & {
     organization: Link<'Organization'>
     shared: boolean
   }

--- a/lib/entities/app-details.ts
+++ b/lib/entities/app-details.ts
@@ -4,7 +4,7 @@ import type { Except } from 'type-fest'
 import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppDetailsSys = Except<BasicMetaSysProps<'User'>, 'version' | 'id'> & {
+type AppDetailsSys = Except<BasicMetaSysProps<'AppDetails', 'User'>, 'version' | 'id'> & {
   appDefinition: Link<'AppDefinition'>
   organization: Link<'Organization'>
 }

--- a/lib/entities/app-event-subscription.ts
+++ b/lib/entities/app-event-subscription.ts
@@ -4,7 +4,7 @@ import type { Except } from 'type-fest'
 import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppEventSubscriptionSys = Except<BasicMetaSysProps<'User'>, 'version' | 'id'> & {
+type AppEventSubscriptionSys = Except<BasicMetaSysProps<'AppEventSubscription', 'User'>, 'version' | 'id'> & {
   appDefinition: Link<'AppDefinition'>
   organization: Link<'Organization'>
 }

--- a/lib/entities/app-event-subscription.ts
+++ b/lib/entities/app-event-subscription.ts
@@ -4,7 +4,10 @@ import type { Except } from 'type-fest'
 import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppEventSubscriptionSys = Except<BasicMetaSysProps<'AppEventSubscription', 'User'>, 'version' | 'id'> & {
+type AppEventSubscriptionSys = Except<
+  BasicMetaSysProps<'AppEventSubscription', 'User'>,
+  'version' | 'id'
+> & {
   appDefinition: Link<'AppDefinition'>
   organization: Link<'Organization'>
 }

--- a/lib/entities/app-installation.ts
+++ b/lib/entities/app-installation.ts
@@ -7,7 +7,7 @@ import type { Except } from 'type-fest'
 import type { FreeFormParameters } from './widget-parameters'
 
 export type AppInstallationProps = {
-  sys: Omit<BasicMetaSysProps<'User'>, 'id'> & {
+  sys: Omit<BasicMetaSysProps<'AppInstallation', 'User'>, 'id'> & {
     appDefinition: Link<'AppDefinition'>
     environment: Link<'Environment'>
     space: Link<'Space'>

--- a/lib/entities/app-key.ts
+++ b/lib/entities/app-key.ts
@@ -5,7 +5,7 @@ import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../c
 import enhanceWithMethods from '../enhance-with-methods'
 import { wrapCollection } from '../common-utils'
 
-type AppKeySys = Except<BasicMetaSysProps<'User'>, 'version'> & {
+type AppKeySys = Except<BasicMetaSysProps<'AppKey', 'User'>, 'version'> & {
   appDefinition: Link<'AppDefinition'>
   organization: Link<'Organization'>
 }

--- a/lib/entities/app-signed-request.ts
+++ b/lib/entities/app-signed-request.ts
@@ -3,7 +3,10 @@ import { toPlainObject } from 'contentful-sdk-core'
 import type { Except } from 'type-fest'
 import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 
-type AppSignedRequestSys = Except<BasicMetaSysProps<'User'>, 'version' | 'id'> & {
+type AppSignedRequestSys = Except<
+  BasicMetaSysProps<'AppSignedRequest', 'User'>,
+  'version' | 'id'
+> & {
   appDefinition: Link<'AppDefinition'>
   space: Link<'Space'>
   environment: Link<'Environment'>

--- a/lib/entities/app-signing-secret.ts
+++ b/lib/entities/app-signing-secret.ts
@@ -4,7 +4,10 @@ import type { Except } from 'type-fest'
 import type { BasicMetaSysProps, DefaultElements, Link, MakeRequest } from '../common-types'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppSigningSecretSys = Except<BasicMetaSysProps<'User'>, 'version' | 'id'> & {
+type AppSigningSecretSys = Except<
+  BasicMetaSysProps<'AppSigningSecret', 'User'>,
+  'version' | 'id'
+> & {
   appDefinition: Link<'AppDefinition'>
   organization: Link<'Organization'>
 }

--- a/lib/entities/app-upload.ts
+++ b/lib/entities/app-upload.ts
@@ -5,7 +5,7 @@ import type { BasicMetaSysProps, DefaultElements, MakeRequest, Link } from '../c
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 
-type AppUploadSys = Except<BasicMetaSysProps<'User'>, 'version'>
+type AppUploadSys = Except<BasicMetaSysProps<'AppUpload', 'User'>, 'version'>
 
 export type AppUploadProps = {
   sys: AppUploadSys & {

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -23,7 +23,7 @@ interface LinkWithReference<T extends string> extends Link<T> {
 }
 
 export type CommentSysProps = Pick<
-  BasicMetaSysProps<'User'>,
+  BasicMetaSysProps<'Comment', 'User'>,
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
 > & {
   type: 'Comment'

--- a/lib/entities/content-type.ts
+++ b/lib/entities/content-type.ts
@@ -38,7 +38,7 @@ export type AnnotationAssignment = Link<'Annotation'> & {
 }
 
 export type ContentTypeProps = {
-  sys: BasicMetaSysProps<'User' | 'AppDefinition'> & {
+  sys: BasicMetaSysProps<'ContentType', 'User' | 'AppDefinition'> & {
     space: Link<'Space'>
     environment: Link<'Environment'>
     firstPublishedAt?: string

--- a/lib/entities/environment-alias.ts
+++ b/lib/entities/environment-alias.ts
@@ -8,7 +8,7 @@ export type EnvironmentAliasProps = {
   /**
    * System meta data
    */
-  sys: BasicMetaSysProps<'User'> & { space: Link<'Space'> }
+  sys: BasicMetaSysProps<'EnvironmentAlias', 'User'> & { space: Link<'Space'> }
   environment: Link<'Environment'>
 }
 

--- a/lib/entities/environment-template-installation.ts
+++ b/lib/entities/environment-template-installation.ts
@@ -27,7 +27,7 @@ export type EnvironmentTemplateInstallationStatus =
   keyof typeof EnvironmentTemplateInstallationStatuses
 
 export type EnvironmentTemplateInstallationProps = {
-  sys: BasicMetaSysProps<'User'> & {
+  sys: BasicMetaSysProps<'EnvironmentTemplateInstallation', 'User'> & {
     type: 'EnvironmentTemplateInstallation'
     space: Link<'Space'>
     template: VersionedLink<'Template'>

--- a/lib/entities/environment-template.ts
+++ b/lib/entities/environment-template.ts
@@ -29,7 +29,7 @@ export interface ContentTypeTemplateProps extends Omit<ContentTypeProps, 'sys'> 
 }
 
 export type EnvironmentTemplateProps = {
-  sys: BasicMetaSysProps<'User'> & { version: number; organization: Link<'Organization'> }
+  sys: BasicMetaSysProps<'EnvironmentTemplate', 'User'> & { version: number; organization: Link<'Organization'> }
   name: string
   description?: string
   versionName: string

--- a/lib/entities/environment-template.ts
+++ b/lib/entities/environment-template.ts
@@ -29,7 +29,10 @@ export interface ContentTypeTemplateProps extends Omit<ContentTypeProps, 'sys'> 
 }
 
 export type EnvironmentTemplateProps = {
-  sys: BasicMetaSysProps<'EnvironmentTemplate', 'User'> & { version: number; organization: Link<'Organization'> }
+  sys: BasicMetaSysProps<'EnvironmentTemplate', 'User'> & {
+    version: number
+    organization: Link<'Organization'>
+  }
   name: string
   description?: string
   versionName: string

--- a/lib/entities/environment.ts
+++ b/lib/entities/environment.ts
@@ -6,7 +6,7 @@ import createEnvironmentApi from '../create-environment-api'
 import { wrapCollection } from '../common-utils'
 import type { DefaultElements, BasicMetaSysProps, MakeRequest, Link } from '../common-types'
 
-type EnvironmentMetaSys = BasicMetaSysProps<'User'> & {
+type EnvironmentMetaSys = BasicMetaSysProps<'EnvironmentMeta', 'User'> & {
   status: Link<'Status'>
   space: Link<'Space'>
   aliases?: Array<Link<'EnvironmentAlias'>>

--- a/lib/entities/extension.ts
+++ b/lib/entities/extension.ts
@@ -11,7 +11,7 @@ import { wrapCollection } from '../common-utils'
 import type { DefaultElements, BasicMetaSysProps, MakeRequest, Link } from '../common-types'
 import type { SetRequired, RequireExactlyOne } from 'type-fest'
 
-type ExtensionSysProps = BasicMetaSysProps<'User'> & {
+type ExtensionSysProps = BasicMetaSysProps<'Extension', 'User'> & {
   space: Link<'Space'>
   environment: Link<'Environment'>
   srcdocSha256?: string

--- a/lib/entities/locale.ts
+++ b/lib/entities/locale.ts
@@ -6,7 +6,7 @@ import { wrapCollection } from '../common-utils'
 import type { BasicMetaSysProps, DefaultElements, MakeRequest, Link } from '../common-types'
 
 export type LocaleProps = {
-  sys: BasicMetaSysProps<'User' | 'AppDefinition'> & {
+  sys: BasicMetaSysProps<'Locale', 'User' | 'AppDefinition'> & {
     space: Link<'Space'>
     environment: Link<'Environment'>
   }

--- a/lib/entities/oauth-application.ts
+++ b/lib/entities/oauth-application.ts
@@ -4,7 +4,7 @@ import enhanceWithMethods from '../enhance-with-methods'
 import copy from 'fast-copy'
 import { wrapCursorPaginatedCollection } from '../common-utils'
 
-type OAuthApplicationSysProps = BasicMetaSysProps<'User'> & {
+type OAuthApplicationSysProps = BasicMetaSysProps<'Application', 'User'> & {
   lastUsedAt: string | null
 }
 

--- a/lib/entities/resource-provider.ts
+++ b/lib/entities/resource-provider.ts
@@ -15,7 +15,7 @@ export type ResourceProviderProps = {
   /**
    * System metadata
    */
-  sys: Omit<BasicMetaSysProps<'User'>, 'version'> & {
+  sys: Omit<BasicMetaSysProps<'ResourceProvider', 'User'>, 'version'> & {
     organization: Link<'Organization'>
     appDefinition: Link<'AppDefinition'>
   }

--- a/lib/entities/resource-type.ts
+++ b/lib/entities/resource-type.ts
@@ -15,7 +15,7 @@ export type ResourceTypeProps = {
   /**
    * System metadata
    */
-  sys: Omit<BasicMetaSysProps<'User'>, 'version'> & {
+  sys: Omit<BasicMetaSysProps<'ResourceType', 'User'>, 'version'> & {
     appDefinition: Link<'AppDefinition'>
     resourceProvider: Link<'ResourceProvider'>
     organization: Link<'Organization'>

--- a/lib/entities/role.ts
+++ b/lib/entities/role.ts
@@ -20,7 +20,7 @@ export type ConstraintType = {
 }
 
 export type RoleProps = {
-  sys: BasicMetaSysProps<'User'> & { space: Link<'Space'> }
+  sys: BasicMetaSysProps<'Role', 'User'> & { space: Link<'Space'> }
   name: string
   description?: string
   /**

--- a/lib/entities/space.ts
+++ b/lib/entities/space.ts
@@ -7,7 +7,7 @@ import createSpaceApi from '../create-space-api'
 import enhanceWithMethods from '../enhance-with-methods'
 
 export type SpaceProps = {
-  sys: BasicMetaSysProps<'User'> & { organization: { sys: { id: string } }; archivedAt?: string }
+  sys: BasicMetaSysProps<'Space', 'User'> & { organization: { sys: { id: string } }; archivedAt?: string }
   name: string
 }
 

--- a/lib/entities/space.ts
+++ b/lib/entities/space.ts
@@ -7,7 +7,10 @@ import createSpaceApi from '../create-space-api'
 import enhanceWithMethods from '../enhance-with-methods'
 
 export type SpaceProps = {
-  sys: BasicMetaSysProps<'Space', 'User'> & { organization: { sys: { id: string } }; archivedAt?: string }
+  sys: BasicMetaSysProps<'Space', 'User'> & {
+    organization: { sys: { id: string } }
+    archivedAt?: string
+  }
   name: string
 }
 

--- a/lib/entities/task.ts
+++ b/lib/entities/task.ts
@@ -14,7 +14,7 @@ import enhanceWithMethods from '../enhance-with-methods'
 export type TaskStatus = 'active' | 'resolved'
 
 export type TaskSysProps = Pick<
-  BasicMetaSysProps<'User' | 'AppDefinition'>,
+  BasicMetaSysProps<'Task', 'User' | 'AppDefinition'>,
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
 > & {
   type: 'Task'

--- a/lib/entities/ui-config.ts
+++ b/lib/entities/ui-config.ts
@@ -17,7 +17,7 @@ export type UIConfigProps = {
   publish?: { publishMode: 'entryPublishing' | 'localePublishing' }
 }
 
-export interface UIConfigSysProps extends BasicMetaSysProps<'User' | 'AppDefinition'> {
+export interface UIConfigSysProps extends BasicMetaSysProps<'UIConfig', 'User' | 'AppDefinition'> {
   space: Link<'Space'>
   environment: Link<'Environment'>
 }

--- a/lib/entities/usage.ts
+++ b/lib/entities/usage.ts
@@ -12,13 +12,17 @@ export interface UsageQuery extends QueryOptions {
   'dateRange.endAt'?: string
 }
 
-export type UsageProps = {
+export type UsageProps<
+  TType extends 'SpacePeriodicUsage' | 'OrganizationPeriodicUsage' =
+    | 'SpacePeriodicUsage'
+    | 'OrganizationPeriodicUsage'
+> = {
   /**
    * System metadata
    */
   sys: {
     id: string
-    type: string
+    type: TType
     organization?: Link<'Organization'>
   }
 

--- a/lib/entities/user-ui-config.ts
+++ b/lib/entities/user-ui-config.ts
@@ -14,7 +14,8 @@ export type UserUIConfigProps = {
   entryListViews: ViewFolder[]
 }
 
-export interface UserUIConfigSysProps extends BasicMetaSysProps<'User' | 'AppDefinition'> {
+export interface UserUIConfigSysProps
+  extends BasicMetaSysProps<'UserUIConfig', 'User' | 'AppDefinition'> {
   space: Link<'Space'>
   environment: Link<'Environment'>
 }

--- a/lib/entities/user.ts
+++ b/lib/entities/user.ts
@@ -8,7 +8,7 @@ export type UserProps = {
   /**
    * System metadata
    */
-  sys: BasicMetaSysProps<'User'>
+  sys: BasicMetaSysProps<'User', 'User'>
 
   /**
    * First name of the user

--- a/lib/entities/webhook.ts
+++ b/lib/entities/webhook.ts
@@ -143,7 +143,10 @@ export type WebhookHealthProps = {
   calls: WebhookCalls
 }
 
-export type WebhookSigningSecretSys = Except<BasicMetaSysProps<'WebhookSigningSecret', 'User'>, 'version'>
+export type WebhookSigningSecretSys = Except<
+  BasicMetaSysProps<'WebhookSigningSecret', 'User'>,
+  'version'
+>
 
 export type WebhookSigningSecretProps = {
   sys: WebhookSigningSecretSys & { space: Link<'Space'> }
@@ -154,7 +157,10 @@ export type WebhookRetryPolicyPayload = {
   maxRetries: number
 }
 
-export type WebhookRetryPolicySys = Except<BasicMetaSysProps<'WebhookRetryPolicy', 'User'>, 'version'>
+export type WebhookRetryPolicySys = Except<
+  BasicMetaSysProps<'WebhookRetryPolicy', 'User'>,
+  'version'
+>
 
 export type WebhookRetryPolicyProps = {
   sys: WebhookRetryPolicySys & { space: Link<'Space'> }

--- a/lib/entities/webhook.ts
+++ b/lib/entities/webhook.ts
@@ -48,12 +48,12 @@ export type WebhookCallRequest = {
 export type WebhookCallResponse = WebhookCallRequest & { statusCode: number }
 
 export type WebhookHealthSys = Except<
-  BasicMetaSysProps<'WebhookDefinition'>,
+  BasicMetaSysProps<'Webhook', 'WebhookDefinition'>,
   'version' | 'updatedAt' | 'updatedBy' | 'createdAt'
 >
 
 export type WebhookCallDetailsSys = Except<
-  BasicMetaSysProps<'WebhookDefinition'>,
+  BasicMetaSysProps<'WebhookCallOverview', 'WebhookDefinition'>,
   'version' | 'updatedAt' | 'updatedBy'
 >
 
@@ -143,7 +143,7 @@ export type WebhookHealthProps = {
   calls: WebhookCalls
 }
 
-export type WebhookSigningSecretSys = Except<BasicMetaSysProps<'User'>, 'version'>
+export type WebhookSigningSecretSys = Except<BasicMetaSysProps<'WebhookSigningSecret', 'User'>, 'version'>
 
 export type WebhookSigningSecretProps = {
   sys: WebhookSigningSecretSys & { space: Link<'Space'> }
@@ -154,7 +154,7 @@ export type WebhookRetryPolicyPayload = {
   maxRetries: number
 }
 
-export type WebhookRetryPolicySys = Except<BasicMetaSysProps<'User'>, 'version'>
+export type WebhookRetryPolicySys = Except<BasicMetaSysProps<'WebhookRetryPolicy', 'User'>, 'version'>
 
 export type WebhookRetryPolicyProps = {
   sys: WebhookRetryPolicySys & { space: Link<'Space'> }
@@ -165,7 +165,7 @@ export type WebhookProps = {
   /**
    * System metadata
    */
-  sys: BasicMetaSysProps<'User'> & { space: Link<'Space'> }
+  sys: BasicMetaSysProps<'Webhook', 'User'> & { space: Link<'Space'> }
 
   /**
    * Webhook name

--- a/lib/entities/workflow-definition.ts
+++ b/lib/entities/workflow-definition.ts
@@ -96,7 +96,7 @@ export type CreateWorkflowStepProps = Omit<WorkflowStepProps, 'id'>
 /* Workflow Definition */
 
 export type WorkflowDefinitionSysProps = Pick<
-  BasicMetaSysProps<'User'>,
+  BasicMetaSysProps<'WorkflowDefinition', 'User'>,
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
 > & {
   type: 'WorkflowDefinition'

--- a/lib/entities/workflow.ts
+++ b/lib/entities/workflow.ts
@@ -13,7 +13,7 @@ import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 
 export type WorkflowSysProps = Pick<
-  BasicMetaSysProps<'User' | 'AppDefinition'>,
+  BasicMetaSysProps<'Workflow', 'User' | 'AppDefinition'>,
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
 > & {
   type: 'Workflow'

--- a/lib/plain/checks.ts
+++ b/lib/plain/checks.ts
@@ -1,13 +1,13 @@
 import type { MetaSysProps } from '../common-types'
 
-export const isPublished = (data: { sys: MetaSysProps }) => !!data.sys.publishedVersion
+export const isPublished = <T extends string>(data: { sys: MetaSysProps<T> }) => !!data.sys.publishedVersion
 
-export const isUpdated = (data: { sys: MetaSysProps }) => {
+export const isUpdated = <T extends string>(data: { sys: MetaSysProps<T> }) => {
   // The act of publishing an entity increases its version by 1, so any entry which has
   // 2 versions higher or more than the publishedVersion has unpublished changes.
   return !!(data.sys.publishedVersion && data.sys.version > data.sys.publishedVersion + 1)
 }
 
-export const isDraft = (data: { sys: MetaSysProps }) => !data.sys.publishedVersion
+export const isDraft = <T extends string>(data: { sys: MetaSysProps<T> }) => !data.sys.publishedVersion
 
-export const isArchived = (data: { sys: MetaSysProps }) => !!data.sys.archivedVersion
+export const isArchived = <T extends string>(data: { sys: MetaSysProps<T> }) => !!data.sys.archivedVersion

--- a/lib/plain/checks.ts
+++ b/lib/plain/checks.ts
@@ -1,6 +1,7 @@
 import type { MetaSysProps } from '../common-types'
 
-export const isPublished = <T extends string>(data: { sys: MetaSysProps<T> }) => !!data.sys.publishedVersion
+export const isPublished = <T extends string>(data: { sys: MetaSysProps<T> }) =>
+  !!data.sys.publishedVersion
 
 export const isUpdated = <T extends string>(data: { sys: MetaSysProps<T> }) => {
   // The act of publishing an entity increases its version by 1, so any entry which has
@@ -8,6 +9,8 @@ export const isUpdated = <T extends string>(data: { sys: MetaSysProps<T> }) => {
   return !!(data.sys.publishedVersion && data.sys.version > data.sys.publishedVersion + 1)
 }
 
-export const isDraft = <T extends string>(data: { sys: MetaSysProps<T> }) => !data.sys.publishedVersion
+export const isDraft = <T extends string>(data: { sys: MetaSysProps<T> }) =>
+  !data.sys.publishedVersion
 
-export const isArchived = <T extends string>(data: { sys: MetaSysProps<T> }) => !!data.sys.archivedVersion
+export const isArchived = <T extends string>(data: { sys: MetaSysProps<T> }) =>
+  !!data.sys.archivedVersion


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

For many entities, `sys.type` is `string`. This PR changes the type to the actual string literal.

This is a breaking change.

## Description

Adding a new generic to `BasicMetaSysProps` and `MetaSysProps`. For each entity, the correct type string is passed.

## Motivation and Context

Improved types for internal use cases

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation


## Callouts

We should try to get rid of `MetaSysProps` and `BasicMetaSysProps`... It's likely that many types are not accurate because of the fields in there.