### PR TITLE
feat: add new endpoints for AppActionCall to fetch structured results [EXT-6593]

### DIFF
--- a/lib/adapters/REST/endpoints/app-action-call.ts
+++ b/lib/adapters/REST/endpoints/app-action-call.ts
@@ -112,7 +112,7 @@ export const createWithResponse: RestEndpoint<'AppActionCall', 'createWithRespon
   return callAppActionResult(http, params, { callId })
 }
 
-// New: Get structured AppActionCall (status/result/error) via new route that includes app installation context
+// Get structured AppActionCall (status/result/error) via new route that includes app installation context
 export const get: RestEndpoint<'AppActionCall', 'get'> = (
   http: AxiosInstance,
   params: GetAppActionCallParamsWithId
@@ -123,7 +123,7 @@ export const get: RestEndpoint<'AppActionCall', 'get'> = (
   )
 }
 
-// New: Get raw AppActionCall response (headers/body) for a completed call
+// Get raw AppActionCall response (headers/body) for a completed call
 export const getResponse: RestEndpoint<'AppActionCall', 'getResponse'> = (
   http: AxiosInstance,
   params: GetAppActionCallParamsWithId
@@ -178,7 +178,7 @@ async function pollStructuredAppActionCall(
   })
 }
 
-// New: Create and poll the structured AppActionCall until completion (succeeded/failed)
+// Create and poll the structured AppActionCall until completion (succeeded/failed)
 export const createWithResult: RestEndpoint<'AppActionCall', 'createWithResult'> = async (
   http: AxiosInstance,
   params: CreateWithResponseParams,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -10,6 +10,7 @@ import type { AppActionProps, CreateAppActionProps } from './entities/app-action
 import type {
   AppActionCallProps,
   AppActionCallResponse,
+  AppActionCallRawResponseProps,
   CreateAppActionCallProps,
 } from './entities/app-action-call'
 import type { AppBundleProps, CreateAppBundleProps } from './entities/app-bundle'
@@ -445,6 +446,12 @@ type MRInternal<UA extends boolean> = {
     'createWithResponse'
   >
   (opts: MROpts<'AppActionCall', 'getCallDetails', UA>): MRReturn<'AppActionCall', 'getCallDetails'>
+  (opts: MROpts<'AppActionCall', 'get', UA>): MRReturn<'AppActionCall', 'get'>
+  (opts: MROpts<'AppActionCall', 'createWithResult', UA>): MRReturn<
+    'AppActionCall',
+    'createWithResult'
+  >
+  (opts: MROpts<'AppActionCall', 'getResponse', UA>): MRReturn<'AppActionCall', 'getResponse'>
 
   (opts: MROpts<'AppBundle', 'get', UA>): MRReturn<'AppBundle', 'get'>
   (opts: MROpts<'AppBundle', 'getMany', UA>): MRReturn<'AppBundle', 'getMany'>
@@ -1015,6 +1022,10 @@ export type MRActions = {
       payload: CreateAppActionCallProps
       return: AppActionCallProps
     }
+    get: {
+      params: GetAppActionCallParamsWithId
+      return: AppActionCallProps
+    }
     getCallDetails: {
       params: GetAppActionCallDetailsParams
       return: AppActionCallResponse
@@ -1023,6 +1034,15 @@ export type MRActions = {
       params: GetAppActionCallParams
       payload: CreateAppActionCallProps
       return: AppActionCallResponse
+    }
+    createWithResult: {
+      params: CreateWithResponseParams
+      payload: CreateAppActionCallProps
+      return: AppActionCallProps
+    }
+    getResponse: {
+      params: GetAppActionCallParamsWithId
+      return: AppActionCallRawResponseProps
     }
   }
   AppBundle: {
@@ -2297,6 +2317,9 @@ export type GetAppActionCallDetailsParams = GetSpaceEnvironmentParams & {
   appActionId: string
   callId: string
 }
+
+// New route params for fetching structured call or raw response
+export type GetAppActionCallParamsWithId = GetAppActionCallParams & { callId: string }
 export type GetAppBundleParams = GetAppDefinitionParams & { appBundleId: string }
 export type GetAppDefinitionParams = GetOrganizationParams & { appDefinitionId: string }
 export type GetAppInstallationsForOrgParams = GetOrganizationParams & {

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -11,7 +11,10 @@ import type { BasicQueryOptions, MakeRequest } from './common-types'
 import entities from './entities'
 import type { CreateAppInstallationProps } from './entities/app-installation'
 import type { CreateAppSignedRequestProps } from './entities/app-signed-request'
-import type { CreateAppActionCallProps } from './entities/app-action-call'
+import type {
+  CreateAppActionCallProps,
+  AppActionCallRawResponseProps,
+} from './entities/app-action-call'
 import type {
   AssetFileProp,
   AssetProps,
@@ -1596,6 +1599,46 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
         },
         payload: data,
       }).then((payload) => wrapAppActionCall(makeRequest, payload))
+    },
+
+    /**
+     * Gets the raw response (headers/body) for a completed App Action Call
+     * @param appDefinitionId - AppDefinition ID
+     * @param appActionId - App Action ID
+     * @param callId - App Action Call ID
+     * @return Promise for the raw response object including `response.body` and optional `response.headers`
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client
+     *   .getSpace('<space_id>')
+     *   .then((space) => space.getEnvironment('<environment_id>'))
+     *   .then((environment) => environment.getAppActionCallResponse('<app_definition_id>', '<app_action_id>', '<call_id>'))
+     *   .then((raw) => console.log(raw.response.body))
+     *   .catch(console.error)
+     * ```
+     */
+    getAppActionCallResponse(
+      appDefinitionId: string,
+      appActionId: string,
+      callId: string
+    ): Promise<AppActionCallRawResponseProps> {
+      const raw = this.toPlainObject() as EnvironmentProps
+      return makeRequest({
+        entityType: 'AppActionCall',
+        action: 'getResponse',
+        params: {
+          spaceId: raw.sys.space.sys.id,
+          environmentId: raw.sys.id,
+          appDefinitionId,
+          appActionId,
+          callId,
+        },
+      })
     },
     /**
      * Creates an app signed request

--- a/lib/entities/app-action-call.ts
+++ b/lib/entities/app-action-call.ts
@@ -16,20 +16,36 @@ type AppActionCallSys = Except<BasicMetaSysProps, 'version'> & {
   space: SysLink
   environment: SysLink
   action: SysLink
+  appActionCallResponse?: SysLink
 }
 
 type RetryOptions = Pick<CreateWithResponseParams, 'retries' | 'retryInterval'>
+
+export type AppActionCallStatus = 'processing' | 'succeeded' | 'failed'
+
+export interface AppActionCallErrorProps {
+  sys: { type: 'Error'; id: string }
+  message: string
+  details?: Record<string, unknown>
+  statusCode?: number
+}
 
 export type AppActionCallProps = {
   /**
    * System metadata
    */
   sys: AppActionCallSys
+  /** The execution status of the app action call, if available */
+  status?: AppActionCallStatus
+  /** Structured result when execution succeeded */
+  result?: unknown
+  /** Structured error when execution failed */
+  error?: AppActionCallErrorProps
 }
 
 export type CreateAppActionCallProps = {
   /** The body for the call */
-  parameters: { [key: string]: any }
+  parameters: { [key: string]: unknown }
 }
 
 type AppActionCallApi = {
@@ -38,6 +54,23 @@ type AppActionCallApi = {
 }
 
 export type AppActionCallResponse = WebhookCallDetailsProps
+
+// Raw App Action call response (new endpoint). Not yet wired to runtime behavior.
+export interface AppActionCallRawResponseProps {
+  sys: {
+    id: string
+    type: 'AppActionCallResponse'
+    space: SysLink
+    environment: SysLink
+    appInstallation: SysLink
+    appAction: SysLink
+    createdAt: string
+  }
+  response: {
+    headers?: { contentType?: string }
+    body: string
+  }
+}
 
 export interface AppActionCallResponseData
   extends AppActionCallResponse,

--- a/lib/entities/app-action-call.ts
+++ b/lib/entities/app-action-call.ts
@@ -51,6 +51,8 @@ export type CreateAppActionCallProps = {
 type AppActionCallApi = {
   createWithResponse(): Promise<AppActionCallResponse>
   getCallDetails(): Promise<AppActionCallResponse>
+  get(): Promise<AppActionCallProps>
+  createWithResult(): Promise<AppActionCallProps>
 }
 
 export type AppActionCallResponse = WebhookCallDetailsProps
@@ -120,6 +122,42 @@ export default function createAppActionCallApi(
           appActionId: 'app-action-id',
         },
       }).then((data) => wrapAppActionCallResponse(makeRequest, data))
+    },
+
+    get: function get() {
+      return makeRequest({
+        entityType: 'AppActionCall',
+        action: 'get',
+        params: {
+          spaceId: 'space-id',
+          environmentId: 'environment-id',
+          appDefinitionId: 'app-definiton-id',
+          appActionId: 'app-action-id',
+          callId: 'call-id',
+        },
+      }).then((data) => wrapAppActionCall(makeRequest, data))
+    },
+
+    createWithResult: function () {
+      const payload: CreateAppActionCallProps = {
+        parameters: {
+          recipient: 'Alice <alice@my-company.com>',
+          message_body: 'Hello from Bob!',
+        },
+      }
+
+      return makeRequest({
+        entityType: 'AppActionCall',
+        action: 'createWithResult',
+        params: {
+          spaceId: 'space-id',
+          environmentId: 'environment-id',
+          appDefinitionId: 'app-definiton-id',
+          appActionId: 'app-action-id',
+          ...retryOptions,
+        },
+        payload: payload,
+      }).then((data) => wrapAppActionCall(makeRequest, data))
     },
   }
 }

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -24,6 +24,9 @@ export type {
 export type {
   AppActionCall,
   AppActionCallProps,
+  AppActionCallErrorProps,
+  AppActionCallRawResponseProps,
+  AppActionCallStatus,
   CreateAppActionCallProps,
 } from './entities/app-action-call'
 export type {

--- a/lib/plain/entities/app-action-call.ts
+++ b/lib/plain/entities/app-action-call.ts
@@ -1,7 +1,12 @@
-import type { GetAppActionCallDetailsParams, GetAppActionCallParams } from '../../common-types'
+import type {
+  GetAppActionCallDetailsParams,
+  GetAppActionCallParams,
+  GetAppActionCallParamsWithId,
+} from '../../common-types'
 import type {
   AppActionCallProps,
   AppActionCallResponse,
+  AppActionCallRawResponseProps,
   CreateAppActionCallProps,
 } from '../../entities/app-action-call'
 import type { OptionalDefaults } from '../wrappers/wrap'
@@ -75,4 +80,94 @@ export type AppActionCallPlainClientAPI = {
     params: OptionalDefaults<GetAppActionCallParams>,
     payload: CreateAppActionCallProps
   ): Promise<AppActionCallResponse>
+
+  /**
+   * Fetches a structured App Action Call by id.
+   *
+   * Returns the RFC-aligned shape for an app action invocation including
+   * `status` ("processing" | "succeeded" | "failed"), and either
+   * `result` (on success) or `error` (on failure).
+   *
+   * @param params Entity IDs to identify the App Action Call
+   * @returns A structured `AppActionCall` object with `status`, `result` or `error`
+   * @throws if the request fails, or the App Action Call is not found
+   * @example
+   * ```javascript
+   * const call = await client.appActionCall.get({
+   *   spaceId: "<space_id>",
+   *   environmentId: "<environment_id>",
+   *   appDefinitionId: "<app_definition_id>",
+   *   appActionId: "<app_action_id>",
+   *   callId: "<call_id>",
+   * });
+   * if (call.status === 'succeeded') {
+   *   console.log(call.result);
+   * } else if (call.status === 'failed') {
+   *   console.error(call.error);
+   * }
+   * ```
+   */
+  get(params: OptionalDefaults<GetAppActionCallParamsWithId>): Promise<AppActionCallProps>
+
+  /**
+   * Calls (triggers) an App Action and resolves with the structured result.
+   *
+   * This method abstracts away polling. It creates an app action call and then
+   * polls the structured call route until `status` becomes either
+   * `"succeeded"` (returns with `result`) or `"failed"` (returns with `error`).
+   * If the call does not complete within the default retry policy, it rejects.
+   *
+   * @param params Entity IDs to identify the App Action to call
+   * @param payload Parameters to send to the App Action
+   * @returns A completed structured `AppActionCall` with `status`, `result` or `error`
+   * @throws if the request fails, or the call does not complete in time
+   * @example
+   * ```javascript
+   * const call = await client.appActionCall.createWithResult(
+   *   {
+   *     spaceId: "<space_id>",
+   *     environmentId: "<environment_id>",
+   *     appDefinitionId: "<app_definition_id>",
+   *     appActionId: "<app_action_id>",
+   *   },
+   *   {
+   *     parameters: { // your inputs },
+   *   }
+   * );
+   * if (call.status === 'succeeded') {
+   *   console.log(call.result);
+   * } else {
+   *   console.error(call.error);
+   * }
+   * ```
+   */
+  createWithResult(
+    params: OptionalDefaults<GetAppActionCallParams>,
+    payload: CreateAppActionCallProps
+  ): Promise<AppActionCallProps>
+
+  /**
+   * Fetches the raw response (headers/body) for a completed App Action Call.
+   *
+   * Use this when you need access to the unparsed executor response. For most
+   * use cases, prefer the structured call via `get` or `createWithResult`.
+   *
+   * @param params Entity IDs to identify the App Action Call
+   * @returns The raw response including serialized `body` and optional `headers`
+   * @throws if the request fails, or the App Action Call is not found
+   * @example
+   * ```javascript
+   * const raw = await client.appActionCall.getResponse({
+   *   spaceId: "<space_id>",
+   *   environmentId: "<environment_id>",
+   *   appDefinitionId: "<app_definition_id>",
+   *   appActionId: "<app_action_id>",
+   *   callId: "<call_id>",
+   * });
+   * console.log(raw.response.body);
+   * ```
+   */
+  getResponse(
+    params: OptionalDefaults<GetAppActionCallParamsWithId>
+  ): Promise<AppActionCallRawResponseProps>
 }

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -83,6 +83,9 @@ export const createPlainClient = (
       create: wrap(wrapParams, 'AppActionCall', 'create'),
       getCallDetails: wrap(wrapParams, 'AppActionCall', 'getCallDetails'),
       createWithResponse: wrap(wrapParams, 'AppActionCall', 'createWithResponse'),
+      get: wrap(wrapParams, 'AppActionCall', 'get'),
+      createWithResult: wrap(wrapParams, 'AppActionCall', 'createWithResult'),
+      getResponse: wrap(wrapParams, 'AppActionCall', 'getResponse'),
     },
     appBundle: {
       get: wrap(wrapParams, 'AppBundle', 'get'),

--- a/test/integration/app-action-call-structured-integration.test.ts
+++ b/test/integration/app-action-call-structured-integration.test.ts
@@ -1,0 +1,95 @@
+import { expect, describe, test, beforeAll, afterAll } from 'vitest'
+import type { PlainClientAPI, AppActionCallProps } from '../../lib/contentful-management'
+import {
+  initPlainClient,
+  getTestOrganization,
+  getDefaultSpace,
+  createAppInstallation,
+  timeoutToCalmRateLimiting,
+} from '../helpers'
+
+describe('AppActionCall structured endpoints', function () {
+  let client: PlainClientAPI
+  let organization
+  let space
+  let appDefinition
+
+  beforeAll(async () => {
+    organization = await getTestOrganization()
+    space = await getDefaultSpace()
+
+    // Create an app definition for installation context
+    appDefinition = await organization.createAppDefinition({
+      name: 'Structured AppActionCall Test',
+    })
+
+    client = initPlainClient({
+      spaceId: space.sys.id,
+      environmentId: 'master',
+    })
+
+    await createAppInstallation(appDefinition.sys.id)
+  })
+
+  afterAll(async () => {
+    if (appDefinition) {
+      await client.appInstallation.delete({ appDefinitionId: appDefinition.sys.id })
+      await appDefinition.delete()
+    }
+  })
+
+  afterAll(timeoutToCalmRateLimiting)
+
+  test('createWithResult returns a completed structured AppActionCall', async () => {
+    // This assumes an existing action configured to return quickly in the test env
+    const appActionId = 'test-action'
+
+    const call: AppActionCallProps = await client.appActionCall.createWithResult(
+      {
+        spaceId: space.sys.id,
+        environmentId: 'master',
+        appDefinitionId: appDefinition.sys.id,
+        appActionId,
+      },
+      { parameters: {} }
+    )
+
+    expect(['succeeded', 'failed', 'processing']).toContain(call.status)
+  })
+
+  test('get and getResponse endpoints are reachable for a known call id', async () => {
+    const appActionId = 'test-action'
+
+    const created = await client.appActionCall.create(
+      {
+        spaceId: space.sys.id,
+        environmentId: 'master',
+        appDefinitionId: appDefinition.sys.id,
+        appActionId,
+      },
+      { parameters: {} }
+    )
+
+    const call = await client.appActionCall.get({
+      spaceId: space.sys.id,
+      environmentId: 'master',
+      appDefinitionId: appDefinition.sys.id,
+      appActionId,
+      callId: created.sys.id,
+    })
+
+    expect(call.sys.type).toBe('AppActionCall')
+
+    const raw = await client.appActionCall.getResponse({
+      spaceId: space.sys.id,
+      environmentId: 'master',
+      appDefinitionId: appDefinition.sys.id,
+      appActionId,
+      callId: created.sys.id,
+    })
+
+    expect(raw.sys.type).toBe('AppActionCallResponse')
+  })
+})
+
+

--- a/test/integration/app-action-call-structured-integration.test.ts
+++ b/test/integration/app-action-call-structured-integration.test.ts
@@ -35,6 +35,12 @@ describe('AppActionCall structured endpoints', function () {
 
     await createAppInstallation(appDefinition.sys.id)
 
+    // Ensure the App Signing Secret exists to allow invoking App Action Calls
+    await client.appSigningSecret.upsert(
+      { organizationId: organization.sys.id, appDefinitionId: appDefinition.sys.id },
+      { value: 'q_Oly53ipVRUxyoBmkG0MITMR9oca9wPsXOpsQ-bWdndmWwc_xT3AIJrJ_yWwI74' }
+    )
+
     // Create an App Action to target in this suite
     appAction = await client.appAction.create(
       { organizationId: organization.sys.id, appDefinitionId: appDefinition.sys.id },
@@ -49,6 +55,11 @@ describe('AppActionCall structured endpoints', function () {
 
   afterAll(async () => {
     if (appDefinition) {
+      // Clean up signing secret and installation
+      await client.appSigningSecret.delete({
+        organizationId: organization.sys.id,
+        appDefinitionId: appDefinition.sys.id,
+      })
       await client.appInstallation.delete({ appDefinitionId: appDefinition.sys.id })
       if (appAction) {
         await client.appAction.delete({

--- a/test/integration/app-action-call-structured-integration.test.ts
+++ b/test/integration/app-action-call-structured-integration.test.ts
@@ -91,5 +91,3 @@ describe('AppActionCall structured endpoints', function () {
     expect(raw.sys.type).toBe('AppActionCallResponse')
   })
 })
-
-

--- a/test/unit/adapters/REST/endpoints/app-action-call.test.ts
+++ b/test/unit/adapters/REST/endpoints/app-action-call.test.ts
@@ -4,6 +4,7 @@ import setupRestAdapter from '../helpers/setupRestAdapter'
 
 import type { CreateAppActionCallProps } from '../../../../../lib/entities/app-action-call'
 import { wrapAppActionCallResponse } from '../../../../../lib/entities/app-action-call'
+import * as rest from '../../../../../lib/adapters/REST/endpoints/app-action-call'
 import type { MakeRequest, MakeRequestOptions } from '../../../../../lib/export-types'
 
 function setup(promise, mockName, params = {}) {
@@ -15,6 +16,188 @@ function setup(promise, mockName, params = {}) {
 }
 
 describe('Rest App Action Call', { concurrent: true }, () => {
+  it('should get structured App Action Call via new route', async () => {
+    const structuredCall: any = {
+      sys: { id: 'call-id', type: 'AppActionCall' },
+      status: 'processing',
+    }
+
+    const { httpMock } = setup(Promise.resolve({ data: structuredCall }), 'appActionCallResponse')
+
+    const result = await rest.get(httpMock as any, {
+      spaceId: 'space-id',
+      environmentId: 'environment-id',
+      appDefinitionId: 'app-definiton-id',
+      appActionId: 'app-action-id',
+      callId: 'call-id',
+    })
+
+    expect(result).to.deep.equal(structuredCall)
+    expect(httpMock.get.mock.calls[0][0]).toBe(
+      `/spaces/space-id/environments/environment-id/app_installations/app-definiton-id/actions/app-action-id/calls/call-id`
+    )
+  })
+
+  it('should get raw response via new route', async () => {
+    const rawResponse: any = {
+      sys: { id: 'call-id', type: 'AppActionCallResponse' },
+      response: { body: 'OK', headers: { contentType: 'application/json' } },
+    }
+
+    const { httpMock } = setup(Promise.resolve({ data: rawResponse }), 'appActionCallResponse')
+
+    const result = await rest.getResponse(httpMock as any, {
+      spaceId: 'space-id',
+      environmentId: 'environment-id',
+      appDefinitionId: 'app-definiton-id',
+      appActionId: 'app-action-id',
+      callId: 'call-id',
+    })
+
+    expect(result).to.deep.equal(rawResponse)
+    expect(httpMock.get.mock.calls[0][0]).toBe(
+      `/spaces/space-id/environments/environment-id/app_installations/app-definiton-id/actions/app-action-id/calls/call-id/response`
+    )
+  })
+
+  it('should create with result and poll until completion', async () => {
+    // First POST returns the created call with sys.id; then GET returns processing, then succeeded
+    const createdCall: any = { sys: { id: 'call-id', type: 'AppActionCall' } }
+    const processing: any = { sys: { id: 'call-id', type: 'AppActionCall' }, status: 'processing' }
+    const succeeded: any = {
+      sys: { id: 'call-id', type: 'AppActionCall' },
+      status: 'succeeded',
+      result: { ok: true },
+    }
+
+    const { httpMock } = setup(Promise.resolve({ data: createdCall }), 'appActionCallResponse')
+
+    httpMock.get
+      .mockImplementationOnce(() => Promise.resolve({ data: processing }))
+      .mockImplementationOnce(() => Promise.resolve({ data: succeeded }))
+
+    const result = await rest.createWithResult(
+      httpMock as any,
+      {
+        spaceId: 'space-id',
+        environmentId: 'environment-id',
+        appDefinitionId: 'app-definiton-id',
+        appActionId: 'app-action-id',
+        retryInterval: 10,
+        retries: 5,
+      },
+      { parameters: {} }
+    )
+
+    expect(result).to.deep.equal(succeeded)
+
+    expect(httpMock.post.mock.calls[0][0]).toBe(
+      `/spaces/space-id/environments/environment-id/app_installations/app-definiton-id/actions/app-action-id/calls`
+    )
+
+    expect(
+      httpMock.get.mock.calls.filter((call) =>
+        call.includes(
+          `/spaces/space-id/environments/environment-id/app_installations/app-definiton-id/actions/app-action-id/calls/call-id`
+        )
+      )
+    ).toHaveLength(2)
+  })
+
+  it('createWithResult times out when status stays processing', async () => {
+    const createdCall: any = { sys: { id: 'call-id', type: 'AppActionCall' } }
+    const processing: any = { sys: { id: 'call-id', type: 'AppActionCall' }, status: 'processing' }
+
+    const { httpMock } = setup(Promise.resolve({ data: createdCall }), 'appActionCallResponse')
+
+    // Always return processing to trigger timeout
+    httpMock.get.mockImplementation(() => Promise.resolve({ data: processing }))
+
+    const numRetries = 4
+
+    await expect(
+      rest.createWithResult(
+        httpMock as any,
+        {
+          spaceId: 'space-id',
+          environmentId: 'environment-id',
+          appDefinitionId: 'app-definiton-id',
+          appActionId: 'app-action-id',
+          retryInterval: 5,
+          retries: numRetries,
+        },
+        { parameters: {} }
+      )
+    ).rejects.toThrow('The app action result is taking longer than expected to process.')
+
+    expect(
+      httpMock.get.mock.calls.filter((call) =>
+        call.includes(
+          `/spaces/space-id/environments/environment-id/app_installations/app-definiton-id/actions/app-action-id/calls/call-id`
+        )
+      )
+    ).toHaveLength(numRetries)
+  })
+
+  it('createWithResult resolves with failed status and error intact', async () => {
+    const createdCall: any = { sys: { id: 'call-id', type: 'AppActionCall' } }
+    const failed: any = {
+      sys: { id: 'call-id', type: 'AppActionCall' },
+      status: 'failed',
+      error: { sys: { type: 'Error', id: 'ValidationError' }, message: 'invalid' },
+    }
+
+    const { httpMock } = setup(Promise.resolve({ data: createdCall }), 'appActionCallResponse')
+    httpMock.get.mockImplementationOnce(() => Promise.resolve({ data: failed }))
+
+    const result = await rest.createWithResult(
+      httpMock as any,
+      {
+        spaceId: 'space-id',
+        environmentId: 'environment-id',
+        appDefinitionId: 'app-definiton-id',
+        appActionId: 'app-action-id',
+        retryInterval: 5,
+        retries: 3,
+      },
+      { parameters: {} }
+    )
+
+    expect(result).to.deep.equal(failed)
+  })
+
+  it('createWithResult retries on thrown GET errors then times out', async () => {
+    const createdCall: any = { sys: { id: 'call-id', type: 'AppActionCall' } }
+    const { httpMock } = setup(Promise.resolve({ data: createdCall }), 'appActionCallResponse')
+
+    httpMock.get.mockRejectedValue(new Error('not ready'))
+
+    const numRetries = 3
+
+    await expect(
+      rest.createWithResult(
+        httpMock as any,
+        {
+          spaceId: 'space-id',
+          environmentId: 'environment-id',
+          appDefinitionId: 'app-definiton-id',
+          appActionId: 'app-action-id',
+          retryInterval: 5,
+          retries: numRetries,
+        },
+        { parameters: {} }
+      )
+    ).rejects.toThrow('The app action result is taking longer than expected to process.')
+
+    expect(
+      httpMock.get.mock.calls.filter((call) =>
+        call.includes(
+          `/spaces/space-id/environments/environment-id/app_installations/app-definiton-id/actions/app-action-id/calls/call-id`
+        )
+      )
+    ).toHaveLength(numRetries)
+  })
+
   it('should create a new App Action Call', async () => {
     const responseMock = cloneMock('appActionCallResponse')
 
@@ -174,6 +357,10 @@ describe('Rest App Action Call', { concurrent: true }, () => {
     responseMock.statusCode = 200
     responseMock.response = {
       statusCode: 404,
+      url: '',
+      method: '',
+      headers: {},
+      body: '',
     }
 
     const { httpMock, adapterMock, entityMock } = setup(
@@ -233,6 +420,10 @@ describe('Rest App Action Call', { concurrent: true }, () => {
     responseMock.statusCode = 200
     responseMock.response = {
       statusCode: 500,
+      url: '',
+      method: '',
+      headers: {},
+      body: '',
     }
 
     const { httpMock, adapterMock, entityMock } = setup(

--- a/test/unit/create-environment-api.test.ts
+++ b/test/unit/create-environment-api.test.ts
@@ -34,6 +34,7 @@ import { wrapAsset } from '../../lib/entities/asset'
 import { wrapTagCollection } from '../../lib/entities/tag'
 import setupMakeRequest from './mocks/makeRequest'
 import createEnvironmentApi from '../../lib/create-environment-api'
+import { AppActionCallRawResponseProps } from '../../lib/entities/app-action-call'
 
 function setup<T>(promise: Promise<T>) {
   const entitiesMock = setupEntitiesMock()
@@ -537,6 +538,38 @@ describe('A createEnvironmentApi', () => {
   test('API call createAppActionCall fails', async () => {
     return makeEntityMethodFailingTest(setup, {
       methodToTest: 'createAppActionCall',
+    })
+  })
+
+  test('API call getAppActionCallResponse', async () => {
+    const rawResponse: AppActionCallRawResponseProps = {
+      sys: {
+        id: 'call-1',
+        type: 'AppActionCallResponse',
+        space: { sys: { type: 'Link', linkType: 'Space', id: 'spaceId' } },
+        environment: { sys: { type: 'Link', linkType: 'Environment', id: 'envId' } },
+        appInstallation: { sys: { type: 'Link', linkType: 'AppInstallation', id: 'appDef' } },
+        appAction: { sys: { type: 'Link', linkType: 'AppAction', id: 'actionId' } },
+        createdAt: new Date().toISOString(),
+      },
+      response: { body: '{"ok":true}' },
+    }
+
+    const { api, makeRequest } = setup(Promise.resolve(rawResponse))
+
+    const result = await api.getAppActionCallResponse('appDef', 'actionId', 'call-1')
+
+    expect(result).to.eql(rawResponse)
+    expect(makeRequest).toHaveBeenCalledWith({
+      entityType: 'AppActionCall',
+      action: 'getResponse',
+      params: {
+        spaceId: environmentMock.sys.space.sys.id,
+        environmentId: environmentMock.sys.id,
+        appDefinitionId: 'appDef',
+        appActionId: 'actionId',
+        callId: 'call-1',
+      },
     })
   })
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Add structured App Action Call support and a convenient polling-abstracting method:
- New REST endpoints: `get` (structured call), `getResponse` (raw response), `createWithResult` (create + poll).
- Plain client API exposure with JSDocs for the new structured/response flows.
- Default client methods added for structured flow and raw response.
- Types updated to model status/result/error per RFC.
- Unit and integration tests for success, timeout, failure, transient error and endpoint paths.

## Description

### Types
- Extend `AppActionCallProps` with:
  - `status: 'processing' | 'succeeded' | 'failed'`
  - `result?: unknown`
  - `error?: { sys: { type: 'Error'; id: string }, message: string, details?: Record<string, unknown>, statusCode?: number }`
- Extend `AppActionCallSys` with `appActionCallResponse?: SysLink`.
- Add `AppActionCallRawResponseProps` (raw headers/body envelope).
- Update `CreateAppActionCallProps.parameters` to `{ [key: string]: unknown }`.

### REST adapter (`lib/adapters/REST/endpoints/app-action-call.ts`)
- `get`: GET new route (includes app installation id) returning structured `AppActionCall`:
  `/spaces/{spaceId}/environments/{environmentId}/app_installations/{appDefinitionId}/actions/{appActionId}/calls/{callId}`
- `getResponse`: GET raw response for a call:
  `/spaces/{spaceId}/environments/{environmentId}/app_installations/{appDefinitionId}/actions/{appActionId}/calls/{callId}/response`
- `createWithResult`: POST create + poll `get` until terminal status, returning completed `AppActionCall`.
  - Default retry policy: 15 retries, 2000ms interval; overridable via `retries`/`retryInterval`.
  - Transient GET errors (e.g., propagation/404) re-poll; terminal 4xx/5xx in nested response stop polling.

### Common types (`lib/common-types.ts`)
- Add `GetAppActionCallParamsWithId` (new route includes `callId`).
- Add/extend `CreateWithResponseParams` with optional `retries` and `retryInterval`.
- Extend `MRActions`/`MRInternal` overloads for:
  - `AppActionCall.get`, `AppActionCall.getResponse`, `AppActionCall.createWithResult`.

### Plain client (`lib/plain/entities/app-action-call.ts`, `lib/plain/plain-client.ts`)
- Add methods (with JSDocs and examples):
  - `get(params): Promise<AppActionCallProps>`
  - `createWithResult(params, payload): Promise<AppActionCallProps>`
  - `getResponse(params): Promise<AppActionCallRawResponseProps>`
- Existing `create`, `getCallDetails`, `createWithResponse` remain available.

### Default client
- Entity API (`lib/entities/app-action-call.ts`)
  - Add methods:
    - `get(): Promise<AppActionCallProps>`
    - `createWithResult(): Promise<AppActionCallProps>`
  - Existing `createWithResponse()` and `getCallDetails()` remain available.
- Environment API (`lib/create-environment-api.ts`)
  - Add `getAppActionCallResponse(appDefinitionId, appActionId, callId): Promise<AppActionCallRawResponseProps>`
    - Calls `makeRequest({ entityType: 'AppActionCall', action: 'getResponse', ... })`.

### Exports (`lib/export-types.ts`)
- Export new public types:
  - `AppActionCallErrorProps`
  - `AppActionCallRawResponseProps`
  - `AppActionCallStatus`

### Tests
- Unit tests covering:
  - Success path (processing → succeeded)
  - Failure path (failed with structured error)
  - Timeout when status remains processing
  - Thrown GET errors leading to timeout
  - Correct paths for new endpoints (`get`, `getResponse`) and polling
  - Default client environment method: `getAppActionCallResponse` calls correct endpoint
- Integration tests for the structured flow (`test/integration/app-action-call-structured-integration.test.ts`)
  - Includes increased retries/intervals and retry loop for `get` to handle eventual consistency
  - Configures `AppSigningSecret` and creates an `AppAction` to satisfy backend requirements

## Motivation and Context

- Jira:
  - Convenient SDK Method for App Action Results — [EXT-6593](https://contentful.atlassian.net/browse/EXT-6593)
  - Convenient SDK Method for Raw Response — [EXT-6735](https://contentful.atlassian.net/browse/EXT-6735)

This change provides a simple, predictable way for developers and Automations/Workflows to invoke App Actions and work with structured outcomes without manual polling, and to retrieve the raw executor response when needed.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes (changes are additive; legacy methods remain)
- [x] Changes are reflected in the documentation
  - JSDocs added to public methods in this repo
  - API blueprint and developer docs updated in `doc-app` (separate PR to be opened)

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
  - Plain client: `get`, `createWithResult`, `getResponse`
  - Default client (entity API): `get`, `createWithResult`
  - Default client (environment API): `getAppActionCallResponse`
- [x] All new public types are exported from `./lib/export-types.ts`
  - `AppActionCallRawResponseProps`, `AppActionCallErrorProps`, `AppActionCallStatus`
- [x] Added a unit test for the new method(s)
- [x] Added an integration test for the structured-flow method(s)
- [x] The new method(s) are added to the documentation
  - Developer docs and API blueprint prepared in `doc-app`; to be merged separately

[EXT-6593]: https://contentful.atlassian.net/browse/EXT-6593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ