### PR TITLE
feat: update entry.createWithId to accept releaseId [DX-208]

### DIFF
--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -7,6 +7,7 @@ import type {
   CollectionProp,
   GetEntryParams,
   GetManyEntryParams,
+  CreateWithIdReleaseEntryParams,
   GetSpaceEnvironmentParams,
   KeyValueMap,
   PatchEntryParams,
@@ -16,6 +17,7 @@ import type {
 import type { CreateEntryProps, EntryProps, EntryReferenceProps } from '../../../entities/entry'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
+import { createWithId as createWithIdReleaseEntry } from './release-entry'
 import { normalizeSelect } from './utils'
 import * as releaseEntry from './release-entry'
 
@@ -219,21 +221,29 @@ export const createWithId: RestEndpoint<'Entry', 'createWithId'> = <
   T extends KeyValueMap = KeyValueMap
 >(
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { entryId: string; contentTypeId: string },
+  params: GetSpaceEnvironmentParams & {
+    entryId: string
+    contentTypeId: string
+    releaseId?: string
+  },
   rawData: CreateEntryProps<T>
 ) => {
-  const data = copy(rawData)
+  if (params.releaseId) {
+    return createWithIdReleaseEntry(http, params as CreateWithIdReleaseEntryParams, rawData, {})
+  } else {
+    const data = copy(rawData)
 
-  return raw.put<EntryProps<T>>(
-    http,
-    `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}`,
-    data,
-    {
-      headers: {
-        'X-Contentful-Content-Type': params.contentTypeId,
-      },
-    }
-  )
+    return raw.put<EntryProps<T>>(
+      http,
+      `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}`,
+      data,
+      {
+        headers: {
+          'X-Contentful-Content-Type': params.contentTypeId,
+        },
+      }
+    )
+  }
 }
 
 export const references: RestEndpoint<'Entry', 'references'> = (

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1647,9 +1647,13 @@ export type MRActions = {
       return: EntryProps<any>
     }
     createWithId: {
-      params: GetSpaceEnvironmentParams & { entryId: string; contentTypeId: string }
+      params: GetSpaceEnvironmentParams & {
+        entryId: string
+        contentTypeId: string
+        releaseId?: string
+      }
       payload: CreateEntryProps<any>
-      return: EntryProps<any>
+      return: EntryProps<any, any>
     }
     references: {
       params: GetSpaceEnvironmentParams & {

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -350,10 +350,23 @@ export type PlainClientAPI = {
     ): Promise<EntryProps<T>>
     createWithId<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<
-        GetSpaceEnvironmentParams & { entryId: string; contentTypeId: string }
+        GetSpaceEnvironmentParams & { entryId: string; contentTypeId: string; releaseId?: string }
       >,
       rawData: CreateEntryProps<T>
-    ): Promise<EntryProps<T>>
+    ): Promise<
+      EntryProps<
+        T,
+        {
+          release: {
+            sys: {
+              type: 'Link'
+              linkType: 'Entry' | 'Asset'
+              id: string
+            }
+          }
+        }
+      >
+    >
     references(
       params: OptionalDefaults<
         GetSpaceEnvironmentParams & {

--- a/test/unit/adapters/REST/endpoints/entry.test.ts
+++ b/test/unit/adapters/REST/endpoints/entry.test.ts
@@ -41,7 +41,7 @@ describe('Rest Entry', () => {
     })
   })
 
-  test('API call createEntryWithId', async () => {
+  test('API call createEntryWithId without releaseId', async () => {
     const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
 
     httpMock.put.mockReturnValue(Promise.resolve({ data: entityMock }))
@@ -64,6 +64,39 @@ describe('Rest Entry', () => {
         expect(httpMock.put.mock.calls[0][0]).to.eql(
           '/spaces/id/environments/id/entries/entryId',
           'entry id is sent'
+        )
+        expect(httpMock.put.mock.calls[0][1]).to.eql(entityMock, 'data is sent')
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Content-Type']).to.eql(
+          'contentTypeId',
+          'content type is specified'
+        )
+      })
+  })
+
+  test('API call createEntryWithId with releaseId', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.put.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Entry',
+        action: 'createWithId',
+        userAgent: 'mocked',
+        params: {
+          environmentId: 'id',
+          spaceId: 'id',
+          contentTypeId: 'contentTypeId',
+          entryId: 'entryId',
+          releaseId: 'releaseId',
+        },
+        payload: entityMock,
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/id/environments/id/releases/releaseId/entries/entryId',
+          'release entry endpoint is used when releaseId is provided'
         )
         expect(httpMock.put.mock.calls[0][1]).to.eql(entityMock, 'data is sent')
         expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Content-Type']).to.eql(


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Update the `entry.createWithId` method to support releases.

## Description

When `releaseId` is passed in as a parameter to `entry.createWithId`, the `release.entry.createWithId` method is called. Added a unit test to verify this behavior.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
