### PR TITLE
fix: add response.statusCode to AppActionCallRawResponse [EXT-6767]

### DIFF
--- a/lib/entities/app-action-call.ts
+++ b/lib/entities/app-action-call.ts
@@ -78,6 +78,7 @@ export interface AppActionCallRawResponseProps {
   }
   response: {
     headers?: { contentType?: string }
+    statusCode?: number
     body: string
   }
 }


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Fixes issue where `response.statusCode` was missing from `AppActionCallRawResponse` interface. 

<!-- Give a short summary what your PR is introducing/fixing. -->


## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation
