### PR TITLE
feat: add support for release asset endpoints [TOL-3357]

### DIFF
--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -16,6 +16,8 @@ import type {
   UpdateEntryParams,
   UpdateReleaseEntryParams,
   CreateReleaseEntryParams,
+  GetManyReleaseEntryParams,
+  GetReleaseEntryParams,
 } from '../../../common-types'
 import type { CreateEntryProps, EntryProps, EntryReferenceProps } from '../../../entities/entry'
 import type { RestEndpoint } from '../types'
@@ -26,10 +28,14 @@ import * as releaseEntry from './release-entry'
 
 export const get: RestEndpoint<'Entry', 'get'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: GetEntryParams & QueryParams,
+  params: GetEntryParams & QueryParams & { releaseId?: string },
   rawData?: unknown,
   headers?: RawAxiosRequestHeaders
 ) => {
+  if (params.releaseId) {
+    return releaseEntry.get(http, params as GetReleaseEntryParams)
+  }
+
   return raw.get<EntryProps<T>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}`,
@@ -60,10 +66,14 @@ export const getPublished: RestEndpoint<'Entry', 'getPublished'> = <
 
 export const getMany: RestEndpoint<'Entry', 'getMany'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: GetManyEntryParams & QueryParams,
+  params: GetManyEntryParams & QueryParams & { releaseId?: string },
   rawData?: unknown,
   headers?: RawAxiosRequestHeaders
 ) => {
+  if (params.releaseId) {
+    return releaseEntry.getMany(http, params as GetManyReleaseEntryParams)
+  }
+
   return raw.get<CollectionProp<EntryProps<T>>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/entries`,

--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -39,6 +39,7 @@ import * as OAuthApplication from './oauth-application'
 import * as PersonalAccessToken from './personal-access-token'
 import * as PreviewApiKey from './preview-api-key'
 import * as Release from './release'
+import * as ReleaseAsset from './release-asset'
 import * as ReleaseEntry from './release-entry'
 import * as ReleaseAction from './release-action'
 import * as Resource from './resource'
@@ -108,6 +109,7 @@ export default {
   AccessToken,
   PreviewApiKey,
   Release,
+  ReleaseAsset,
   ReleaseEntry,
   ReleaseAction,
   Resource,

--- a/lib/adapters/REST/endpoints/release-asset.ts
+++ b/lib/adapters/REST/endpoints/release-asset.ts
@@ -1,0 +1,280 @@
+import { errorHandler, type AxiosInstance } from 'contentful-sdk-core'
+import type {
+  CreateReleaseAssetParams,
+  GetReleaseAssetParams,
+  GetManyReleaseAssetParams,
+  QueryParams,
+  UpdateReleaseAssetParams,
+  Link,
+  CollectionProp,
+  CreateWithIdReleaseAssetParams,
+  CreateWithFilesReleaseAssetParams,
+  ProcessForLocaleReleaseAssetParams,
+  ProcessForAllLocalesReleaseAssetParams,
+} from '../../../common-types'
+import type {
+  CreateAssetProps,
+  AssetProps,
+  AssetFileProp,
+  AssetProcessingForLocale,
+} from '../../../entities/asset'
+import copy from 'fast-copy'
+import type { RestEndpoint } from '../types'
+import * as raw from './raw'
+import type { RawAxiosRequestHeaders } from 'axios'
+import type { SetOptional } from 'type-fest'
+import { getUploadHttpClient } from '../../../upload-http-client'
+import { create as createUpload } from './upload'
+import { normalizeSelect } from './utils'
+
+type ReleaseAssetProps = AssetProps<{ release: Link<'Release'> }>
+
+export const get: RestEndpoint<'ReleaseAsset', 'get'> = (
+  http: AxiosInstance,
+  params: GetReleaseAssetParams & QueryParams,
+  rawData?: unknown,
+  headers?: RawAxiosRequestHeaders
+) => {
+  return raw.get<ReleaseAssetProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/assets/${params.assetId}`,
+    {
+      params: normalizeSelect(params.query),
+      headers: headers ? { ...headers } : undefined,
+    }
+  )
+}
+
+export const getMany: RestEndpoint<'ReleaseAsset', 'getMany'> = (
+  http: AxiosInstance,
+  params: GetManyReleaseAssetParams & QueryParams,
+  rawData?: unknown,
+  headers?: RawAxiosRequestHeaders
+) => {
+  params.query = { ...params.query, 'sys.schemaVersion': 'Release.V2' }
+
+  return raw.get<CollectionProp<ReleaseAssetProps>>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/assets`,
+    {
+      params: normalizeSelect(params.query),
+      headers: headers ? { ...headers } : undefined,
+    }
+  )
+}
+
+export const update: RestEndpoint<'ReleaseAsset', 'update'> = (
+  http: AxiosInstance,
+  params: UpdateReleaseAssetParams & QueryParams,
+  rawData: AssetProps,
+  headers?: RawAxiosRequestHeaders
+) => {
+  const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
+  delete data.sys
+  return raw.put<ReleaseAssetProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/assets/${params.assetId}`,
+    data,
+    {
+      headers: {
+        'X-Contentful-Version': rawData.sys.version ?? 0,
+        ...headers,
+      },
+    }
+  )
+}
+
+export const create: RestEndpoint<'ReleaseAsset', 'create'> = (
+  http: AxiosInstance,
+  params: CreateReleaseAssetParams,
+  rawData: CreateAssetProps,
+  headers?: RawAxiosRequestHeaders
+) => {
+  const data = copy(rawData)
+
+  return raw.post<ReleaseAssetProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/assets`,
+    data,
+    {
+      headers,
+    }
+  )
+}
+
+export const createWithId: RestEndpoint<'ReleaseAsset', 'createWithId'> = (
+  http: AxiosInstance,
+  params: CreateWithIdReleaseAssetParams,
+  rawData: CreateAssetProps,
+  headers?: RawAxiosRequestHeaders
+) => {
+  const data = copy(rawData)
+
+  return raw.put<ReleaseAssetProps>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/assets/${params.assetId}`,
+    data,
+    {
+      headers,
+    }
+  )
+}
+
+export const createFromFiles: RestEndpoint<'ReleaseAsset', 'createFromFiles'> = async (
+  http: AxiosInstance,
+  params: CreateWithFilesReleaseAssetParams,
+  data: Omit<AssetFileProp, 'sys'>
+) => {
+  const httpUpload = getUploadHttpClient(http, { uploadTimeout: params.uploadTimeout })
+
+  const { file } = data.fields
+  return Promise.all(
+    Object.keys(file).map(async (locale) => {
+      const { contentType, fileName } = file[locale]
+
+      return createUpload(httpUpload, params, file[locale]).then((upload) => {
+        return {
+          [locale]: {
+            contentType,
+            fileName,
+            uploadFrom: {
+              sys: {
+                type: 'Link',
+                linkType: 'Upload',
+                id: upload.sys.id,
+              },
+            },
+          },
+        }
+      })
+    })
+  )
+    .then((uploads) => {
+      const file = uploads.reduce((fieldsData, upload) => ({ ...fieldsData, ...upload }), {})
+      const asset = {
+        ...data,
+        fields: {
+          ...data.fields,
+          file,
+        },
+      }
+      return create(http, params, asset, {})
+    })
+    .catch(errorHandler)
+}
+
+/**
+ * Asset processing
+ */
+
+const ASSET_PROCESSING_CHECK_WAIT = 3000
+const ASSET_PROCESSING_CHECK_RETRIES = 10
+
+async function checkIfAssetHasUrl(
+  http: AxiosInstance,
+  params: GetReleaseAssetParams,
+  {
+    resolve,
+    reject,
+    locale,
+    processingCheckWait = ASSET_PROCESSING_CHECK_WAIT,
+    processingCheckRetries = ASSET_PROCESSING_CHECK_RETRIES,
+    checkCount = 0,
+  }: {
+    resolve: (asset: ReleaseAssetProps) => unknown
+    reject: (err: Error) => unknown
+    locale: string
+    checkCount?: number
+  } & AssetProcessingForLocale
+) {
+  return get(http, params).then((asset) => {
+    if (asset.fields.file[locale].url) {
+      resolve(asset)
+    } else if (checkCount === processingCheckRetries) {
+      const error = new Error()
+      error.name = 'AssetProcessingTimeout'
+      error.message = 'Asset is taking longer then expected to process.'
+      reject(error)
+    } else {
+      checkCount++
+      setTimeout(
+        () =>
+          checkIfAssetHasUrl(http, params, {
+            resolve: resolve,
+            reject: reject,
+            locale: locale,
+            checkCount: checkCount,
+            processingCheckWait,
+            processingCheckRetries,
+          }),
+        processingCheckWait
+      )
+    }
+  })
+}
+
+export const processForLocale: RestEndpoint<'ReleaseAsset', 'processForLocale'> = async (
+  http: AxiosInstance,
+  {
+    asset,
+    locale,
+    options: { processingCheckRetries, processingCheckWait } = {},
+    ...params
+  }: ProcessForLocaleReleaseAssetParams
+) => {
+  return raw
+    .put<ReleaseAssetProps>(
+      http,
+      `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${asset.sys.release.sys.id}/assets/${asset.sys.id}/files/${locale}/process`,
+      null,
+      {
+        headers: {
+          'X-Contentful-Version': asset.sys.version,
+        },
+      }
+    )
+    .then(() => {
+      return new Promise<ReleaseAssetProps>((resolve, reject) =>
+        checkIfAssetHasUrl(
+          http,
+          {
+            spaceId: params.spaceId,
+            environmentId: params.environmentId,
+            assetId: asset.sys.id,
+            releaseId: asset.sys.release.sys.id,
+          },
+          {
+            resolve,
+            reject,
+            locale,
+            processingCheckWait,
+            processingCheckRetries,
+          }
+        )
+      )
+    })
+}
+
+export const processForAllLocales: RestEndpoint<'ReleaseAsset', 'processForAllLocales'> = async (
+  http: AxiosInstance,
+  { asset, options = {}, ...params }: ProcessForAllLocalesReleaseAssetParams
+) => {
+  const locales = Object.keys(asset.fields.file || {})
+
+  let mostUpToDateAssetVersion: ReleaseAssetProps = asset
+
+  // Let all the locales process
+  // Since they all resolve at different times,
+  // we need to pick the last resolved value
+  // to reflect the most recent state
+  const allProcessingLocales = locales.map((locale) =>
+    processForLocale(http, { ...params, asset, locale, options }).then((result) => {
+      // Side effect of always setting the most up to date asset version
+      // The last one to call this will be the last one that finished
+      // and thus the most up to date
+      mostUpToDateAssetVersion = result
+    })
+  )
+
+  return Promise.all(allProcessingLocales).then(() => mostUpToDateAssetVersion)
+}

--- a/lib/adapters/REST/endpoints/release-entry.ts
+++ b/lib/adapters/REST/endpoints/release-entry.ts
@@ -8,6 +8,8 @@ import type {
   QueryParams,
   UpdateReleaseEntryParams,
   CreateWithIdReleaseEntryParams,
+  Link,
+  CollectionProp,
 } from '../../../common-types'
 import type { CreateEntryProps, EntryProps } from '../../../entities/entry'
 import copy from 'fast-copy'
@@ -16,53 +18,51 @@ import * as raw from './raw'
 import type { RawAxiosRequestHeaders } from 'axios'
 import type { SetOptional } from 'type-fest'
 import type { OpPatch } from 'json-patch'
+import { normalizeSelect } from './utils'
+
+type ReleaseEntryProps = EntryProps<unknown, { release: Link<'Release'> }>
 
 export const get: RestEndpoint<'ReleaseEntry', 'get'> = (
   http: AxiosInstance,
-  params: GetReleaseEntryParams
+  params: GetReleaseEntryParams & QueryParams,
+  rawData?: unknown,
+  headers?: RawAxiosRequestHeaders
 ) => {
-  //TODO: not fully implemented yet, only the get method
-  return raw.get(
+  return raw.get<ReleaseEntryProps>(
     http,
-    `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries/${params.entryId}`
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries/${params.entryId}`,
+    {
+      params: normalizeSelect(params.query),
+      headers: { ...headers },
+    }
   )
 }
 
 export const getMany: RestEndpoint<'ReleaseEntry', 'getMany'> = (
   http: AxiosInstance,
-  params: GetManyReleaseEntryParams & QueryParams
+  params: GetManyReleaseEntryParams & QueryParams,
+  rawData?: unknown,
+  headers?: RawAxiosRequestHeaders
 ) => {
-  params.query = { ...params.query, 'sys.schemaVersion': 'Release.V2' }
-
-  return raw.get(
+  return raw.get<CollectionProp<ReleaseEntryProps>>(
     http,
-    `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries`
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries`,
+    {
+      params: normalizeSelect(params.query),
+      headers: { ...headers },
+    }
   )
 }
 
 export const update: RestEndpoint<'ReleaseEntry', 'update'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: UpdateReleaseEntryParams & QueryParams,
+  params: UpdateReleaseEntryParams,
   rawData: EntryProps<T>,
   headers?: RawAxiosRequestHeaders
 ) => {
-  params.query = { ...params.query, 'sys.schemaVersion': 'Release.V2' }
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys
-  return raw.put<
-    EntryProps<
-      T,
-      {
-        release: {
-          sys: {
-            type: 'Link'
-            linkType: 'Entry' | 'Asset'
-            id: string
-          }
-        }
-      }
-    >
-  >(
+  return raw.put<ReleaseEntryProps>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries/${params.entryId}`,
     data,
@@ -77,12 +77,11 @@ export const update: RestEndpoint<'ReleaseEntry', 'update'> = <T extends KeyValu
 
 export const patch: RestEndpoint<'ReleaseEntry', 'patch'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: PatchReleaseEntryParams & QueryParams,
+  params: PatchReleaseEntryParams,
   data: OpPatch[],
   headers?: RawAxiosRequestHeaders
 ) => {
-  params.query = { ...params.query, 'sys.schemaVersion': 'Release.V2' }
-  return raw.patch<EntryProps<T, any>>(
+  return raw.patch<ReleaseEntryProps>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries/${params.entryId}`,
     data,
@@ -98,27 +97,13 @@ export const patch: RestEndpoint<'ReleaseEntry', 'patch'> = <T extends KeyValueM
 
 export const create: RestEndpoint<'ReleaseEntry', 'create'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: CreateReleaseEntryParams & QueryParams,
+  params: CreateReleaseEntryParams,
   rawData: CreateEntryProps<T>,
   headers?: RawAxiosRequestHeaders
 ) => {
-  params.query = { ...params.query, 'sys.schemaVersion': 'Release.V2' }
   const data = copy(rawData)
 
-  return raw.post<
-    EntryProps<
-      T,
-      {
-        release: {
-          sys: {
-            type: 'Link'
-            linkType: 'Entry' | 'Asset'
-            id: string
-          }
-        }
-      }
-    >
-  >(
+  return raw.post<ReleaseEntryProps>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries`,
     data,
@@ -135,27 +120,13 @@ export const createWithId: RestEndpoint<'ReleaseEntry', 'createWithId'> = <
   T extends KeyValueMap = KeyValueMap
 >(
   http: AxiosInstance,
-  params: CreateWithIdReleaseEntryParams & QueryParams,
+  params: CreateWithIdReleaseEntryParams,
   rawData: CreateEntryProps<T>,
   headers?: RawAxiosRequestHeaders
 ) => {
-  params.query = { ...params.query, 'sys.schemaVersion': 'Release.V2' }
   const data = copy(rawData)
 
-  return raw.put<
-    EntryProps<
-      T,
-      {
-        release: {
-          sys: {
-            type: 'Link'
-            linkType: 'Entry' | 'Asset'
-            id: string
-          }
-        }
-      }
-    >
-  >(
+  return raw.put<ReleaseEntryProps>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries/${params.entryId}`,
     data,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -723,6 +723,21 @@ type MRInternal<UA extends boolean> = {
     'queryForRelease'
   >
 
+  (opts: MROpts<'ReleaseAsset', 'get', UA>): MRReturn<'ReleaseAsset', 'get'>
+  (opts: MROpts<'ReleaseAsset', 'getMany', UA>): MRReturn<'ReleaseAsset', 'getMany'>
+  (opts: MROpts<'ReleaseAsset', 'update', UA>): MRReturn<'ReleaseAsset', 'update'>
+  (opts: MROpts<'ReleaseAsset', 'create', UA>): MRReturn<'ReleaseAsset', 'create'>
+  (opts: MROpts<'ReleaseAsset', 'createWithId', UA>): MRReturn<'ReleaseAsset', 'createWithId'>
+  (opts: MROpts<'ReleaseAsset', 'createFromFiles', UA>): MRReturn<'ReleaseAsset', 'createFromFiles'>
+  (opts: MROpts<'ReleaseAsset', 'processForAllLocales', UA>): MRReturn<
+    'ReleaseAsset',
+    'processForAllLocales'
+  >
+  (opts: MROpts<'ReleaseAsset', 'processForLocale', UA>): MRReturn<
+    'ReleaseAsset',
+    'processForLocale'
+  >
+
   (opts: MROpts<'ReleaseEntry', 'get', UA>): MRReturn<'ReleaseEntry', 'get'>
   (opts: MROpts<'ReleaseEntry', 'getMany', UA>): MRReturn<'ReleaseEntry', 'getMany'>
   (opts: MROpts<'ReleaseEntry', 'update', UA>): MRReturn<'ReleaseEntry', 'update'>
@@ -1235,17 +1250,17 @@ export type MRActions = {
       return: CollectionProp<AssetProps>
     }
     getMany: {
-      params: GetSpaceEnvironmentParams & QueryParams
+      params: GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }
       headers?: RawAxiosRequestHeaders
       return: CollectionProp<AssetProps>
     }
     get: {
-      params: GetSpaceEnvironmentParams & { assetId: string } & QueryParams
+      params: GetSpaceEnvironmentParams & { assetId: string; releaseId?: string } & QueryParams
       headers?: RawAxiosRequestHeaders
       return: AssetProps
     }
     update: {
-      params: GetSpaceEnvironmentParams & { assetId: string }
+      params: GetSpaceEnvironmentParams & { assetId: string; releaseId?: string }
       payload: AssetProps
       headers?: RawAxiosRequestHeaders
       return: AssetProps
@@ -1259,14 +1274,18 @@ export type MRActions = {
     unpublish: { params: GetSpaceEnvironmentParams & { assetId: string }; return: AssetProps }
     archive: { params: GetSpaceEnvironmentParams & { assetId: string }; return: AssetProps }
     unarchive: { params: GetSpaceEnvironmentParams & { assetId: string }; return: AssetProps }
-    create: { params: GetSpaceEnvironmentParams; payload: CreateAssetProps; return: AssetProps }
+    create: {
+      params: GetSpaceEnvironmentParams & { releaseId?: string }
+      payload: CreateAssetProps
+      return: AssetProps
+    }
     createWithId: {
-      params: GetSpaceEnvironmentParams & { assetId: string }
+      params: GetSpaceEnvironmentParams & { assetId: string; releaseId?: string }
       payload: CreateAssetProps
       return: AssetProps
     }
     createFromFiles: {
-      params: GetSpaceEnvironmentParams & { uploadTimeout?: number }
+      params: GetSpaceEnvironmentParams & { uploadTimeout?: number; releaseId?: string }
       payload: Omit<AssetFileProp, 'sys'>
       return: AssetProps
     }
@@ -1626,21 +1645,21 @@ export type MRActions = {
       return: CollectionProp<EntryProps<any>>
     }
     getMany: {
-      params: GetManyEntryParams & QueryParams
+      params: GetManyEntryParams & QueryParams & { releaseId?: string }
       return: CollectionProp<EntryProps<any, any>>
     }
     get: {
-      params: GetEntryParams & QueryParams
+      params: GetEntryParams & QueryParams & { releaseId?: string }
       return: EntryProps<any, any>
     }
     patch: {
-      params: PatchEntryParams & QueryParams
+      params: PatchEntryParams & QueryParams & { releaseId?: string }
       payload: OpPatch[]
       headers?: RawAxiosRequestHeaders
       return: EntryProps<any>
     }
     update: {
-      params: UpdateEntryParams & QueryParams
+      params: UpdateEntryParams & QueryParams & { releaseId?: string }
       payload: EntryProps<any>
       headers?: RawAxiosRequestHeaders
       return: EntryProps<any>
@@ -1882,89 +1901,86 @@ export type MRActions = {
       return: ReleaseActionProps<'validate'>
     }
   }
+  ReleaseAsset: {
+    get: {
+      params: GetReleaseAssetParams & QueryParams
+      headers?: RawAxiosRequestHeaders
+      return: AssetProps<{ release: Link<'Release'> }>
+    }
+    getMany: {
+      params: GetManyReleaseAssetParams & QueryParams
+      headers?: RawAxiosRequestHeaders
+      return: CollectionProp<AssetProps<{ release: Link<'Release'> }>>
+    }
+    update: {
+      params: UpdateReleaseAssetParams & QueryParams
+      payload: AssetProps
+      headers?: RawAxiosRequestHeaders
+      return: AssetProps<{ release: Link<'Release'> }>
+    }
+    create: {
+      params: CreateReleaseAssetParams & QueryParams
+      payload: CreateAssetProps
+      headers?: RawAxiosRequestHeaders
+      return: AssetProps<{ release: Link<'Release'> }>
+    }
+    createWithId: {
+      params: CreateWithIdReleaseAssetParams & QueryParams
+      payload: CreateAssetProps
+      headers?: RawAxiosRequestHeaders
+      return: AssetProps<{ release: Link<'Release'> }>
+    }
+    createFromFiles: {
+      params: CreateWithFilesReleaseAssetParams & QueryParams
+      payload: Omit<AssetFileProp, 'sys'>
+      headers?: RawAxiosRequestHeaders
+      return: AssetProps<{ release: Link<'Release'> }>
+    }
+    processForAllLocales: {
+      params: ProcessForAllLocalesReleaseAssetParams
+      return: AssetProps<{ release: Link<'Release'> }>
+    }
+    processForLocale: {
+      params: ProcessForLocaleReleaseAssetParams
+      return: AssetProps<{ release: Link<'Release'> }>
+    }
+  }
   ReleaseEntry: {
     get: {
-      params: GetReleaseEntryParams
+      params: GetReleaseEntryParams & QueryParams
+      headers?: RawAxiosRequestHeaders
       return: EntryProps<any, any>
     }
     getMany: {
-      params: GetManyReleaseEntryParams
+      params: GetManyReleaseEntryParams & QueryParams
+      headers?: RawAxiosRequestHeaders
       return: CollectionProp<EntryProps<any, any>>
     }
     update: {
-      params: UpdateReleaseEntryParams & { entryId: string }
+      params: UpdateReleaseEntryParams & QueryParams
       payload: EntryProps<any>
       headers?: RawAxiosRequestHeaders
-      return: EntryProps<
-        any,
-        {
-          release: {
-            sys: {
-              type: 'Link'
-              linkType: 'Entry' | 'Asset'
-              id: string
-            }
-          }
-        }
-      >
+      return: EntryProps<any, { release: Link<'Release'> }>
     }
     patch: {
-      params: PatchReleaseEntryParams & {
-        entryId: string
-        version: number
-      }
+      params: PatchReleaseEntryParams & QueryParams
       payload: OpPatch[]
       headers?: RawAxiosRequestHeaders
-      return: EntryProps<
-        any,
-        {
-          release: {
-            sys: {
-              type: 'Link'
-              linkType: 'Entry' | 'Asset'
-              id: string
-            }
-          }
-        }
-      >
+      return: EntryProps<any, { release: Link<'Release'> }>
     }
     create: {
-      params: CreateReleaseEntryParams
+      params: CreateReleaseEntryParams & QueryParams
       payload: CreateEntryProps<any>
       headers?: RawAxiosRequestHeaders
-      return: EntryProps<
-        any,
-        {
-          release: {
-            sys: {
-              type: 'Link'
-              linkType: 'Entry' | 'Asset'
-              id: string
-            }
-          }
-        }
-      >
+      return: EntryProps<any, { release: Link<'Release'> }>
     }
     createWithId: {
-      params: GetSpaceEnvironmentParams & {
-        releaseId: string
+      params: CreateReleaseEntryParams & {
         entryId: string
-        contentTypeId: string
-      }
+      } & QueryParams
       payload: CreateEntryProps<any>
       headers?: RawAxiosRequestHeaders
-      return: EntryProps<
-        any,
-        {
-          release: {
-            sys: {
-              type: 'Link'
-              linkType: 'Entry' | 'Asset'
-              id: string
-            }
-          }
-        }
-      >
+      return: EntryProps<any, { release: Link<'Release'> }>
     }
   }
   ReleaseAction: {
@@ -2462,9 +2478,38 @@ export type GetManyFunctionLogParams = CursorBasedParams &
 export type GetFunctionLogParams = GetManyFunctionLogParams & { logId: string }
 export type GetOrganizationParams = { organizationId: string }
 export type GetReleaseParams = ReleaseEnvironmentParams & { releaseId: string }
+export type GetReleaseAssetParams = GetSpaceEnvironmentParams & {
+  releaseId: string
+  assetId: string
+}
+export type GetManyReleaseAssetParams = GetSpaceEnvironmentParams & { releaseId: string }
 export type GetReleaseEntryParams = GetSpaceEnvironmentParams & {
-  releaseId?: string
+  releaseId: string
   entryId: string
+}
+export type CreateReleaseAssetParams = GetSpaceEnvironmentParams & {
+  releaseId: string
+}
+export type CreateWithIdReleaseAssetParams = GetSpaceEnvironmentParams & {
+  releaseId: string
+  assetId: string
+}
+export type CreateWithFilesReleaseAssetParams = GetSpaceEnvironmentParams & {
+  releaseId: string
+  uploadTimeout?: number
+}
+export type UpdateReleaseAssetParams = GetSpaceEnvironmentParams & {
+  releaseId: string
+  assetId: string
+}
+export type ProcessForLocaleReleaseAssetParams = GetSpaceEnvironmentParams & {
+  asset: AssetProps<{ release: Link<'Release'> }>
+  locale: string
+  options?: AssetProcessingForLocale
+}
+export type ProcessForAllLocalesReleaseAssetParams = GetSpaceEnvironmentParams & {
+  asset: AssetProps<{ release: Link<'Release'> }>
+  options?: AssetProcessingForLocale
 }
 export type GetManyReleaseEntryParams = GetSpaceEnvironmentParams & { releaseId: string }
 export type UpdateReleaseEntryParams = GetSpaceEnvironmentParams & {

--- a/lib/entities/asset.ts
+++ b/lib/entities/asset.ts
@@ -12,8 +12,8 @@ import type {
 import { wrapCollection } from '../common-utils'
 import * as checks from '../plain/checks'
 
-export type AssetProps = {
-  sys: EntityMetaSysProps
+export type AssetProps<S = {}> = {
+  sys: EntityMetaSysProps & S
   fields: {
     /** Title for this asset */
     title: { [key: string]: string }

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -3,7 +3,10 @@ import type { OpPatch } from 'json-patch'
 import type {
   BasicCursorPaginationOptions,
   CollectionProp,
+  CreateReleaseAssetParams,
   CreateReleaseEntryParams,
+  CreateWithFilesReleaseAssetParams,
+  CreateWithIdReleaseAssetParams,
   CreateWithIdReleaseEntryParams,
   CursorPaginatedCollectionProp,
   EnvironmentTemplateParams,
@@ -12,9 +15,11 @@ import type {
   GetEntryParams,
   GetEnvironmentTemplateParams,
   GetManyEntryParams,
+  GetManyReleaseAssetParams,
   GetManyReleaseEntryParams,
   GetOrganizationMembershipParams,
   GetOrganizationParams,
+  GetReleaseAssetParams,
   GetReleaseEntryParams,
   GetReleaseParams,
   GetSnapshotForContentTypeParams,
@@ -22,11 +27,15 @@ import type {
   GetSpaceEnvironmentParams,
   GetSpaceParams,
   KeyValueMap,
+  Link,
   PatchEntryParams,
   PatchReleaseEntryParams,
+  ProcessForAllLocalesReleaseAssetParams,
+  ProcessForLocaleReleaseAssetParams,
   QueryParams,
   ReleaseEnvironmentParams,
   UpdateEntryParams,
+  UpdateReleaseAssetParams,
   UpdateReleaseEntryParams,
 } from '../common-types'
 import type {
@@ -447,113 +456,80 @@ export type PlainClientAPI = {
   }
   usage: UsagePlainClientAPI
   release: {
+    asset: {
+      get(
+        params: OptionalDefaults<GetReleaseAssetParams & QueryParams>,
+        rawData?: unknown,
+        headers?: RawAxiosRequestHeaders
+      ): Promise<AssetProps<{ release: Link<'Release'> }>>
+      getMany(
+        params: OptionalDefaults<GetManyReleaseAssetParams & QueryParams>,
+        rawData?: unknown,
+        headers?: RawAxiosRequestHeaders
+      ): Promise<CollectionProp<AssetProps<{ release: Link<'Release'> }>>>
+      update(
+        params: OptionalDefaults<UpdateReleaseAssetParams & QueryParams>,
+        rawData: AssetProps,
+        headers?: RawAxiosRequestHeaders
+      ): Promise<AssetProps<{ release: Link<'Release'> }>>
+      create(
+        params: OptionalDefaults<CreateReleaseAssetParams & QueryParams>,
+        rawData: CreateAssetProps,
+        headers?: RawAxiosRequestHeaders
+      ): Promise<AssetProps<{ release: Link<'Release'> }>>
+      createWithId(
+        params: OptionalDefaults<CreateWithIdReleaseAssetParams & QueryParams>,
+        rawData: CreateAssetProps,
+        headers?: RawAxiosRequestHeaders
+      ): Promise<AssetProps<{ release: Link<'Release'> }>>
+      createFromFiles(
+        params: OptionalDefaults<CreateWithFilesReleaseAssetParams & QueryParams>,
+        data: Omit<AssetFileProp, 'sys'>,
+        headers?: RawAxiosRequestHeaders
+      ): Promise<AssetProps<{ release: Link<'Release'> }>>
+      processForLocale(
+        params: OptionalDefaults<ProcessForLocaleReleaseAssetParams>,
+        asset: AssetProps<{ release: Link<'Release'> }>,
+        locale: string,
+        processingOptions?: AssetProcessingForLocale
+      ): Promise<AssetProps<{ release: Link<'Release'> }>>
+      processForAllLocales(
+        params: OptionalDefaults<ProcessForAllLocalesReleaseAssetParams>,
+        asset: AssetProps<{ release: Link<'Release'> }>,
+        processingOptions?: AssetProcessingForLocale
+      ): Promise<AssetProps<{ release: Link<'Release'> }>>
+    }
     entry: {
       get<T extends KeyValueMap = KeyValueMap>(
-        params: OptionalDefaults<GetReleaseEntryParams & QueryParams>
-      ): Promise<
-        EntryProps<
-          T,
-          {
-            release: {
-              sys: {
-                type: 'Link'
-                linkType: 'Entry' | 'Asset'
-                id: string
-              }
-            }
-          }
-        >
-      >
+        params: OptionalDefaults<GetReleaseEntryParams & QueryParams>,
+        rawData?: unknown,
+        headers?: RawAxiosRequestHeaders
+      ): Promise<EntryProps<T, { release: Link<'Release'> }>>
       getMany<T extends KeyValueMap = KeyValueMap>(
-        params: OptionalDefaults<GetManyReleaseEntryParams & QueryParams>
-      ): Promise<
-        CollectionProp<
-          EntryProps<
-            T,
-            {
-              release: {
-                sys: {
-                  type: 'Link'
-                  linkType: 'Entry' | 'Asset'
-                  id: string
-                }
-              }
-            }
-          >
-        >
-      >
+        params: OptionalDefaults<GetManyReleaseEntryParams & QueryParams>,
+        rawData?: unknown,
+        headers?: RawAxiosRequestHeaders
+      ): Promise<CollectionProp<EntryProps<T, { release: Link<'Release'> }>>>
       update<T extends KeyValueMap = KeyValueMap>(
         params: OptionalDefaults<UpdateReleaseEntryParams & QueryParams>,
         rawData: EntryProps<T>,
         headers?: RawAxiosRequestHeaders
-      ): Promise<
-        EntryProps<
-          T,
-          {
-            release: {
-              sys: {
-                type: 'Link'
-                linkType: 'Entry' | 'Asset'
-                id: string
-              }
-            }
-          }
-        >
-      >
+      ): Promise<EntryProps<T, { release: Link<'Release'> }>>
       patch<T extends KeyValueMap = KeyValueMap>(
         params: OptionalDefaults<PatchReleaseEntryParams & QueryParams>,
         rawData: OpPatch[],
         headers?: RawAxiosRequestHeaders
-      ): Promise<
-        EntryProps<
-          T,
-          {
-            release: {
-              sys: {
-                type: 'Link'
-                linkType: 'Entry' | 'Asset'
-                id: string
-              }
-            }
-          }
-        >
-      >
+      ): Promise<EntryProps<T, { release: Link<'Release'> }>>
       create<T extends KeyValueMap = KeyValueMap>(
         params: OptionalDefaults<CreateReleaseEntryParams & QueryParams>,
         rawData: CreateEntryProps<T>,
         headers?: RawAxiosRequestHeaders
-      ): Promise<
-        EntryProps<
-          T,
-          {
-            release: {
-              sys: {
-                type: 'Link'
-                linkType: 'Entry' | 'Asset'
-                id: string
-              }
-            }
-          }
-        >
-      >
+      ): Promise<EntryProps<T, { release: Link<'Release'> }>>
       createWithId<T extends KeyValueMap = KeyValueMap>(
         params: OptionalDefaults<CreateWithIdReleaseEntryParams & QueryParams>,
         rawData: CreateEntryProps<T>,
         headers?: RawAxiosRequestHeaders
-      ): Promise<
-        EntryProps<
-          T,
-          {
-            release: {
-              sys: {
-                type: 'Link'
-                linkType: 'Entry' | 'Asset'
-                id: string
-              }
-            }
-          }
-        >
-      >
+      ): Promise<EntryProps<T, { release: Link<'Release'> }>>
     }
     archive(params: OptionalDefaults<GetReleaseParams & { version: number }>): Promise<ReleaseProps>
     get(params: OptionalDefaults<GetReleaseParams>): Promise<ReleaseProps>

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -345,6 +345,35 @@ export const createPlainClient = (
       getManyForOrganization: wrap(wrapParams, 'Usage', 'getManyForOrganization'),
     },
     release: {
+      asset: {
+        get: wrap(wrapParams, 'ReleaseAsset', 'get'),
+        getMany: wrap(wrapParams, 'ReleaseAsset', 'getMany'),
+        update: wrap(wrapParams, 'ReleaseAsset', 'update'),
+        create: wrap(wrapParams, 'ReleaseAsset', 'create'),
+        createWithId: wrap(wrapParams, 'ReleaseAsset', 'createWithId'),
+        createFromFiles: wrap(wrapParams, 'ReleaseAsset', 'createFromFiles'),
+        processForAllLocales: (params, asset, options) =>
+          makeRequest({
+            entityType: 'ReleaseAsset',
+            action: 'processForAllLocales',
+            params: {
+              ...({ ...defaults, ...params } as GetSpaceEnvironmentParams),
+              options,
+              asset,
+            },
+          }),
+        processForLocale: (params, asset, locale, options) =>
+          makeRequest({
+            entityType: 'ReleaseAsset',
+            action: 'processForLocale',
+            params: {
+              ...({ ...defaults, ...params } as GetSpaceEnvironmentParams),
+              locale,
+              asset,
+              options,
+            },
+          }),
+      },
       entry: {
         get: wrap(wrapParams, 'ReleaseEntry', 'get'),
         getMany: wrap(wrapParams, 'ReleaseEntry', 'getMany'),

--- a/test/unit/adapters/REST/endpoints/release-asset.test.ts
+++ b/test/unit/adapters/REST/endpoints/release-asset.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from 'vitest'
+import { cloneMock } from '../../../mocks/entities'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+
+function setup(promise, params = {}) {
+  return {
+    ...setupRestAdapter(promise, params),
+    entityMock: cloneMock('releaseAsset'),
+  }
+}
+
+describe('Rest ReleaseAsset', () => {
+  test('get', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.get.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseAsset',
+        action: 'get',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          releaseId: 'mock-release-id',
+          assetId: 'abc123',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/mock-release-id/assets/abc123'
+        )
+      })
+  })
+
+  test('getMany', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.get.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseAsset',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          releaseId: 'mock-release-id',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/mock-release-id/assets'
+        )
+      })
+  })
+
+  test('update', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.put.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseAsset',
+        action: 'update',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          releaseId: 'mock-release-id',
+          assetId: 'abc123',
+        },
+        payload: entityMock,
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/mock-release-id/assets/abc123'
+        )
+      })
+  })
+
+  test('create', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.post.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseAsset',
+        action: 'create',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          releaseId: 'mock-release-id',
+        },
+        payload: entityMock,
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.post.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/mock-release-id/assets'
+        )
+        expect(httpMock.post.mock.calls[0][1]).to.eql(entityMock)
+      })
+  })
+
+  test('createWithId', async () => {
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({}))
+
+    httpMock.put.mockReturnValue(Promise.resolve({ data: entityMock }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseAsset',
+        action: 'createWithId',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          releaseId: 'mock-release-id',
+          assetId: 'abc123',
+        },
+        payload: entityMock,
+      })
+      .then((r) => {
+        expect(r).to.eql(entityMock)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/mock-release-id/assets/abc123'
+        )
+      })
+  })
+
+  test('Asset processing for multiple locales succeeds', async () => {
+    const responseMock = cloneMock('releaseAsset')
+    responseMock.fields = {
+      file: {
+        'en-US': {
+          fileName: 'filename.jpg',
+          url: 'http://server/filename.jpg',
+        },
+        'de-DE': {
+          fileName: 'filename.jpg',
+          url: 'http://server/filename.jpg',
+        },
+      },
+    }
+    const { httpMock, adapterMock, entityMock } = setup(Promise.resolve({ data: responseMock }))
+    entityMock.fields = {
+      file: {
+        'en-US': {
+          fileName: 'filename.jpg',
+          upload: 'http://server/filename.jpg',
+        },
+        'de-DE': {
+          fileName: 'filename.jpg',
+          upload: 'http://server/filename.jpg',
+        },
+      },
+    }
+    entityMock.sys.version = 2
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseAsset',
+        action: 'processForAllLocales',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          asset: entityMock,
+        },
+      })
+      .then(() => {
+        expect(httpMock.put.mock.calls[0][0]).equals(
+          '/spaces/space123/environments/master/releases/mock-release-id/assets/id/files/en-US/process',
+          'en-US locale is sent'
+        )
+        expect(httpMock.put.mock.calls[1][0]).equals(
+          '/spaces/space123/environments/master/releases/mock-release-id/assets/id/files/de-DE/process',
+          'de-DE locale is sent'
+        )
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).equals(
+          2,
+          'version header is sent for first locale'
+        )
+        expect(httpMock.put.mock.calls[1][2].headers['X-Contentful-Version']).equals(
+          2,
+          'version header is sent for second locale'
+        )
+        expect(httpMock.get.mock.calls[0][0]).equals(
+          '/spaces/space123/environments/master/releases/mock-release-id/assets/id',
+          'asset was checked after processing for first locale'
+        )
+        expect(httpMock.get.mock.calls[1][0]).equals(
+          '/spaces/space123/environments/master/releases/mock-release-id/assets/id',
+          'asset was checked after processing for second locale'
+        )
+      })
+  })
+
+  test('Asset processing for one locale succeeds', async () => {
+    const responseMock = cloneMock('releaseAsset')
+    responseMock.fields = {
+      file: {
+        'en-US': {
+          fileName: 'filename.jpg',
+          url: 'http://server/filename.jpg',
+        },
+      },
+    }
+    const { httpMock, entityMock, adapterMock } = setup(Promise.resolve({ data: responseMock }))
+    entityMock.sys.version = 2
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseAsset',
+        action: 'processForLocale',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          locale: 'en-US',
+          asset: entityMock,
+        },
+      })
+      .then(() => {
+        expect(httpMock.put.mock.calls[0][0]).equals(
+          '/spaces/space123/environments/master/releases/mock-release-id/assets/id/files/en-US/process',
+          'correct locale is sent'
+        )
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).equals(
+          2,
+          'version header is sent'
+        )
+        expect(httpMock.get.mock.calls[0][0]).equals(
+          '/spaces/space123/environments/master/releases/mock-release-id/assets/id',
+          'asset was checked after processing'
+        )
+      })
+  })
+})

--- a/test/unit/mocks/entities.ts
+++ b/test/unit/mocks/entities.ts
@@ -814,10 +814,21 @@ const releaseActionUnpublishMock: ReleaseActionProps = {
   action: 'unpublish',
 }
 
-const releaseEntryMock: EntryProps<
-  any,
-  { release: { sys: { type: 'Link'; linkType: 'Release'; id: string } } }
-> = {
+const releaseAssetMock: AssetProps<{ release: Link<'Release'> }> = {
+  ...assetMock,
+  sys: {
+    ...assetMock.sys,
+    release: {
+      sys: {
+        type: 'Link' as const,
+        linkType: 'Release' as const,
+        id: 'mock-release-id',
+      },
+    },
+  },
+}
+
+const releaseEntryMock: EntryProps<any, { release: Link<'Release'> }> = {
   ...entryMock,
   sys: {
     ...entryMock.sys,
@@ -1426,6 +1437,7 @@ const mocks = {
   releaseAction: releaseActionMock,
   releaseActionValidate: releaseActionValidateMock,
   releaseActionUnpublish: releaseActionUnpublishMock,
+  releaseAsset: releaseAssetMock,
   releaseEntry: releaseEntryMock,
   resource: resourceMock,
   resourceProvider: resourceProviderMock,


### PR DESCRIPTION
## Summary

Add support for the release asset endpoints + improve typing for release entities

- [x] release scoped endpoints
- [x] support releaseId on asset endpoints
- [x] tests
