### PR TITLE
chore: add details for hostUpload in README [DX-371]

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,11 +320,11 @@ Your CMA access token.
 
 #### host (default: `'api.contentful.com'`)
 
-Set the host used to build the request URI's.
+Set the host used to build the request URIs.
 
 #### hostUpload (default: `'upload.contentful.com'`)
 
-Set the host used to build the upload related request uri's.
+Set the host used to build the upload related request URIs. Learn more about the Upload API [here](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/uploads).
 
 #### basePath (default: ``)
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

This PR provides a link to the Upload API documentation within the `hostUpload` configuration option in the `README`. 

## Description

This will make it easier for customers to learn more about the Upload API.

## Motivation and Context

We are also updating the CMA docs to include the Upload API base URL for EU Data Residency customers, so this provides a link to that information.

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
