### PR TITLE
chore: update test entry IDs in TestDefaults for failing integ tests [DX-198]

### DIFF
--- a/test/defaults.ts
+++ b/test/defaults.ts
@@ -6,13 +6,13 @@ export const TestDefaults = {
     withCrossSpaceReferenceId: 'test-content-type33324244',
   },
   entry: {
-    testEntryId: '5ETMRzkl9KM4omyMwKAOki',
+    testEntryId: '3Z76Riu91MIwPWIMG93LNb',
     /** Used in the entry references specs */
     testEntryReferenceId: '3ZgkmNQJxGjO9TUcnDgNQC',
     /** Used in Release specs */
-    testEntryReleasesId: '11NZX9PeFBvuQPc6LyCRpP',
+    testEntryReleasesId: '7pw3xjgbpE41JJrenBessW',
     /** Used in BulkAction specs */
-    testEntryBulkActionId: '375PMdQrwWOsifPJYP5Bb9',
+    testEntryBulkActionId: '6THqkC8vpDqAFtomRQazPu',
   },
   userId: '0DdCYLZI33Oe1uZ0FLpCzw',
   userEmail: 'for_tests_contentful-management.js@contentful.com',

--- a/test/integration/entry-integration.test.ts
+++ b/test/integration/entry-integration.test.ts
@@ -32,7 +32,7 @@ describe('Entry Api', () => {
     })
 
     test('Gets entry', async () => {
-      return environment.getEntry('5ETMRzkl9KM4omyMwKAOki').then((response) => {
+      return environment.getEntry(TestDefaults.entry.testEntryId).then((response) => {
         expect(response.sys, 'sys').to.be.ok
         expect(response.fields, 'fields').to.be.ok
       })
@@ -45,7 +45,7 @@ describe('Entry Api', () => {
       })
     })
     test('Gets Entry snapshots', async () => {
-      return environment.getEntry('5ETMRzkl9KM4omyMwKAOki').then((entry) => {
+      return environment.getEntry(TestDefaults.entry.testEntryId).then((entry) => {
         return entry.getSnapshots().then((response) => {
           expect(response, 'entry snapshots').ok
           expect(response.items, 'entry snapshots items').ok
@@ -300,6 +300,7 @@ describe('Entry Api', () => {
               'dog',
               'human',
               'kangaroo',
+              'test-content-type33324244',
               'testEntryReferences',
             ],
             'orders'

--- a/test/integration/entry-references-integration.test.ts
+++ b/test/integration/entry-references-integration.test.ts
@@ -22,9 +22,12 @@ describe('Entry References', () => {
     let entryWithReferences: any
 
     beforeAll(async () => {
-      entryWithReferences = await testEnvironment.getEntryReferences(TestDefaults.entry.testEntryReferenceId, {
-        include: 2,
-      })
+      entryWithReferences = await testEnvironment.getEntryReferences(
+        TestDefaults.entry.testEntryReferenceId,
+        {
+          include: 2,
+        }
+      )
     })
 
     it('Get the correct entry with references', () => {

--- a/test/integration/entry-references-integration.test.ts
+++ b/test/integration/entry-references-integration.test.ts
@@ -5,7 +5,6 @@ import type { Space } from '../../lib/entities/space'
 import { TestDefaults } from '../defaults'
 import { getDefaultSpace, initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 
-const ENTRY_WITH_REFERENCES_ID = TestDefaults.entry.testEntryReferenceId
 const WRONG_ENTRY_ID = '123123XD'
 
 describe('Entry References', () => {
@@ -23,18 +22,18 @@ describe('Entry References', () => {
     let entryWithReferences: any
 
     beforeAll(async () => {
-      entryWithReferences = await testEnvironment.getEntryReferences(ENTRY_WITH_REFERENCES_ID, {
+      entryWithReferences = await testEnvironment.getEntryReferences(TestDefaults.entry.testEntryReferenceId, {
         include: 2,
       })
     })
 
     it('Get the correct entry with references', () => {
-      expect(entryWithReferences.items[0].sys.id).toBe(ENTRY_WITH_REFERENCES_ID)
+      expect(entryWithReferences.items[0].sys.id).toBe(TestDefaults.entry.testEntryReferenceId)
       expect(entryWithReferences.includes).not.toBeUndefined()
       expect(entryWithReferences.includes.Entry.length).toBeGreaterThan(0)
     })
 
-    it('Should return the correct cities', () => {
+    it.only('Should return the correct cities', () => {
       const cities = entryWithReferences.includes.Entry.map(
         (entry: any) => entry.fields.name['en-US']
       )
@@ -62,7 +61,7 @@ describe('Entry References', () => {
       plainClient = initPlainClient(defaultParams)
 
       entry = await plainClient.entry.get({
-        entryId: ENTRY_WITH_REFERENCES_ID,
+        entryId: TestDefaults.entry.testEntryReferenceId,
       })
 
       entryWithReferences = await plainClient.entry.references({
@@ -72,7 +71,7 @@ describe('Entry References', () => {
     })
 
     it('Get the correct entry with references', () => {
-      expect(entryWithReferences.items[0].sys.id).toBe(ENTRY_WITH_REFERENCES_ID)
+      expect(entryWithReferences.items[0].sys.id).toBe(TestDefaults.entry.testEntryReferenceId)
       expect(entryWithReferences.includes).not.toBeUndefined()
       expect(entryWithReferences.includes.Entry.length).toBeGreaterThan(0)
     })

--- a/test/integration/entry-references-integration.test.ts
+++ b/test/integration/entry-references-integration.test.ts
@@ -36,7 +36,7 @@ describe('Entry References', () => {
       expect(entryWithReferences.includes.Entry.length).toBeGreaterThan(0)
     })
 
-    it.only('Should return the correct cities', () => {
+    it('Should return the correct cities', () => {
       const cities = entryWithReferences.includes.Entry.map(
         (entry: any) => entry.fields.name['en-US']
       )


### PR DESCRIPTION
Created new Entries that seem to have been inadvertently deleted and updated the const file with the new ids