### PR TITLE
fix: removed inapplicable query params and improved AiAction types

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -180,7 +180,7 @@ import type {
   UpdateOAuthApplicationProps,
 } from './entities/oauth-application'
 import type { FunctionLogProps } from './entities/function-log'
-import type { AiActionProps, CreateAiActionProps } from './entities/ai-action'
+import type { AiActionProps, AiActionQueryOptions, CreateAiActionProps } from './entities/ai-action'
 import type {
   AiActionInvocationProps,
   AiActionInvocationType,
@@ -948,7 +948,7 @@ export type MRActions = {
   AiAction: {
     get: { params: GetSpaceParams & { aiActionId: string }; return: AiActionProps }
     getMany: {
-      params: GetSpaceParams & QueryParams
+      params: GetSpaceParams & AiActionQueryOptions
       return: CollectionProp<AiActionProps>
     }
     create: {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -948,7 +948,7 @@ export type MRActions = {
   AiAction: {
     get: { params: GetSpaceParams & { aiActionId: string }; return: AiActionProps }
     getMany: {
-      params: GetSpaceParams & AiActionQueryOptions
+      params: GetSpaceParams & { query: AiActionQueryOptions }
       return: CollectionProp<AiActionProps>
     }
     create: {

--- a/lib/entities/ai-action-invocation.ts
+++ b/lib/entities/ai-action-invocation.ts
@@ -4,17 +4,9 @@ import type { DefaultElements, MakeRequest, SysLink } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import type { Document as RichTextDocument } from '@contentful/rich-text-types'
 
-export enum InvocationStatus {
-  Scheduled = 'SCHEDULED',
-  InProgress = 'IN_PROGRESS',
-  Failed = 'FAILED',
-  Completed = 'COMPLETED',
-  Cancelled = 'CANCELLED',
-}
+export type InvocationStatus = 'SCHEDULED' | 'IN_PROGRESS' | 'FAILED' | 'COMPLETED' | 'CANCELLED'
 
-export enum InvocationResultType {
-  Text = 'text',
-}
+export type InvocationResultType = 'text'
 
 export const AiActionOutputFormat = {
   RichText: 'RichText',

--- a/lib/entities/ai-action.ts
+++ b/lib/entities/ai-action.ts
@@ -1,6 +1,6 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type { DefaultElements, MakeRequest, MetaSysProps } from '../common-types'
+import type { DefaultElements, Link, MakeRequest, MetaSysProps } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 import {
@@ -9,27 +9,17 @@ import {
   type AiActionInvocation,
 } from './ai-action-invocation'
 
-export enum StatusFilter {
-  ALL = 'all',
-  PUBLISHED = 'published',
-}
-
-export enum VariableType {
-  RESOURCE_LINK = 'ResourceLink',
-  TEXT = 'Text',
-  STANDARD_INPUT = 'StandardInput',
-  LOCALE = 'Locale',
-  MEDIA_REFERENCE = 'MediaReference',
-  REFERENCE = 'Reference',
-  SMART_CONTEXT = 'SmartContext',
-}
-
-export enum EntityTypeEntry {
-  ENTRY = 'Entry',
-}
+export type VariableType =
+  | 'ResourceLink'
+  | 'Text'
+  | 'StandardInput'
+  | 'Locale'
+  | 'MediaReference'
+  | 'Reference'
+  | 'SmartContext'
 
 export type ReferenceVariableConfiguration = {
-  allowedEntities: Array<EntityTypeEntry>
+  allowedEntities: Array<'Entry'>
 }
 
 export type VariableConfiguration =
@@ -71,27 +61,19 @@ export type AiActionTestCase =
       }
     }
 
-export type SysLinkUserOrApp = {
-  sys: {
-    id: string
-    linkType: 'User' | 'App'
-    type: 'Link'
-  }
-}
-
 export interface AiActionQueryOptions {
   limit?: number
   skip?: number
-  status?: StatusFilter
+  status?: 'all' | 'published'
 }
 
 export type AiActionProps = {
   sys: MetaSysProps & {
     type: 'AiAction'
     space: { sys: { id: string } }
-    publishedBy?: SysLinkUserOrApp
-    updatedBy: SysLinkUserOrApp
-    createdBy: SysLinkUserOrApp
+    publishedBy?: Link<'User'> | Link<'AppDefinition'>
+    updatedBy: Link<'User'> | Link<'AppDefinition'>
+    createdBy: Link<'User'> | Link<'AppDefinition'>
     publishedVersion?: number
     version: number
     publishedAt?: string


### PR DESCRIPTION
- Use `AiActionQueryOptions` for nested client implementation of `AiAction.getMany`
- Convert `InvocationStatus`, `InvocationResultType`, `VariableType` and `StatusFilter` from enums to string types to improve compatibility (no requirement to import them)
- Use `Link<'User'> | Link<'AppDefinition'>` for subject links in `AiActionProps`