### PR TITLE
feat: add releaseId to DefaultParams type in wrap.ts [EXT-6580]

### DIFF
--- a/lib/plain/wrappers/wrap.ts
+++ b/lib/plain/wrappers/wrap.ts
@@ -4,6 +4,7 @@ export type DefaultParams = {
   spaceId?: string
   environmentId?: string
   organizationId?: string
+  releaseId?: string
 }
 /**
  * @private


### PR DESCRIPTION
## Summary

This pull request enhances the plain client's `DefaultParams` by adding an optional `releaseId` property. This allows the CMA client to be instantiated with a default release context.

## Description

The primary change in this PR is the modification of the `DefaultParams` type in `lib/plain/wrappers/wrap.ts`. I have added `releaseId?: string` to this type definition.

This update enables consuming libraries, such as the `ui-extensions-sdk`, to create a pre-configured CMA client that automatically directs its API requests to the specified release, without needing to add the `releaseId` to every individual API call.

## Motivation and Context

This change is required to improve the developer experience for apps running within Contentful's Releases feature. It directly addresses the requirements of Jira ticket [EXT-6580](https://contentful.atlassian.net/jira/software/c/projects/EXT/boards/38?selectedIssue=EXT-6580).

By allowing a `releaseId` to be set in the client's defaults, we streamline the process for developers, making the SDKs more intuitive and reducing the potential for error when interacting with release-scoped content. This is a foundational step for enabling the `ui-extensions-sdk` to provide a release-aware CMA client.


## Checklist (check all before merging)

- \[x] Both unit and integration tests are passing

* \[x] There are no breaking changes

- \[ ] Changes are reflected in the documentation

When adding a new method:

- \[ ] The new method is exported through the default and plain CMA client

* \[ ] All new public types are exported from `./lib/export-types.ts`

- \[ ] Added a unit test for the new method

* \[ ] Added an integration test for the new method

- \[ ] The new method is added to the documentation


[EXT-6580]: https://contentful.atlassian.net/browse/EXT-6580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ