### PR TITLE
feat: add forTemplatedSpaces property for env template operations [DX-173]

### DIFF
--- a/lib/entities/environment-template.ts
+++ b/lib/entities/environment-template.ts
@@ -38,6 +38,7 @@ export type EnvironmentTemplateProps = {
     contentTypeTemplates: Array<ContentTypeTemplateProps>
     editorInterfaceTemplates: Array<EditorInterfaceTemplateProps>
   }
+  forTemplatedSpaces?: boolean
 }
 
 export type CreateEnvironmentTemplateProps = Omit<EnvironmentTemplateProps, 'sys'>

--- a/test/integration/environment-template-integration.test.ts
+++ b/test/integration/environment-template-integration.test.ts
@@ -19,7 +19,7 @@ import type {
 
 type InstallTemplate = () => Promise<EnvironmentTemplateInstallationProps>
 
-describe.skip('Environment template API', () => {
+describe('Environment template API', () => {
   const client = defaultClient
   const orgId = getTestOrganizationId()
   const templateDescription = `${baseEnvironmentTemplateDescription} ${generateRandomId()}`
@@ -238,6 +238,7 @@ describe.skip('Environment template API', () => {
         contentTypeTemplates: [],
         editorInterfaceTemplates: [],
       },
+      forTemplatedSpaces: false,
     }
   }
 })


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Add the new optional `forTemplatedSpaces` property for creating and editing environment templates.

## Description

Add the new optional `forTemplatedSpaces` property for creating and editing environment templates to the `EnvironmentTemplateProps` type. Also update the environment template creation helper in the integrations tests with this new property.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
