### PR TITLE
fix: delete entry2 as part of entry integration test cleanup [DX-258]

### DIFF
--- a/test/integration/entry-integration.test.ts
+++ b/test/integration/entry-integration.test.ts
@@ -782,6 +782,9 @@ describe('Entry Api', () => {
       await createEntryClient.entry.delete({
         entryId: entry.sys.id,
       })
+      await createEntryClient.entry.delete({
+        entryId: entry2.sys.id,
+      })
       await timeoutToCalmRateLimiting()
     })
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Our releases integration tests weren't deleting one of the created entries, so that was starting to pile up in our testing space.

## Description

Ensure that both entries are deleted add the end of the test. I validated that the entry was no longer in the space after the latest CI run on this branch.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
