### PR TITLE
chore: add canary build to release/releasev2 branch [DX-212]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,3 +148,4 @@ workflows:
               only:
                 - master
                 - beta
+                - release/releasesv2

--- a/README.md
+++ b/README.md
@@ -417,6 +417,20 @@ This means that new versions are released automatically as fixes, features or br
 
 You can check the changelog on the [releases](https://github.com/contentful/contentful-management.js/releases) page.
 
+## Experimental features
+
+To download a build that has features that are not yet released, you can use the `canary` channel. This is a pre-release version of the library that contains features that are still in development and may not be stable. To install a canary version, you can use the following command:
+
+```bash
+npm install contentful-management@canary
+```
+
+### Current experimental features
+
+#### Timeline Preview / Releases v2
+
+This feature allows you to schedule content changes in the future and preview them before they go live. 
+
 ## Reach out to us
 
 ### You have questions about how to use this library?

--- a/package.json
+++ b/package.json
@@ -142,6 +142,11 @@
         "name": "beta",
         "channel": "beta",
         "prerelease": true
+      },
+      {
+        "name": "release/releasesv2",
+        "channel": "canary",
+        "prerelease": true
       }
     ],
     "plugins": [


### PR DESCRIPTION
This PR will build a canary (experiemental) release and publish it under the canary tag to npm.

I took the direction of keeping this task simple and adding it to the release/releasev2 branch for now, which is where all the current experimental work is. 

If we continue to do canary releases, we should create a new canary branch, and figure out the branching/merging strategy there to keep it up to date and have multiple experiemental features in it.