### PR TITLE
[DX-193] feat(releases): release.entry.getMany()

### DIFF
--- a/lib/adapters/REST/endpoints/release-entry.ts
+++ b/lib/adapters/REST/endpoints/release-entry.ts
@@ -1,5 +1,9 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
-import type { GetReleaseEntryParams } from '../../../common-types'
+import type {
+  GetReleaseEntryParams,
+  GetSpaceEnvironmentParams,
+  QueryParams,
+} from '../../../common-types'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
 
@@ -11,5 +15,17 @@ export const get: RestEndpoint<'ReleaseEntry', 'get'> = (
   return raw.get(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries/${params.entryId}`
+  )
+}
+
+export const getMany: RestEndpoint<'ReleaseEntry', 'getMany'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams & QueryParams & { releaseId: string }
+) => {
+  params.query = { ...params.query, 'sys.schemaVersion': 'Release.V2' }
+
+  return raw.get(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries`
   )
 }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1851,6 +1851,10 @@ export type MRActions = {
       params: GetReleaseEntryParams
       return: EntryProps<any, any>
     }
+    getMany: {
+      params: GetManyReleaseEntryParams
+      return: CollectionProp<EntryProps<any, any>>
+    }
   }
   ReleaseAction: {
     get: {
@@ -2335,6 +2339,11 @@ export type GetReleaseEntryParams = GetSpaceEnvironmentParams & {
   releaseId: string
   entryId: string
 }
+
+export type GetManyReleaseEntryParams = GetSpaceEnvironmentParams & {
+  releaseId: string
+}
+
 export type GetSnapshotForContentTypeParams = GetSpaceEnvironmentParams & { contentTypeId: string }
 export type GetSnapshotForEntryParams = GetSpaceEnvironmentParams & { entryId: string }
 export type GetSpaceEnvAliasParams = GetSpaceParams & { environmentAliasId: string }

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -8,6 +8,7 @@ import type {
   GetBulkActionParams,
   GetContentTypeParams,
   GetEnvironmentTemplateParams,
+  GetManyReleaseEntryParams,
   GetOrganizationMembershipParams,
   GetOrganizationParams,
   GetReleaseEntryParams,
@@ -438,6 +439,24 @@ export type PlainClientAPI = {
               }
             }
           }
+        >
+      >
+      getMany<T extends KeyValueMap = KeyValueMap>(
+        params: OptionalDefaults<GetManyReleaseEntryParams>
+      ): Promise<
+        CollectionProp<
+          EntryProps<
+            T,
+            {
+              release: {
+                sys: {
+                  type: 'Link'
+                  linkType: 'Entry' | 'Asset'
+                  id: string
+                }
+              }
+            }
+          >
         >
       >
     }

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -344,6 +344,7 @@ export const createPlainClient = (
     release: {
       entry: {
         get: wrap(wrapParams, 'ReleaseEntry', 'get'),
+        getMany: wrap(wrapParams, 'ReleaseEntry', 'getMany'),
       },
       archive: wrap(wrapParams, 'Release', 'archive'),
       get: wrap(wrapParams, 'Release', 'get'),

--- a/test/unit/adapters/REST/endpoints/release-entry.test.ts
+++ b/test/unit/adapters/REST/endpoints/release-entry.test.ts
@@ -1,16 +1,12 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { cloneMock } from '../../../mocks/entities'
 import * as raw from '../../../../../lib/adapters/REST/endpoints/raw'
-import { get } from '../../../../../lib/adapters/REST/endpoints/release-entry'
+import { get, getMany } from '../../../../../lib/adapters/REST/endpoints/release-entry'
 import { EntryProps } from '../../../../../lib/entities/entry'
 import { GetReleaseEntryParams } from '../../../../../lib/contentful-management'
 
 describe('Rest ReleaseEntry', () => {
   let mockReleaseEntry: EntryProps<
-    any,
-    { release: { sys: { type: 'Link'; linkType: 'Release'; id: string } } }
-  >
-  let result: EntryProps<
     any,
     { release: { sys: { type: 'Link'; linkType: 'Release'; id: string } } }
   >
@@ -28,7 +24,7 @@ describe('Rest ReleaseEntry', () => {
       releaseId: 'black-friday',
       entryId: 'abc123',
     }
-    result = await get(httpMock, params)
+    await get(httpMock, params)
   })
 
   afterEach(() => {
@@ -42,11 +38,18 @@ describe('Rest ReleaseEntry', () => {
     )
   })
 
-  test('release.entry.get returns the correct entry', async () => {
-    expect(result).toEqual(mockReleaseEntry)
-  })
+  test('release.entry.getMany calls raw.get with the correct URL and params', async () => {
+    const expectedParams = {
+      spaceId: 'space123',
+      environmentId: 'master',
+      releaseId: 'black-friday',
+    }
 
-  test('release.entry.get returns release metadata', async () => {
-    expect(result.sys.release).toBeDefined()
+    await getMany(httpMock, expectedParams)
+
+    expect(rawGetSpy).toHaveBeenCalledWith(
+      httpMock,
+      '/spaces/space123/environments/master/releases/black-friday/entries'
+    )
   })
 })


### PR DESCRIPTION
## Summary
Add support for `client.release.entry.getMany()`.  Calls the endpoint: `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries`



## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [ ] The new method is added to the documentation
