### PR TITLE
fix: remove startDate from releasev2 payload [DX-380]

### DIFF
--- a/lib/entities/release.ts
+++ b/lib/entities/release.ts
@@ -120,7 +120,6 @@ export interface ReleasePayloadV2 extends MakeRequestPayload {
   }
   title: string
   entities: BaseCollection<{ entity: Link<Entity> } & ReleaseValidatePayload>
-  startDate?: ISO8601Timestamp
 }
 
 export interface ReleaseValidatePayload {

--- a/test/integration/releasev2-integration.test.ts
+++ b/test/integration/releasev2-integration.test.ts
@@ -129,7 +129,6 @@ describe('Release Api v2', () => {
               },
             ],
           },
-          startDate: '2025-08-28T10:00:000Z',
         }
       )
       expect(updatedRelease.sys.schemaVersion).toEqual('Release.v2')
@@ -197,7 +196,6 @@ describe('Release Api v2', () => {
               },
             ],
           },
-          startDate: '2025-08-28T10:00:000Z',
         }
       )
       expect(updatedRelease.sys.schemaVersion).toEqual('Release.v2')

--- a/test/integration/utils/release-entry.utils.ts
+++ b/test/integration/utils/release-entry.utils.ts
@@ -18,7 +18,6 @@ export async function createEmptyRelease(
       sys: { type: 'Array' },
       items: [],
     },
-    startDate: '2025-08-28T10:00:000Z',
   })
 }
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

The `startDate` property can be removed from the releases v2 payload as scheduled actions are now being used for releases.

## Description

Removes `startDate` from the releases v2 payload type definition and integration tests.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
