### PR TITLE
feat: entry.update supports releaseId [DX-210]

### DIFF
--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -13,6 +13,7 @@ import type {
   PatchReleaseEntryParams,
   QueryParams,
   UpdateEntryParams,
+  UpdateReleaseEntryParams,
 } from '../../../common-types'
 import type { CreateEntryProps, EntryProps, EntryReferenceProps } from '../../../entities/entry'
 import type { RestEndpoint } from '../types'
@@ -109,9 +110,7 @@ export const update: RestEndpoint<'Entry', 'update'> = <T extends KeyValueMap = 
   headers?: RawAxiosRequestHeaders
 ) => {
   if (params.releaseId) {
-    return releaseEntry.update(http, { ...params, releaseId: params.releaseId }, rawData, {
-      ...headers,
-    })
+    return releaseEntry.update(http, params as UpdateReleaseEntryParams, rawData, headers ?? {})
   }
 
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)

--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -107,7 +107,7 @@ export const patch: RestEndpoint<'Entry', 'patch'> = <T extends KeyValueMap = Ke
 
 export const update: RestEndpoint<'Entry', 'update'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: UpdateEntryParams,
+  params: UpdateEntryParams & QueryParams,
   rawData: EntryProps<T>,
   headers?: RawAxiosRequestHeaders
 ) => {

--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -12,6 +12,7 @@ import type {
   PatchEntryParams,
   PatchReleaseEntryParams,
   QueryParams,
+  UpdateEntryParams,
 } from '../../../common-types'
 import type { CreateEntryProps, EntryProps, EntryReferenceProps } from '../../../entities/entry'
 import type { RestEndpoint } from '../types'
@@ -103,10 +104,16 @@ export const patch: RestEndpoint<'Entry', 'patch'> = <T extends KeyValueMap = Ke
 
 export const update: RestEndpoint<'Entry', 'update'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { entryId: string },
+  params: UpdateEntryParams,
   rawData: EntryProps<T>,
   headers?: RawAxiosRequestHeaders
 ) => {
+  if (params.releaseId) {
+    return releaseEntry.update(http, { ...params, releaseId: params.releaseId }, rawData, {
+      ...headers,
+    })
+  }
+
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys
   return raw.put<EntryProps<T>>(

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1618,7 +1618,7 @@ export type MRActions = {
       return: EntryProps<any>
     }
     update: {
-      params: GetSpaceEnvironmentParams & { entryId: string }
+      params: UpdateEntryParams
       payload: EntryProps<any>
       headers?: RawAxiosRequestHeaders
       return: EntryProps<any>
@@ -2392,6 +2392,7 @@ export type PatchEntryParams = GetSpaceEnvironmentParams & {
   version: number
   releaseId?: string
 }
+export type UpdateEntryParams = GetSpaceEnvironmentParams & { entryId: string; releaseId?: string }
 export type GetExtensionParams = GetSpaceEnvironmentParams & { extensionId: string }
 export type GetEnvironmentTemplateParams = GetOrganizationParams & { environmentTemplateId: string }
 export type GetFunctionParams = GetAppDefinitionParams & { functionId: string }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1618,7 +1618,7 @@ export type MRActions = {
       return: EntryProps<any>
     }
     update: {
-      params: UpdateEntryParams
+      params: UpdateEntryParams & QueryParams
       payload: EntryProps<any>
       headers?: RawAxiosRequestHeaders
       return: EntryProps<any>

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -321,7 +321,7 @@ export type PlainClientAPI = {
       >
     >
     update<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<UpdateEntryParams>,
+      params: OptionalDefaults<UpdateEntryParams & QueryParams>,
       rawData: EntryProps<T>,
       headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -25,6 +25,7 @@ import type {
   PatchReleaseEntryParams,
   QueryParams,
   ReleaseEnvironmentParams,
+  UpdateEntryParams,
   UpdateReleaseEntryParams,
 } from '../common-types'
 import type {
@@ -320,7 +321,7 @@ export type PlainClientAPI = {
       >
     >
     update<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string }>,
+      params: OptionalDefaults<UpdateEntryParams>,
       rawData: EntryProps<T>,
       headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>

--- a/test/integration/entry-integration.test.ts
+++ b/test/integration/entry-integration.test.ts
@@ -823,6 +823,32 @@ describe('Entry Api', () => {
         expect(patchedEntry.sys.version).toBeGreaterThan(entryToPatch.sys.version)
         expect((patchedEntry as any).sys.release.sys.id).toEqual(entryToPatch.sys.release.sys.id)
       })
+
+      test('entry.update works', async () => {
+        const entryToUpdate = await createEntryClient.entry.get({
+          entryId: entry.sys.id,
+          releaseId: release.sys.id,
+        })
+
+        const updatedEntry = await createEntryClient.entry.update(
+          {
+            entryId: entryToUpdate.sys.id,
+            releaseId: release.sys.id,
+          },
+          {
+            ...entryToUpdate,
+            fields: {
+              ...entryToUpdate.fields,
+              title: { 'en-US': 'Entry updated via release' },
+            },
+          }
+        )
+
+        expect(updatedEntry.sys.id).toEqual(entryToUpdate.sys.id)
+        expect(updatedEntry.fields.title['en-US']).toEqual('Entry updated via release')
+        expect(updatedEntry.sys.version).toBeGreaterThan(entryToUpdate.sys.version)
+        expect((updatedEntry as any).sys.release.sys.id).toEqual(entryToUpdate.sys.release.sys.id)
+      })
     })
 
     describe('releaseId is provided in default params, but not in params', () => {
@@ -877,6 +903,30 @@ describe('Entry Api', () => {
         expect(patchedEntry.fields.title['en-US']).toEqual('Entry patched via default release')
         expect(patchedEntry.sys.version).toBeGreaterThan(entryToPatch.sys.version)
         expect((patchedEntry as any).sys.release.sys.id).toEqual(entryToPatch.sys.release.sys.id)
+      })
+
+      test('entry.update works', async () => {
+        const entryToUpdate = await createEntryClient.entry.get({
+          entryId: entry.sys.id,
+        })
+
+        const updatedEntry = await createEntryClient.entry.update(
+          {
+            entryId: entryToUpdate.sys.id,
+          },
+          {
+            ...entryToUpdate,
+            fields: {
+              ...entryToUpdate.fields,
+              title: { 'en-US': 'Entry updated via default release' },
+            },
+          }
+        )
+
+        expect(updatedEntry.sys.id).toEqual(entryToUpdate.sys.id)
+        expect(updatedEntry.fields.title['en-US']).toEqual('Entry updated via default release')
+        expect(updatedEntry.sys.version).toBeGreaterThan(entryToUpdate.sys.version)
+        expect((updatedEntry as any).sys.release.sys.id).toEqual(entryToUpdate.sys.release.sys.id)
       })
     })
   })

--- a/test/unit/adapters/REST/endpoints/entry.test.ts
+++ b/test/unit/adapters/REST/endpoints/entry.test.ts
@@ -316,7 +316,9 @@ describe('Rest Entry', () => {
         )
         // Check that sys is removed from the payload
         expect(httpMock.put.mock.calls[0][1]).not.toHaveProperty('sys')
-        expect(httpMock.put.mock.calls[0][1].fields.title['en-US']).to.eql('Updated Title in Release')
+        expect(httpMock.put.mock.calls[0][1].fields.title['en-US']).to.eql(
+          'Updated Title in Release'
+        )
         expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(
           updateData.sys.version
         )


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->
JIRA: [DX-210](https://contentful.atlassian.net/browse/DX-210)

`entry.update` takes `releaseId` and delegates to release entry update endpoint.

## Description

<!-- Describe your changes in detail -->

- Add `releaseId` to entry.update params
- If request has `releaseId`, call `release.entry.update` endpoint
- Unit tests for entry.update
- Integration tests for entry.update

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [x] Added a unit test for the new method
- [x] Added an integration test for the new method
- [ ] The new method is added to the documentation


[DX-210]: https://contentful.atlassian.net/browse/DX-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ