### PR TITLE
feat: entry.patch handle releaseId [DX-209]

### DIFF
--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -5,19 +5,22 @@ import type { OpPatch } from 'json-patch'
 import type { SetOptional } from 'type-fest'
 import type {
   CollectionProp,
-  GetReleaseEntryParams,
+  GetEntryParams,
+  GetManyEntryParams,
   GetSpaceEnvironmentParams,
   KeyValueMap,
+  PatchEntryParams,
   QueryParams,
 } from '../../../common-types'
 import type { CreateEntryProps, EntryProps, EntryReferenceProps } from '../../../entities/entry'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
 import { normalizeSelect } from './utils'
+import * as releaseEntry from './release-entry'
 
 export const get: RestEndpoint<'Entry', 'get'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: GetReleaseEntryParams & QueryParams,
+  params: GetEntryParams & QueryParams,
   rawData?: unknown,
   headers?: RawAxiosRequestHeaders
 ) => {
@@ -55,7 +58,7 @@ export const getPublished: RestEndpoint<'Entry', 'getPublished'> = <
 
 export const getMany: RestEndpoint<'Entry', 'getMany'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & QueryParams & { releaseId?: string },
+  params: GetManyEntryParams & QueryParams,
   rawData?: unknown,
   headers?: RawAxiosRequestHeaders
 ) => {
@@ -75,10 +78,14 @@ export const getMany: RestEndpoint<'Entry', 'getMany'> = <T extends KeyValueMap 
 
 export const patch: RestEndpoint<'Entry', 'patch'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { entryId: string; version: number },
+  params: PatchEntryParams & { version: number } & QueryParams,
   data: OpPatch[],
   headers?: RawAxiosRequestHeaders
 ) => {
+  if (params.releaseId) {
+    return releaseEntry.patch(http, { ...params, releaseId: params.releaseId }, data, { ...headers })
+  }
+
   return raw.patch<EntryProps<T>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}`,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1604,15 +1604,15 @@ export type MRActions = {
       return: CollectionProp<EntryProps<any>>
     }
     getMany: {
-      params: GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }
+      params: GetManyEntryParams & QueryParams,
       return: CollectionProp<EntryProps<any, any>>
     }
     get: {
-      params: GetReleaseEntryParams & QueryParams
+      params: GetEntryParams & QueryParams
       return: EntryProps<any, any>
     }
     patch: {
-      params: GetSpaceEnvironmentParams & { entryId: string; version: number }
+      params: PatchEntryParams & { entryId: string; version: number }
       payload: OpPatch[]
       headers?: RawAxiosRequestHeaders
       return: EntryProps<any>
@@ -2385,7 +2385,9 @@ export type GetCommentParams = (GetEntryParams | GetCommentParentEntityParams) &
 }
 export type GetContentTypeParams = GetSpaceEnvironmentParams & { contentTypeId: string }
 export type GetEditorInterfaceParams = GetSpaceEnvironmentParams & { contentTypeId: string }
-export type GetEntryParams = GetSpaceEnvironmentParams & { entryId: string }
+export type GetEntryParams = GetSpaceEnvironmentParams & { entryId: string; releaseId?: string }
+export type GetManyEntryParams = GetSpaceEnvironmentParams & { releaseId?: string }
+export type PatchEntryParams = GetSpaceEnvironmentParams & { entryId: string; releaseId?: string }
 export type GetExtensionParams = GetSpaceEnvironmentParams & { extensionId: string }
 export type GetEnvironmentTemplateParams = GetOrganizationParams & { environmentTemplateId: string }
 export type GetFunctionParams = GetAppDefinitionParams & { functionId: string }

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -8,7 +8,9 @@ import type {
   EnvironmentTemplateParams,
   GetBulkActionParams,
   GetContentTypeParams,
+  GetEntryParams,
   GetEnvironmentTemplateParams,
+  GetManyEntryParams,
   GetManyReleaseEntryParams,
   GetOrganizationMembershipParams,
   GetOrganizationParams,
@@ -19,6 +21,7 @@ import type {
   GetSpaceEnvironmentParams,
   GetSpaceParams,
   KeyValueMap,
+  PatchEntryParams,
   PatchReleaseEntryParams,
   QueryParams,
   ReleaseEnvironmentParams,
@@ -279,7 +282,7 @@ export type PlainClientAPI = {
       headers?: RawAxiosRequestHeaders
     ): Promise<CollectionProp<EntryProps<T>>>
     getMany<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }>,
+      params: OptionalDefaults<GetManyEntryParams & QueryParams>,
       rawData?: unknown,
       headers?: RawAxiosRequestHeaders
     ): Promise<
@@ -299,7 +302,7 @@ export type PlainClientAPI = {
       >
     >
     get<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<GetReleaseEntryParams>,
+      params: OptionalDefaults<GetEntryParams>,
       rawData?: unknown,
       headers?: RawAxiosRequestHeaders
     ): Promise<
@@ -322,7 +325,7 @@ export type PlainClientAPI = {
       headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>
     patch<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string; version?: number }>,
+      params: OptionalDefaults<PatchEntryParams & { version?: number }>,
       rawData: OpPatch[],
       headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>

--- a/test/unit/adapters/REST/endpoints/entry.test.ts
+++ b/test/unit/adapters/REST/endpoints/entry.test.ts
@@ -50,6 +50,7 @@ describe('Rest Entry', () => {
       .makeRequest({
         entityType: 'Entry',
         action: 'createWithId',
+        userAgent: 'mocked',
         params: {
           environmentId: 'id',
           spaceId: 'id',
@@ -69,6 +70,179 @@ describe('Rest Entry', () => {
           'contentTypeId',
           'content type is specified'
         )
+      })
+  })
+
+  test('get', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.get.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Entry',
+        action: 'get',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          entryId: 'entry123',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/entries/entry123'
+        )
+        expect(httpMock.get.mock.calls[0][1].params).toBeUndefined
+      })
+  })
+
+  test('get with releaseId', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.get.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Entry',
+        action: 'get',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          entryId: 'entry123',
+          releaseId: 'release456',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/entries/entry123'
+        )
+        // Should have release query parameter
+        expect(httpMock.get.mock.calls[0][1].params).toMatchObject({
+          'release[lte]': 'release456'
+        })
+      })
+  })
+
+  test('getMany', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.get.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Entry',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/entries'
+        )
+        expect(httpMock.get.mock.calls[0][1].params).toBeUndefined
+      })
+  })
+
+  test('getMany with releaseId', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.get.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Entry',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          releaseId: 'release456',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/entries'
+        )
+        // Should have release query parameter
+        expect(httpMock.get.mock.calls[0][1].params).toMatchObject({
+          'release[lte]': 'release456'
+        })
+      })
+  })
+
+  test('patch without releaseId', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.patch.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    const patchOps = [{ op: 'replace', path: '/fields/title/en-US', value: 'New Title' }]
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Entry',
+        action: 'patch',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          entryId: 'entry123',
+          version: 5,
+        },
+        payload: patchOps,
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.patch.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/entries/entry123'
+        )
+        expect(httpMock.patch.mock.calls[0][1]).to.eql(patchOps)
+        expect(httpMock.patch.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(5)
+        expect(httpMock.patch.mock.calls[0][2].headers['Content-Type']).to.eql('application/json-patch+json')
+      })
+  })
+
+  test('patch with releaseId delegates to release entry', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    // Mock the release entry endpoint
+    httpMock.patch.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    const patchOps = [{ op: 'replace', path: '/fields/title/en-US', value: 'New Title' }]
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Entry',
+        action: 'patch',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          entryId: 'entry123',
+          releaseId: 'release456',
+          version: 5,
+        },
+        payload: patchOps,
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        // When releaseId is provided, it should call the release entry endpoint
+        expect(httpMock.patch.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/release456/entries/entry123'
+        )
+        expect(httpMock.patch.mock.calls[0][1]).to.eql(patchOps)
+        expect(httpMock.patch.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(5)
+        expect(httpMock.patch.mock.calls[0][2].headers['Content-Type']).to.eql('application/json-patch+json')
+        // Should have schema version for release API
+        expect(httpMock.patch.mock.calls[0][1]).toMatchObject(patchOps)
       })
   })
 })


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary
<!-- Give a short summary what your PR is introducing/fixing. -->

JIRA: [DX-209](https://contentful.atlassian.net/browse/DX-209)

- entry.patch takes `releaseId`
- if `releaseId` provided, use the `release.entry.patch` method instead
- light refactor of existing entry method params that use `releaseId`

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
