### PR TITLE
feat: add `resultSchema` and `parametersSchema` support to AppAction definitions [EXT-6739]

### DIFF
--- a/lib/entities/app-action.ts
+++ b/lib/entities/app-action.ts
@@ -69,11 +69,11 @@ type BaseAppActionProps = AppActionCategory & {
   /**
    * Optional JSON Schema describing the request payload shape
    */
-  parametersSchema?: object
+  parametersSchema?: Record<string, unknown>
   /**
    * Optional JSON Schema describing the result shape
    */
-  resultSchema?: object
+  resultSchema?: Record<string, unknown>
 }
 
 type CreateEndpointAppActionProps = {
@@ -141,11 +141,11 @@ export type CreateAppActionProps = AppActionCategory & {
   /**
    * Optional JSON Schema describing the request payload shape
    */
-  parametersSchema?: object
+  parametersSchema?: Record<string, unknown>
   /**
    * Optional JSON Schema describing the result shape
    */
-  resultSchema?: object
+  resultSchema?: Record<string, unknown>
 } & (CreateEndpointAppActionProps | CreateFunctionAppActionProps | LegacyFunctionAppActionProps)
 
 export type AppActionProps = BaseAppActionProps &

--- a/lib/entities/app-action.ts
+++ b/lib/entities/app-action.ts
@@ -66,6 +66,14 @@ type BaseAppActionProps = AppActionCategory & {
    * Human readable description of the action
    */
   description?: string
+  /**
+   * Optional JSON Schema describing the request payload shape
+   */
+  parametersSchema?: object
+  /**
+   * Optional JSON Schema describing the result shape
+   */
+  resultSchema?: object
 }
 
 type CreateEndpointAppActionProps = {
@@ -130,6 +138,14 @@ type LegacyFunctionAppActionProps = Record<string, unknown> & {
 export type CreateAppActionProps = AppActionCategory & {
   name: string
   description?: string
+  /**
+   * Optional JSON Schema describing the request payload shape
+   */
+  parametersSchema?: object
+  /**
+   * Optional JSON Schema describing the result shape
+   */
+  resultSchema?: object
 } & (CreateEndpointAppActionProps | CreateFunctionAppActionProps | LegacyFunctionAppActionProps)
 
 export type AppActionProps = BaseAppActionProps &

--- a/test/unit/adapters/REST/endpoints/app-action.test.ts
+++ b/test/unit/adapters/REST/endpoints/app-action.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+import * as rest from '../../../../../lib/adapters/REST/endpoints/app-action'
+import type { CreateAppActionProps } from '../../../../../lib/entities/app-action'
+
+describe('AppAction schema fields', () => {
+  it('passes parametersSchema/resultSchema on create', async () => {
+    const payload: CreateAppActionProps = {
+      category: 'Notification.v1.0',
+      url: 'https://example.com',
+      name: 'My Action',
+      parametersSchema: { type: 'object', properties: { a: { type: 'string' } } },
+      resultSchema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+    }
+
+    const { httpMock } = setupRestAdapter(
+      Promise.resolve({ data: { sys: { id: 'id' }, ...payload } }),
+      {}
+    )
+
+    await rest.create(
+      httpMock as unknown as import('contentful-sdk-core').AxiosInstance,
+      {
+        organizationId: 'org',
+        appDefinitionId: 'appDef',
+      } as unknown as import('../../../../../lib/common-types').GetAppDefinitionParams,
+      payload as unknown as never
+    )
+
+    expect(httpMock.post.mock.calls[0][1]).toStrictEqual(payload)
+  })
+
+  it('passes parametersSchema/resultSchema on update', async () => {
+    const payload: CreateAppActionProps = {
+      category: 'Notification.v1.0',
+      url: 'https://example.com',
+      name: 'My Action',
+      parametersSchema: { type: 'object', properties: { a: { type: 'string' } } },
+      resultSchema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+    }
+
+    const { httpMock } = setupRestAdapter(
+      Promise.resolve({ data: { sys: { id: 'id' }, ...payload } }),
+      {}
+    )
+
+    await rest.update(
+      httpMock as unknown as import('contentful-sdk-core').AxiosInstance,
+      {
+        organizationId: 'org',
+        appDefinitionId: 'appDef',
+        appActionId: 'id',
+      } as unknown as import('../../../../../lib/common-types').GetAppActionParams,
+      payload as unknown as never
+    )
+
+    expect(httpMock.put.mock.calls[0][1]).toStrictEqual(payload)
+  })
+})


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

This PR extends the AppAction type definitions by introducing two new optional properties:

`resultSchema` – a JSON Schema describing the expected structure of the value returned by an App Action.

`parametersSchema` – a JSON Schema describing the expected input parameters when calling an App Action.

These additions make it easier for developers to understand, validate, and work with App Actions in a consistent and predictable way.

## Motivation and Context

App Actions currently lack a standardized way to describe their input and output data. This makes it difficult for consumers to reliably use App Actions in workflows, automations, and other integrations that depend on structured results.

By adding `resultSchema` and `parametersSchema`, we provide:

- Better validation: SDKs and tooling can check that inputs and outputs match the defined schema.

- Improved developer experience: Clear documentation of what an App Action expects and returns.

- Consistency: Alignment with JSON Schema for both request and response structures.

Example Usage

```
const appAction = {
  name: "GenerateProduct",
  parametersSchema: {
    type: "object",
    properties: {
      productId: { type: "string" }
    },
    required: ["productId"]
  },
  resultSchema: {
    type: "object",
    properties: {
      name: { type: "string" },
      price: { type: "number" }
    },
    required: ["name", "price"]
  }
}
```

Jira Ticket: [EXT-6739](https://contentful.atlassian.net/jira/software/c/projects/EXT/boards/38?selectedIssue=EXT-6739)

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [x] Changes are reflected in the documentation
    - Edits made in doc-app. PR to come


[EXT-6739]: https://contentful.atlassian.net/browse/EXT-6739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ