### PR TITLE
feat: add release.entry.createWithId method [DX-61]

### DIFF
--- a/lib/adapters/REST/endpoints/release-entry.ts
+++ b/lib/adapters/REST/endpoints/release-entry.ts
@@ -1,11 +1,12 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import type {
   GetReleaseEntryParams,
-  GetSpaceEnvironmentParams,
+  GetManyReleaseEntryParams,
   KeyValueMap,
   PatchReleaseEntryParams,
   QueryParams,
   UpdateReleaseEntryParams,
+  CreateWithIdReleaseEntryParams,
 } from '../../../common-types'
 import type { CreateEntryProps, EntryProps } from '../../../entities/entry'
 import copy from 'fast-copy'
@@ -28,7 +29,7 @@ export const get: RestEndpoint<'ReleaseEntry', 'get'> = (
 
 export const getMany: RestEndpoint<'ReleaseEntry', 'getMany'> = (
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & QueryParams & { releaseId: string }
+  params: GetManyReleaseEntryParams & QueryParams
 ) => {
   params.query = { ...params.query, 'sys.schemaVersion': 'Release.V2' }
 
@@ -40,7 +41,7 @@ export const getMany: RestEndpoint<'ReleaseEntry', 'getMany'> = (
 
 export const update: RestEndpoint<'ReleaseEntry', 'update'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: UpdateReleaseEntryParams & { entryId: string } & QueryParams & { releaseId: string },
+  params: UpdateReleaseEntryParams & QueryParams,
   rawData: EntryProps<T>,
   headers?: RawAxiosRequestHeaders
 ) => {
@@ -75,10 +76,7 @@ export const update: RestEndpoint<'ReleaseEntry', 'update'> = <T extends KeyValu
 
 export const patch: RestEndpoint<'ReleaseEntry', 'patch'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: PatchReleaseEntryParams & {
-    entryId: string
-    version: number
-  } & QueryParams,
+  params: PatchReleaseEntryParams & QueryParams,
   data: OpPatch[],
   headers?: RawAxiosRequestHeaders
 ) => {
@@ -101,11 +99,7 @@ export const createWithId: RestEndpoint<'ReleaseEntry', 'createWithId'> = <
   T extends KeyValueMap = KeyValueMap
 >(
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & {
-    releaseId: string
-    entryId: string
-    contentTypeId: string
-  } & QueryParams,
+  params: CreateWithIdReleaseEntryParams & QueryParams,
   rawData: CreateEntryProps<T>,
   headers?: RawAxiosRequestHeaders
 ) => {

--- a/lib/adapters/REST/endpoints/release-entry.ts
+++ b/lib/adapters/REST/endpoints/release-entry.ts
@@ -7,7 +7,7 @@ import type {
   QueryParams,
   UpdateReleaseEntryParams,
 } from '../../../common-types'
-import type { EntryProps } from '../../../entities/entry'
+import type { CreateEntryProps, EntryProps } from '../../../entities/entry'
 import copy from 'fast-copy'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
@@ -91,6 +91,47 @@ export const patch: RestEndpoint<'ReleaseEntry', 'patch'> = <T extends KeyValueM
       headers: {
         'X-Contentful-Version': params.version,
         'Content-Type': 'application/json-patch+json',
+        ...headers,
+      },
+    }
+  )
+}
+
+export const createWithId: RestEndpoint<'ReleaseEntry', 'createWithId'> = <
+  T extends KeyValueMap = KeyValueMap
+>(
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams & {
+    releaseId: string
+    entryId: string
+    contentTypeId: string
+  } & QueryParams,
+  rawData: CreateEntryProps<T>,
+  headers?: RawAxiosRequestHeaders
+) => {
+  params.query = { ...params.query, 'sys.schemaVersion': 'Release.V2' }
+  const data = copy(rawData)
+
+  return raw.put<
+    EntryProps<
+      T,
+      {
+        release: {
+          sys: {
+            type: 'Link'
+            linkType: 'Entry' | 'Asset'
+            id: string
+          }
+        }
+      }
+    >
+  >(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries/${params.entryId}`,
+    data,
+    {
+      headers: {
+        'X-Contentful-Content-Type': params.contentTypeId,
         ...headers,
       },
     }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -714,6 +714,13 @@ type MRInternal<UA extends boolean> = {
     'ReleaseAction',
     'queryForRelease'
   >
+
+  (opts: MROpts<'ReleaseEntry', 'get', UA>): MRReturn<'ReleaseEntry', 'get'>
+  (opts: MROpts<'ReleaseEntry', 'getMany', UA>): MRReturn<'ReleaseEntry', 'getMany'>
+  (opts: MROpts<'ReleaseEntry', 'update', UA>): MRReturn<'ReleaseEntry', 'update'>
+  (opts: MROpts<'ReleaseEntry', 'patch', UA>): MRReturn<'ReleaseEntry', 'patch'>
+  (opts: MROpts<'ReleaseEntry', 'createWithId', UA>): MRReturn<'ReleaseEntry', 'createWithId'>
+
   (opts: MROpts<'Resource', 'getMany', UA>): MRReturn<'Resource', 'getMany'>
   (opts: MROpts<'ResourceProvider', 'get', UA>): MRReturn<'ResourceProvider', 'get'>
   (opts: MROpts<'ResourceProvider', 'upsert', UA>): MRReturn<'ResourceProvider', 'upsert'>
@@ -1878,6 +1885,27 @@ export type MRActions = {
         version: number
       }
       payload: OpPatch[]
+      headers?: RawAxiosRequestHeaders
+      return: EntryProps<
+        any,
+        {
+          release: {
+            sys: {
+              type: 'Link'
+              linkType: 'Entry' | 'Asset'
+              id: string
+            }
+          }
+        }
+      >
+    }
+    createWithId: {
+      params: GetSpaceEnvironmentParams & {
+        releaseId: string
+        entryId: string
+        contentTypeId: string
+      }
+      payload: CreateEntryProps<any>
       headers?: RawAxiosRequestHeaders
       return: EntryProps<
         any,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -2404,19 +2404,21 @@ export type GetReleaseEntryParams = GetSpaceEnvironmentParams & {
   releaseId?: string
   entryId: string
 }
-
-export type GetManyReleaseEntryParams = GetSpaceEnvironmentParams & {
-  releaseId: string
-}
-
+export type GetManyReleaseEntryParams = GetSpaceEnvironmentParams & { releaseId: string }
 export type UpdateReleaseEntryParams = GetSpaceEnvironmentParams & {
   releaseId: string
+  entryId: string
 }
-
 export type PatchReleaseEntryParams = GetSpaceEnvironmentParams & {
   releaseId: string
+  entryId: string
+  version: number
 }
-
+export type CreateWithIdReleaseEntryParams = GetSpaceEnvironmentParams & {
+  releaseId: string
+  entryId: string
+  contentTypeId: string
+}
 export type GetSnapshotForContentTypeParams = GetSpaceEnvironmentParams & { contentTypeId: string }
 export type GetSnapshotForEntryParams = GetSpaceEnvironmentParams & { entryId: string }
 export type GetSpaceEnvAliasParams = GetSpaceParams & { environmentAliasId: string }

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -525,6 +525,30 @@ export type PlainClientAPI = {
           }
         >
       >
+      createWithId<T extends KeyValueMap = KeyValueMap>(
+        params: OptionalDefaults<
+          GetSpaceEnvironmentParams & {
+            releaseId: string
+            entryId: string
+            contentTypeId: string
+          }
+        >,
+        rawData: CreateEntryProps<T>,
+        headers?: RawAxiosRequestHeaders
+      ): Promise<
+        EntryProps<
+          T,
+          {
+            release: {
+              sys: {
+                type: 'Link'
+                linkType: 'Entry' | 'Asset'
+                id: string
+              }
+            }
+          }
+        >
+      >
     }
     archive(params: OptionalDefaults<GetReleaseParams & { version: number }>): Promise<ReleaseProps>
     get(params: OptionalDefaults<GetReleaseParams>): Promise<ReleaseProps>

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -3,6 +3,7 @@ import type { OpPatch } from 'json-patch'
 import type {
   BasicCursorPaginationOptions,
   CollectionProp,
+  CreateWithIdReleaseEntryParams,
   CursorPaginatedCollectionProp,
   EnvironmentTemplateParams,
   GetBulkActionParams,
@@ -456,7 +457,7 @@ export type PlainClientAPI = {
   release: {
     entry: {
       get<T extends KeyValueMap = KeyValueMap>(
-        params: OptionalDefaults<GetReleaseEntryParams>
+        params: OptionalDefaults<GetReleaseEntryParams & QueryParams>
       ): Promise<
         EntryProps<
           T,
@@ -472,7 +473,7 @@ export type PlainClientAPI = {
         >
       >
       getMany<T extends KeyValueMap = KeyValueMap>(
-        params: OptionalDefaults<GetManyReleaseEntryParams>
+        params: OptionalDefaults<GetManyReleaseEntryParams & QueryParams>
       ): Promise<
         CollectionProp<
           EntryProps<
@@ -490,7 +491,7 @@ export type PlainClientAPI = {
         >
       >
       update<T extends KeyValueMap = KeyValueMap>(
-        params: OptionalDefaults<UpdateReleaseEntryParams & { entryId: string }>,
+        params: OptionalDefaults<UpdateReleaseEntryParams & QueryParams>,
         rawData: EntryProps<T>,
         headers?: RawAxiosRequestHeaders
       ): Promise<
@@ -508,7 +509,7 @@ export type PlainClientAPI = {
         >
       >
       patch<T extends KeyValueMap = KeyValueMap>(
-        params: OptionalDefaults<PatchReleaseEntryParams & { entryId: string; version: number }>,
+        params: OptionalDefaults<PatchReleaseEntryParams & QueryParams>,
         rawData: OpPatch[],
         headers?: RawAxiosRequestHeaders
       ): Promise<
@@ -526,13 +527,7 @@ export type PlainClientAPI = {
         >
       >
       createWithId<T extends KeyValueMap = KeyValueMap>(
-        params: OptionalDefaults<
-          GetSpaceEnvironmentParams & {
-            releaseId: string
-            entryId: string
-            contentTypeId: string
-          }
-        >,
+        params: OptionalDefaults<CreateWithIdReleaseEntryParams & QueryParams>,
         rawData: CreateEntryProps<T>,
         headers?: RawAxiosRequestHeaders
       ): Promise<

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -347,6 +347,7 @@ export const createPlainClient = (
         getMany: wrap(wrapParams, 'ReleaseEntry', 'getMany'),
         update: wrap(wrapParams, 'ReleaseEntry', 'update'),
         patch: wrap(wrapParams, 'ReleaseEntry', 'patch'),
+        createWithId: wrap(wrapParams, 'ReleaseEntry', 'createWithId'),
       },
       archive: wrap(wrapParams, 'Release', 'archive'),
       get: wrap(wrapParams, 'Release', 'get'),

--- a/test/integration/releasev2-integration.test.ts
+++ b/test/integration/releasev2-integration.test.ts
@@ -246,8 +246,7 @@ describe('Release Api v2', () => {
         const foundFirstEntry = entries.find((e) => e.sys.id === entry.sys.id)
         const foundSecondEntry = entries.find((e) => e.sys.id === secondEntry.sys.id)
 
-        // Focus on finding our specific entries rather than exact count (may have leftovers from previous runs)
-        expect(entries.length).toBeGreaterThanOrEqual(2)
+        expect(entries.length).toEqual(2)
         expect(foundFirstEntry?.sys.id).toEqual(entry.sys.id)
         expect(foundSecondEntry?.sys.id).toEqual(secondEntry.sys.id)
       })
@@ -300,40 +299,6 @@ describe('Release Api v2', () => {
         )
         expect(updatedEntry.fields.title['en-US']).toEqual('Patched Test Entry for Release')
       })
-
-      it('release.entry.createWithId works', async () => {
-        const entryId = 'test-release-entry-with-id-default-' + Date.now()
-        const createdEntry = await clientWithReleaseIdDefault.release.entry.createWithId(
-          {
-            releaseId: release.sys.id,
-            entryId: entryId,
-            contentTypeId: TestDefaults.contentType.withCrossSpaceReferenceId,
-            environmentId: TestDefaults.environmentId,
-            spaceId: TestDefaults.spaceId,
-          },
-          {
-            fields: {
-              title: {
-                'en-US': 'New Entry Created With ID in Release',
-              },
-            },
-          }
-        )
-
-        expect(createdEntry.sys.id).toEqual(entryId)
-        expect(createdEntry.fields.title['en-US']).toEqual('New Entry Created With ID in Release')
-        expect(createdEntry.sys.release.sys.id).toEqual(release.sys.id)
-
-        // cleanup - try both release context and regular delete
-        try {
-          await clientWithReleaseIdDefault.entry.delete({
-            entryId: createdEntry.sys.id,
-          })
-        } catch (error) {
-          // If regular delete fails, the entry might not exist or be in a different state
-          console.warn(`Failed to delete entry ${createdEntry.sys.id}:`, error.message)
-        }
-      })
     })
 
     describe('when releaseId is NOT provided as a default in client', () => {
@@ -368,8 +333,7 @@ describe('Release Api v2', () => {
         const foundFirstEntry = entries.find((e) => e.sys.id === entry.sys.id)
         const foundSecondEntry = entries.find((e) => e.sys.id === secondEntry.sys.id)
 
-        // Focus on finding our specific entries rather than exact count (may have leftovers from previous runs)
-        expect(entries.length).toBeGreaterThanOrEqual(2)
+        expect(entries.length).toEqual(2)
         expect(foundFirstEntry?.sys.id).toEqual(entry.sys.id)
         expect(foundSecondEntry?.sys.id).toEqual(secondEntry.sys.id)
       })
@@ -425,40 +389,6 @@ describe('Release Api v2', () => {
           ]
         )
         expect(updatedEntry.fields.title['en-US']).toEqual('Patched Test Entry for Release')
-      })
-
-      it('release.entry.createWithId works', async () => {
-        const entryId = 'test-release-entry-with-id-no-default-' + Date.now()
-        const createdEntry = await clientWithoutReleaseIdDefault.release.entry.createWithId(
-          {
-            releaseId: release.sys.id,
-            entryId: entryId,
-            contentTypeId: TestDefaults.contentType.withCrossSpaceReferenceId,
-            environmentId: TestDefaults.environmentId,
-            spaceId: TestDefaults.spaceId,
-          },
-          {
-            fields: {
-              title: {
-                'en-US': 'New Entry Created With ID in Release',
-              },
-            },
-          }
-        )
-
-        expect(createdEntry.sys.id).toEqual(entryId)
-        expect(createdEntry.fields.title['en-US']).toEqual('New Entry Created With ID in Release')
-        expect(createdEntry.sys.release.sys.id).toEqual(release.sys.id)
-
-        // cleanup - try both release context and regular delete
-        try {
-          await clientWithoutReleaseIdDefault.entry.delete({
-            entryId: createdEntry.sys.id,
-          })
-        } catch (error) {
-          // If regular delete fails, the entry might not exist or be in a different state
-          console.warn(`Failed to delete entry ${createdEntry.sys.id}:`, error.message)
-        }
       })
     })
   })

--- a/test/integration/releasev2-integration.test.ts
+++ b/test/integration/releasev2-integration.test.ts
@@ -299,6 +299,35 @@ describe('Release Api v2', () => {
         )
         expect(updatedEntry.fields.title['en-US']).toEqual('Patched Test Entry for Release')
       })
+
+      it('release.entry.createWithId works', async () => {
+        const entryId = 'test-release-entry-with-id-default-' + Date.now()
+        const createdEntry = await clientWithReleaseIdDefault.release.entry.createWithId(
+          {
+            releaseId: release.sys.id,
+            entryId: entryId,
+            contentTypeId: TestDefaults.contentType.withCrossSpaceReferenceId,
+            environmentId: TestDefaults.environmentId,
+            spaceId: TestDefaults.spaceId,
+          },
+          {
+            fields: {
+              title: {
+                'en-US': 'New Entry Created With ID in Release',
+              },
+            },
+          }
+        )
+
+        expect(createdEntry.sys.id).toEqual(entryId)
+        expect(createdEntry.fields.title['en-US']).toEqual('New Entry Created With ID in Release')
+        expect(createdEntry.sys.release.sys.id).toEqual(release.sys.id)
+
+        // cleanup
+        await clientWithReleaseIdDefault.entry.delete({
+          entryId: createdEntry.sys.id,
+        })
+      })
     })
 
     describe('when releaseId is NOT provided as a default in client', () => {
@@ -389,6 +418,35 @@ describe('Release Api v2', () => {
           ]
         )
         expect(updatedEntry.fields.title['en-US']).toEqual('Patched Test Entry for Release')
+      })
+
+      it('release.entry.createWithId works', async () => {
+        const entryId = 'test-release-entry-with-id-no-default-' + Date.now()
+        const createdEntry = await clientWithoutReleaseIdDefault.release.entry.createWithId(
+          {
+            releaseId: release.sys.id,
+            entryId: entryId,
+            contentTypeId: TestDefaults.contentType.withCrossSpaceReferenceId,
+            environmentId: TestDefaults.environmentId,
+            spaceId: TestDefaults.spaceId,
+          },
+          {
+            fields: {
+              title: {
+                'en-US': 'New Entry Created With ID in Release',
+              },
+            },
+          }
+        )
+
+        expect(createdEntry.sys.id).toEqual(entryId)
+        expect(createdEntry.fields.title['en-US']).toEqual('New Entry Created With ID in Release')
+        expect(createdEntry.sys.release.sys.id).toEqual(release.sys.id)
+
+        // cleanup
+        await clientWithoutReleaseIdDefault.entry.delete({
+          entryId: createdEntry.sys.id,
+        })
       })
     })
   })

--- a/test/integration/releasev2-integration.test.ts
+++ b/test/integration/releasev2-integration.test.ts
@@ -246,7 +246,8 @@ describe('Release Api v2', () => {
         const foundFirstEntry = entries.find((e) => e.sys.id === entry.sys.id)
         const foundSecondEntry = entries.find((e) => e.sys.id === secondEntry.sys.id)
 
-        expect(entries.length).toEqual(2)
+        // Focus on finding our specific entries rather than exact count (may have leftovers from previous runs)
+        expect(entries.length).toBeGreaterThanOrEqual(2)
         expect(foundFirstEntry?.sys.id).toEqual(entry.sys.id)
         expect(foundSecondEntry?.sys.id).toEqual(secondEntry.sys.id)
       })
@@ -323,10 +324,15 @@ describe('Release Api v2', () => {
         expect(createdEntry.fields.title['en-US']).toEqual('New Entry Created With ID in Release')
         expect(createdEntry.sys.release.sys.id).toEqual(release.sys.id)
 
-        // cleanup
-        await clientWithReleaseIdDefault.entry.delete({
-          entryId: createdEntry.sys.id,
-        })
+        // cleanup - try both release context and regular delete
+        try {
+          await clientWithReleaseIdDefault.entry.delete({
+            entryId: createdEntry.sys.id,
+          })
+        } catch (error) {
+          // If regular delete fails, the entry might not exist or be in a different state
+          console.warn(`Failed to delete entry ${createdEntry.sys.id}:`, error.message)
+        }
       })
     })
 
@@ -362,7 +368,8 @@ describe('Release Api v2', () => {
         const foundFirstEntry = entries.find((e) => e.sys.id === entry.sys.id)
         const foundSecondEntry = entries.find((e) => e.sys.id === secondEntry.sys.id)
 
-        expect(entries.length).toEqual(2)
+        // Focus on finding our specific entries rather than exact count (may have leftovers from previous runs)
+        expect(entries.length).toBeGreaterThanOrEqual(2)
         expect(foundFirstEntry?.sys.id).toEqual(entry.sys.id)
         expect(foundSecondEntry?.sys.id).toEqual(secondEntry.sys.id)
       })
@@ -443,10 +450,15 @@ describe('Release Api v2', () => {
         expect(createdEntry.fields.title['en-US']).toEqual('New Entry Created With ID in Release')
         expect(createdEntry.sys.release.sys.id).toEqual(release.sys.id)
 
-        // cleanup
-        await clientWithoutReleaseIdDefault.entry.delete({
-          entryId: createdEntry.sys.id,
-        })
+        // cleanup - try both release context and regular delete
+        try {
+          await clientWithoutReleaseIdDefault.entry.delete({
+            entryId: createdEntry.sys.id,
+          })
+        } catch (error) {
+          // If regular delete fails, the entry might not exist or be in a different state
+          console.warn(`Failed to delete entry ${createdEntry.sys.id}:`, error.message)
+        }
       })
     })
   })

--- a/test/unit/adapters/REST/endpoints/release-entry.test.ts
+++ b/test/unit/adapters/REST/endpoints/release-entry.test.ts
@@ -1,55 +1,138 @@
-import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { cloneMock } from '../../../mocks/entities'
-import * as raw from '../../../../../lib/adapters/REST/endpoints/raw'
-import { get, getMany } from '../../../../../lib/adapters/REST/endpoints/release-entry'
-import { EntryProps } from '../../../../../lib/entities/entry'
-import { GetReleaseEntryParams } from '../../../../../lib/contentful-management'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+
+function setup(promise, params = {}) {
+  return {
+    ...setupRestAdapter(promise, params),
+    entityMock: cloneMock('releaseEntry'),
+  }
+}
 
 describe('Rest ReleaseEntry', () => {
-  let mockReleaseEntry: EntryProps<
-    any,
-    { release: { sys: { type: 'Link'; linkType: 'Release'; id: string } } }
-  >
-  let rawGetSpy: any
-  let params: GetReleaseEntryParams
-  let httpMock: any
+  test('get', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
 
-  beforeEach(async () => {
-    mockReleaseEntry = cloneMock('releaseEntry')
-    rawGetSpy = vi.spyOn(raw, 'get').mockResolvedValue(mockReleaseEntry)
-    httpMock = {}
-    params = {
-      spaceId: 'space123',
-      environmentId: 'master',
-      releaseId: 'black-friday',
-      entryId: 'abc123',
-    }
-    await get(httpMock, params)
+    httpMock.get.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseEntry',
+        action: 'get',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          releaseId: 'black-friday',
+          entryId: 'abc123',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/black-friday/entries/abc123'
+        )
+      })
   })
 
-  afterEach(() => {
-    rawGetSpy.mockRestore()
+  test('getMany', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.get.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseEntry',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          releaseId: 'black-friday',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/black-friday/entries'
+        )
+      })
   })
 
-  test('release.entry.get calls raw.get with correct URL and params', async () => {
-    expect(rawGetSpy).toHaveBeenCalledWith(
-      httpMock,
-      '/spaces/space123/environments/master/releases/black-friday/entries/abc123'
-    )
+  test('update', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.put.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseEntry',
+        action: 'update',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          releaseId: 'black-friday',
+          entryId: 'abc123',
+        },
+        payload: entityMock,
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/black-friday/entries/abc123'
+        )
+      })
   })
 
-  test('release.entry.getMany calls raw.get with the correct URL and params', async () => {
-    const expectedParams = {
-      spaceId: 'space123',
-      environmentId: 'master',
-      releaseId: 'black-friday',
-    }
+  test('patch', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
 
-    await getMany(httpMock, expectedParams)
+    httpMock.patch.mockReturnValue(Promise.resolve({ data: entityMock }))
 
-    expect(rawGetSpy).toHaveBeenCalledWith(
-      httpMock,
-      '/spaces/space123/environments/master/releases/black-friday/entries'
-    )
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseEntry',
+        action: 'patch',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          releaseId: 'black-friday',
+          entryId: 'abc123',
+        },
+        userAgent: 'mocked',
+      })
+      .then(() => {
+        expect(httpMock.patch.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/black-friday/entries/abc123'
+        )
+      })
+  })
+
+  test('createWithId', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.put.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseEntry',
+        action: 'createWithId',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          releaseId: 'black-friday',
+          entryId: 'abc123',
+          contentTypeId: 'contentType123',
+        },
+        payload: entityMock,
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/black-friday/entries/abc123'
+        )
+      })
   })
 })


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Add the `release.entry.createWithId` method.

## Description

Follow the pattern and format for other release.entry methods and other createWithId methods. 

Also a few other changes in this PR:
- Add `ReleaseEntry` methods to the `MRInternal` type in `common-types.ts` 
- Adjust the types for release entry parameters and adjust types where this is used
- Refactor the unit tests to align with how we are approaching other REST endpoint tests

I was having some trouble implementing integration tests for this method as I kept getting an error when trying to clean up the created entry. I'll address this in a future PR.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [x] The new method is exported through the default and plain CMA client
- [x] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
