### PR TITLE
fix: app action call params/payload plumbing for legacy client [EXT-6763]

### DIFF
--- a/lib/entities/app-action-call.ts
+++ b/lib/entities/app-action-call.ts
@@ -7,6 +7,10 @@ import type {
   DefaultElements,
   MakeRequest,
   SysLink,
+  CreateWithResponseParams,
+  CreateWithResultParams,
+  GetAppActionCallDetailsParams,
+  GetAppActionCallParamsWithId,
 } from '../common-types'
 import type { WebhookCallDetailsProps } from './webhook'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -49,15 +53,19 @@ export type CreateAppActionCallProps = {
 }
 
 type AppActionCallApi = {
-  createWithResponse(): Promise<AppActionCallResponse>
-  getCallDetails(): Promise<AppActionCallResponse>
-  get(): Promise<AppActionCallProps>
-  createWithResult(): Promise<AppActionCallProps>
+  createWithResponse(
+    params: CreateWithResponseParams,
+    payload: CreateAppActionCallProps
+  ): Promise<AppActionCallResponse>
+  getCallDetails(params: GetAppActionCallDetailsParams): Promise<AppActionCallResponse>
+  get(params: GetAppActionCallParamsWithId): Promise<AppActionCallProps>
+  createWithResult(
+    params: CreateWithResultParams,
+    payload: CreateAppActionCallProps
+  ): Promise<AppActionCallProps>
 }
 
 export type AppActionCallResponse = WebhookCallDetailsProps
-
-// Raw App Action call response (new endpoint). Not yet wired to runtime behavior.
 export interface AppActionCallRawResponseProps {
   sys: {
     id: string
@@ -89,73 +97,39 @@ export default function createAppActionCallApi(
   retryOptions?: RetryOptions
 ): AppActionCallApi {
   return {
-    createWithResponse: function () {
-      const payload: CreateAppActionCallProps = {
-        parameters: {
-          recipient: 'Alice <alice@my-company.com>',
-          message_body: 'Hello from Bob!',
-        },
-      }
-
+    createWithResponse: function (
+      params: CreateWithResponseParams,
+      payload: CreateAppActionCallProps
+    ) {
       return makeRequest({
         entityType: 'AppActionCall',
         action: 'createWithResponse',
-        params: {
-          spaceId: 'space-id',
-          environmentId: 'environment-id',
-          appDefinitionId: 'app-definiton-id',
-          appActionId: 'app-action-id',
-          ...retryOptions,
-        },
+        params: { ...params, ...retryOptions },
         payload: payload,
       }).then((data) => wrapAppActionCallResponse(makeRequest, data))
     },
 
-    getCallDetails: function getCallDetails() {
+    getCallDetails: function getCallDetails(params: GetAppActionCallDetailsParams) {
       return makeRequest({
         entityType: 'AppActionCall',
         action: 'getCallDetails',
-        params: {
-          spaceId: 'space-id',
-          environmentId: 'environment-id',
-          callId: 'call-id',
-          appActionId: 'app-action-id',
-        },
+        params,
       }).then((data) => wrapAppActionCallResponse(makeRequest, data))
     },
 
-    get: function get() {
+    get: function get(params: GetAppActionCallParamsWithId) {
       return makeRequest({
         entityType: 'AppActionCall',
         action: 'get',
-        params: {
-          spaceId: 'space-id',
-          environmentId: 'environment-id',
-          appDefinitionId: 'app-definiton-id',
-          appActionId: 'app-action-id',
-          callId: 'call-id',
-        },
+        params,
       }).then((data) => wrapAppActionCall(makeRequest, data))
     },
 
-    createWithResult: function () {
-      const payload: CreateAppActionCallProps = {
-        parameters: {
-          recipient: 'Alice <alice@my-company.com>',
-          message_body: 'Hello from Bob!',
-        },
-      }
-
+    createWithResult: function (params: CreateWithResultParams, payload: CreateAppActionCallProps) {
       return makeRequest({
         entityType: 'AppActionCall',
         action: 'createWithResult',
-        params: {
-          spaceId: 'space-id',
-          environmentId: 'environment-id',
-          appDefinitionId: 'app-definiton-id',
-          appActionId: 'app-action-id',
-          ...retryOptions,
-        },
+        params: { ...params, ...retryOptions },
         payload: payload,
       }).then((data) => wrapAppActionCall(makeRequest, data))
     },

--- a/test/unit/adapters/REST/endpoints/app-action-call.test.ts
+++ b/test/unit/adapters/REST/endpoints/app-action-call.test.ts
@@ -218,7 +218,15 @@ describe('Rest App Action Call', { concurrent: true }, () => {
       },
     }
 
-    const response = await entity.createWithResponse()
+    const response = await entity.createWithResponse(
+      {
+        spaceId: 'space-id',
+        environmentId: 'environment-id',
+        appDefinitionId: 'app-definiton-id',
+        appActionId: 'app-action-id',
+      },
+      payload
+    )
 
     expect(response).to.be.an('object')
     expect(response).to.deep.equal(entityMock)
@@ -249,9 +257,17 @@ describe('Rest App Action Call', { concurrent: true }, () => {
       { retryInterval: 100 }
     )
 
-    await expect(entity.createWithResponse()).rejects.toThrow(
-      'The app action response is taking longer than expected to process.'
-    )
+    await expect(
+      entity.createWithResponse(
+        {
+          spaceId: 'space-id',
+          environmentId: 'environment-id',
+          appDefinitionId: 'app-definiton-id',
+          appActionId: 'app-action-id',
+        },
+        { parameters: {} }
+      )
+    ).rejects.toThrow('The app action response is taking longer than expected to process.')
 
     expect(
       httpMock.get.mock.calls.filter((call) =>
@@ -283,7 +299,15 @@ describe('Rest App Action Call', { concurrent: true }, () => {
       { retryInterval: 100 }
     )
 
-    const result = await entity.createWithResponse()
+    const result = await entity.createWithResponse(
+      {
+        spaceId: 'space-id',
+        environmentId: 'environment-id',
+        appDefinitionId: 'app-definiton-id',
+        appActionId: 'app-action-id',
+      },
+      { parameters: {} }
+    )
 
     expect(result).to.deep.equal(responseMock)
 
@@ -311,9 +335,17 @@ describe('Rest App Action Call', { concurrent: true }, () => {
       { retryInterval: 100 }
     )
 
-    await expect(entity.createWithResponse()).rejects.toThrow(
-      'The app action response is taking longer than expected to process.'
-    )
+    await expect(
+      entity.createWithResponse(
+        {
+          spaceId: 'space-id',
+          environmentId: 'environment-id',
+          appDefinitionId: 'app-definiton-id',
+          appActionId: 'app-action-id',
+        },
+        { parameters: {} }
+      )
+    ).rejects.toThrow('The app action response is taking longer than expected to process.')
 
     expect(
       httpMock.get.mock.calls.filter((call) =>
@@ -339,9 +371,17 @@ describe('Rest App Action Call', { concurrent: true }, () => {
       { retryInterval: 100 }
     )
 
-    await expect(entity.createWithResponse()).rejects.toThrow(
-      'The app action response is taking longer than expected to process.'
-    )
+    await expect(
+      entity.createWithResponse(
+        {
+          spaceId: 'space-id',
+          environmentId: 'environment-id',
+          appDefinitionId: 'app-definiton-id',
+          appActionId: 'app-action-id',
+        },
+        { parameters: {} }
+      )
+    ).rejects.toThrow('The app action response is taking longer than expected to process.')
 
     expect(
       httpMock.get.mock.calls.filter((call) =>
@@ -373,9 +413,17 @@ describe('Rest App Action Call', { concurrent: true }, () => {
       entityMock
     )
 
-    await expect(entity.createWithResponse()).rejects.toThrow(
-      'App action not found or lambda fails'
-    )
+    await expect(
+      entity.createWithResponse(
+        {
+          spaceId: 'space-id',
+          environmentId: 'environment-id',
+          appDefinitionId: 'app-definiton-id',
+          appActionId: 'app-action-id',
+        },
+        { parameters: {} }
+      )
+    ).rejects.toThrow('App action not found or lambda fails')
 
     expect(
       httpMock.get.mock.calls.filter((call) =>
@@ -402,9 +450,17 @@ describe('Rest App Action Call', { concurrent: true }, () => {
       { retries: numRetries, retryInterval: 250 }
     )
 
-    await expect(entity.createWithResponse()).rejects.toThrow(
-      'The app action response is taking longer than expected to process.'
-    )
+    await expect(
+      entity.createWithResponse(
+        {
+          spaceId: 'space-id',
+          environmentId: 'environment-id',
+          appDefinitionId: 'app-definiton-id',
+          appActionId: 'app-action-id',
+        },
+        { parameters: {} }
+      )
+    ).rejects.toThrow('The app action response is taking longer than expected to process.')
 
     expect(
       httpMock.get.mock.calls.filter((call) =>
@@ -436,9 +492,17 @@ describe('Rest App Action Call', { concurrent: true }, () => {
       entityMock
     )
 
-    await expect(entity.createWithResponse()).rejects.toThrow(
-      'App action not found or lambda fails'
-    )
+    await expect(
+      entity.createWithResponse(
+        {
+          spaceId: 'space-id',
+          environmentId: 'environment-id',
+          appDefinitionId: 'app-definiton-id',
+          appActionId: 'app-action-id',
+        },
+        { parameters: {} }
+      )
+    ).rejects.toThrow('App action not found or lambda fails')
 
     expect(
       httpMock.get.mock.calls.filter((call) =>
@@ -461,7 +525,12 @@ describe('Rest App Action Call', { concurrent: true }, () => {
       entityMock
     )
 
-    const response = await entity.getCallDetails()
+    const response = await entity.getCallDetails({
+      spaceId: 'space-id',
+      environmentId: 'environment-id',
+      appActionId: 'app-action-id',
+      callId: 'call-id',
+    })
 
     expect(response).to.be.an('object')
     expect(response).to.deep.equal(entityMock)


### PR DESCRIPTION
## Summary

Fix legacy client (entity wrapper) for App Action Call to accept caller-provided params/payload. The plain client was already correctly wired and is unaffected.

## Description

- Legacy client: Updated `lib/entities/app-action-call.ts` to forward caller `params` and `payload` instead of using static placeholders.
  - `createWithResponse(params, payload)`
  - `getCallDetails(params)`
  - `get(params)`
  - `createWithResult(params, payload)`
  - Uses `CreateWithResponseParams`, `CreateWithResultParams`, `GetAppActionCallDetailsParams`, `GetAppActionCallParamsWithId`.
- Tests: Updated `test/unit/adapters/REST/endpoints/app-action-call.test.ts` to pass explicit `params`/`payload` to the entity methods.
- Plain client: No changes. It already used `wrap(...)` to merge defaults with user `params` and call the REST endpoints correctly.

## Motivation and Context

- Replace hardcoded placeholders in legacy entity wrapper with real plumbing, aligning with REST endpoints and current behavior.
- Clarify behavior: only the legacy client wrapper was using static data; the plain client was already passing options correctly.
- Public API remains unchanged: plain client and REST endpoints are unaffected. This is an internal fix for the legacy wrapper.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes to the public API (plain client unchanged)
- [x] Changes are reflected in the documentation