### PR TITLE
fix(types): add optional Link<Release> to EntityMetaSysProps []

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -291,6 +291,7 @@ export interface EntityMetaSysProps extends MetaSysProps {
   publishedCounter?: number
   locale?: string
   fieldStatus?: { '*': Record<string, 'draft' | 'changed' | 'published'> }
+  release?: Link<'Release'>
 }
 
 export interface EntryMetaSysProps extends EntityMetaSysProps {


### PR DESCRIPTION
## Summary

With Timeline the `Entry.sys` and `Asset.sys` can contain a proeprty `release`