### PR TITLE
feat(default): release-id

### DIFF
--- a/lib/plain/wrappers/wrap.ts
+++ b/lib/plain/wrappers/wrap.ts
@@ -5,6 +5,7 @@ export type DefaultParams = {
   environmentId?: string
   organizationId?: string
   releaseSchemaVersion?: 'Release.v1' | 'Release.v2'
+  releaseId?: string
 }
 /**
  * @private

--- a/test/unit/contentful-management.test.ts
+++ b/test/unit/contentful-management.test.ts
@@ -54,6 +54,18 @@ describe('Contentful Management', () => {
     expect(createContentfulApiMock).not.toHaveBeenCalled()
   })
 
+  it('generates the correct releaseId', () => {
+    createClient(
+      { accessToken: 'token' },
+      { type: 'plain', defaults: { releaseId: 'my-release-id' } }
+    )
+
+    expect(createPlainClientMock).toHaveBeenCalledWith(expect.any(Function), {
+      releaseId: 'my-release-id',
+    })
+    expect(createContentfulApiMock).not.toHaveBeenCalled()
+  })
+
   it('generates the correct default user agent', () => {
     createClient({ accessToken: 'token' })
 


### PR DESCRIPTION
## Summary
Add `releaseId` as a default initialization param.

## Motivation and Context
See (internal only) [RFC](https://contentful.atlassian.net/wiki/spaces/PROD/pages/5125242881/SDK+API+Campaign+Context+Specifics) for detail

https://contentful.atlassian.net/browse/DX-185


## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
