### PR TITLE
fix: update lib/index.js imports and merge in test fixes [DX-4]

### DIFF
--- a/lib/entities/environment-template.ts
+++ b/lib/entities/environment-template.ts
@@ -41,6 +41,7 @@ export type EnvironmentTemplateProps = {
     contentTypeTemplates: Array<ContentTypeTemplateProps>
     editorInterfaceTemplates: Array<EditorInterfaceTemplateProps>
   }
+  forTemplatedSpaces?: boolean
 }
 
 export type CreateEnvironmentTemplateProps = Omit<EnvironmentTemplateProps, 'sys'>

--- a/test/defaults.ts
+++ b/test/defaults.ts
@@ -6,13 +6,13 @@ export const TestDefaults = {
     withCrossSpaceReferenceId: 'test-content-type33324244',
   },
   entry: {
-    testEntryId: '5ETMRzkl9KM4omyMwKAOki',
+    testEntryId: '3Z76Riu91MIwPWIMG93LNb',
     /** Used in the entry references specs */
     testEntryReferenceId: '3ZgkmNQJxGjO9TUcnDgNQC',
     /** Used in Release specs */
-    testEntryReleasesId: '11NZX9PeFBvuQPc6LyCRpP',
+    testEntryReleasesId: '7pw3xjgbpE41JJrenBessW',
     /** Used in BulkAction specs */
-    testEntryBulkActionId: '375PMdQrwWOsifPJYP5Bb9',
+    testEntryBulkActionId: '6THqkC8vpDqAFtomRQazPu',
   },
   userId: '0DdCYLZI33Oe1uZ0FLpCzw',
   userEmail: 'for_tests_contentful-management.js@contentful.com',

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,6 +1,6 @@
 import type { CreateHttpClientParams } from 'contentful-sdk-core'
-import { createClient } from '../lib.js'
-import type { Environment, Organization, Space } from '../lib.js'
+import { createClient } from '../lib/index.js'
+import type { Environment, Organization, Space } from '../lib/index.js'
 import { TestDefaults } from './defaults.js'
 
 import * as testUtils from '@contentful/integration-test-utils'

--- a/test/integration/app-access-token-integration.test.ts
+++ b/test/integration/app-access-token-integration.test.ts
@@ -14,7 +14,7 @@ import type {
   Environment,
   PlainClientAPI,
   AppKeyProps,
-} from '../../lib.js'
+} from '../../lib/index.js'
 
 describe('AppAccessToken api', { sequential: true }, () => {
   let organization: Organization

--- a/test/integration/app-action-integration.test.ts
+++ b/test/integration/app-action-integration.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, test, beforeAll, afterAll } from 'vitest'
-import type { AppActionProps, PlainClientAPI } from '../../lib.js'
+import type { AppActionProps, PlainClientAPI } from '../../lib/index.js'
 import {
   initPlainClient,
   getTestOrganization,

--- a/test/integration/app-bundle-integration.test.ts
+++ b/test/integration/app-bundle-integration.test.ts
@@ -1,7 +1,7 @@
 import { expect, describe, test, beforeAll, afterAll } from 'vitest'
 import { readFileSync } from 'fs'
 import { getTestOrganization, getDefaultSpace, timeoutToCalmRateLimiting } from '../helpers.js'
-import type { Organization, AppDefinition, AppUpload, Space, Environment } from '../../lib.js'
+import type { Organization, AppDefinition, AppUpload, Space, Environment } from '../../lib/index.js'
 
 describe('AppBundle api', { sequential: true }, () => {
   let organization: Organization

--- a/test/integration/app-definition-integration.test.ts
+++ b/test/integration/app-definition-integration.test.ts
@@ -7,7 +7,7 @@ import {
   getDefaultSpace,
   timeoutToCalmRateLimiting,
 } from '../helpers.js'
-import type { Organization, Space, Environment, AppInstallation } from '../../lib.js'
+import type { Organization, Space, Environment, AppInstallation } from '../../lib/index.js'
 
 describe('AppDefinition api', { sequential: true }, () => {
   let organization: Organization

--- a/test/integration/app-details-integration.test.ts
+++ b/test/integration/app-details-integration.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, test, beforeAll, afterAll } from 'vitest'
 import { initPlainClient, getTestOrganization, timeoutToCalmRateLimiting } from '../helpers.js'
-import type { AppIcon, PlainClientAPI, Organization, AppDefinition } from '../../lib.js'
+import type { AppIcon, PlainClientAPI, Organization, AppDefinition } from '../../lib/index.js'
 
 describe('AppDetails api', { sequential: true }, () => {
   let appDefinition: AppDefinition

--- a/test/integration/app-event-subscription-integration.test.ts
+++ b/test/integration/app-event-subscription-integration.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, test, beforeAll, afterAll } from 'vitest'
 import { initPlainClient, getTestOrganization, timeoutToCalmRateLimiting } from '../helpers.js'
-import type { PlainClientAPI, Organization, AppDefinition } from '../../lib.js'
+import type { PlainClientAPI, Organization, AppDefinition } from '../../lib/index.js'
 
 describe('AppEventSubscription api', { sequential: true }, () => {
   let appDefinition: AppDefinition

--- a/test/integration/app-key-integration.test.ts
+++ b/test/integration/app-key-integration.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, test, beforeAll, afterAll } from 'vitest'
 import { initPlainClient, getTestOrganization, timeoutToCalmRateLimiting } from '../helpers.js'
-import type { PlainClientAPI, Organization, AppDefinition } from '../../lib.js'
+import type { PlainClientAPI, Organization, AppDefinition } from '../../lib/index.js'
 
 describe('AppKey api', { sequential: true }, () => {
   let appDefinition: AppDefinition

--- a/test/integration/app-signed-request-integration.test.ts
+++ b/test/integration/app-signed-request-integration.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, test, beforeAll, afterAll } from 'vitest'
 import { initPlainClient, getTestOrganization, timeoutToCalmRateLimiting } from '../helpers.js'
-import type { PlainClientAPI, Organization, AppDefinition } from '../../lib.js'
+import type { PlainClientAPI, Organization, AppDefinition } from '../../lib/index.js'
 
 describe('AppKey api', { sequential: true }, () => {
   let appDefinition: AppDefinition

--- a/test/integration/app-signing-secret-integration.test.ts
+++ b/test/integration/app-signing-secret-integration.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, test, beforeAll, afterAll } from 'vitest'
 import { initPlainClient, getTestOrganization, timeoutToCalmRateLimiting } from '../helpers.js'
-import type { PlainClientAPI, Organization, AppDefinition } from '../../lib.js'
+import type { PlainClientAPI, Organization, AppDefinition } from '../../lib/index.js'
 
 describe('AppSigningSecret api', { sequential: true }, () => {
   let appDefinition: AppDefinition

--- a/test/integration/app-upload-integration.test.ts
+++ b/test/integration/app-upload-integration.test.ts
@@ -1,7 +1,7 @@
 import { expect, describe, test, beforeAll, afterAll } from 'vitest'
 import { readFileSync } from 'fs'
 import { getTestOrganization, timeoutToCalmRateLimiting } from '../helpers.js'
-import type { Organization } from '../../lib.js'
+import type { Organization } from '../../lib/index.js'
 
 describe('AppUpload api', { sequential: true }, () => {
   let organization: Organization

--- a/test/integration/bulk-action-integration.test.ts
+++ b/test/integration/bulk-action-integration.test.ts
@@ -5,8 +5,8 @@ import type {
   BulkActionPublishPayload,
   BulkActionUnpublishPayload,
   BulkActionValidatePayload,
-} from '../../lib.js'
-import type { Environment, Space } from '../../lib.js'
+} from '../../lib/index.js'
+import type { Environment, Space } from '../../lib/index.js'
 import { waitForBulkActionProcessing } from '../../lib/methods/bulk-action.js'
 import { TestDefaults } from '../defaults.js'
 import { getDefaultSpace, initPlainClient, timeoutToCalmRateLimiting } from '../helpers.js'

--- a/test/integration/entry-integration.test.ts
+++ b/test/integration/entry-integration.test.ts
@@ -32,7 +32,7 @@ describe('Entry Api', () => {
     })
 
     test('Gets entry', async () => {
-      return environment.getEntry('5ETMRzkl9KM4omyMwKAOki').then((response) => {
+      return environment.getEntry(TestDefaults.entry.testEntryId).then((response) => {
         expect(response.sys, 'sys').to.be.ok
         expect(response.fields, 'fields').to.be.ok
       })
@@ -45,7 +45,7 @@ describe('Entry Api', () => {
       })
     })
     test('Gets Entry snapshots', async () => {
-      return environment.getEntry('5ETMRzkl9KM4omyMwKAOki').then((entry) => {
+      return environment.getEntry(TestDefaults.entry.testEntryId).then((entry) => {
         return entry.getSnapshots().then((response) => {
           expect(response, 'entry snapshots').ok
           expect(response.items, 'entry snapshots items').ok
@@ -300,6 +300,7 @@ describe('Entry Api', () => {
               'dog',
               'human',
               'kangaroo',
+              'test-content-type33324244',
               'testEntryReferences',
             ],
             'orders'

--- a/test/integration/entry-references-integration.test.ts
+++ b/test/integration/entry-references-integration.test.ts
@@ -5,7 +5,6 @@ import type { Space } from '../../lib/entities/space.js'
 import { TestDefaults } from '../defaults.js'
 import { getDefaultSpace, initPlainClient, timeoutToCalmRateLimiting } from '../helpers.js'
 
-const ENTRY_WITH_REFERENCES_ID = TestDefaults.entry.testEntryReferenceId
 const WRONG_ENTRY_ID = '123123XD'
 
 describe('Entry References', () => {
@@ -23,13 +22,16 @@ describe('Entry References', () => {
     let entryWithReferences: any
 
     beforeAll(async () => {
-      entryWithReferences = await testEnvironment.getEntryReferences(ENTRY_WITH_REFERENCES_ID, {
-        include: 2,
-      })
+      entryWithReferences = await testEnvironment.getEntryReferences(
+        TestDefaults.entry.testEntryReferenceId,
+        {
+          include: 2,
+        }
+      )
     })
 
     it('Get the correct entry with references', () => {
-      expect(entryWithReferences.items[0].sys.id).toBe(ENTRY_WITH_REFERENCES_ID)
+      expect(entryWithReferences.items[0].sys.id).toBe(TestDefaults.entry.testEntryReferenceId)
       expect(entryWithReferences.includes).not.toBeUndefined()
       expect(entryWithReferences.includes.Entry.length).toBeGreaterThan(0)
     })
@@ -62,7 +64,7 @@ describe('Entry References', () => {
       plainClient = initPlainClient(defaultParams)
 
       entry = await plainClient.entry.get({
-        entryId: ENTRY_WITH_REFERENCES_ID,
+        entryId: TestDefaults.entry.testEntryReferenceId,
       })
 
       entryWithReferences = await plainClient.entry.references({
@@ -72,7 +74,7 @@ describe('Entry References', () => {
     })
 
     it('Get the correct entry with references', () => {
-      expect(entryWithReferences.items[0].sys.id).toBe(ENTRY_WITH_REFERENCES_ID)
+      expect(entryWithReferences.items[0].sys.id).toBe(TestDefaults.entry.testEntryReferenceId)
       expect(entryWithReferences.includes).not.toBeUndefined()
       expect(entryWithReferences.includes.Entry.length).toBeGreaterThan(0)
     })

--- a/test/integration/entry-references-integration.test.ts
+++ b/test/integration/entry-references-integration.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it, beforeAll, afterAll } from 'vitest'
-import type { PlainClientAPI } from '../../lib.js'
+import type { PlainClientAPI } from '../../lib/index.js'
 import type { Environment } from '../../lib/entities/environment.js'
 import type { Space } from '../../lib/entities/space.js'
 import { TestDefaults } from '../defaults.js'

--- a/test/integration/environment-template-integration.test.ts
+++ b/test/integration/environment-template-integration.test.ts
@@ -238,6 +238,7 @@ describe.skip('Environment template API', () => {
         contentTypeTemplates: [],
         editorInterfaceTemplates: [],
       },
+      forTemplatedSpaces: false,
     }
   }
 })

--- a/test/unit/plain/resource-provider.test.ts
+++ b/test/unit/plain/resource-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest'
-import { createClient } from '../../../lib.js'
+import { createClient } from '../../../lib/index.js'
 import setupRestAdapter from '../adapters/REST/helpers/setupRestAdapter.js'
 import { resourceProviderMock } from '../mocks/entities.js'
 

--- a/test/unit/plain/resource-type.test.ts
+++ b/test/unit/plain/resource-type.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest'
-import { createClient } from '../../../lib.js'
+import { createClient } from '../../../lib/index.js'
 import setupRestAdapter from '../adapters/REST/helpers/setupRestAdapter.js'
 import { resourceTypeMock } from '../mocks/entities.js'
 

--- a/test/unit/plain/resource.test.ts
+++ b/test/unit/plain/resource.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest'
-import { createClient } from '../../../lib.js'
+import { createClient } from '../../../lib/index.js'
 import setupRestAdapter from '../adapters/REST/helpers/setupRestAdapter.js'
 import { resourceMock } from '../mocks/entities.js'
 

--- a/test/unit/plain/webhook.test.ts
+++ b/test/unit/plain/webhook.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest'
-import { createClient } from '../../../lib.js'
+import { createClient } from '../../../lib/index.js'
 import setupRestAdapter from '../adapters/REST/helpers/setupRestAdapter.js'
 
 describe('Webhook', () => {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Fix some imports (`/lib` -> `lib/index.js`) that were causing unit tests to fail and merge in the latest from master so that the integration tests will pass.

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
