### PR TITLE
fix: update types, add tests, and cleanup [DX-397]

### DIFF
--- a/lib/adapters/REST/endpoints/entry.ts
+++ b/lib/adapters/REST/endpoints/entry.ts
@@ -5,30 +5,25 @@ import type { OpPatch } from 'json-patch'
 import type { SetOptional } from 'type-fest'
 import type {
   CollectionProp,
-  GetEntryParams,
-  GetManyEntryParams,
-  CreateWithIdReleaseEntryParams,
-  GetSpaceEnvironmentParams,
-  KeyValueMap,
-  PatchEntryParams,
-  PatchReleaseEntryParams,
-  QueryParams,
-  UpdateEntryParams,
-  UpdateReleaseEntryParams,
   CreateReleaseEntryParams,
+  CreateWithIdReleaseEntryParams,
   GetManyReleaseEntryParams,
   GetReleaseEntryParams,
+  GetSpaceEnvironmentParams,
+  KeyValueMap,
+  PatchReleaseEntryParams,
+  QueryParams,
+  UpdateReleaseEntryParams,
 } from '../../../common-types'
 import type { CreateEntryProps, EntryProps, EntryReferenceProps } from '../../../entities/entry'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
-import { createWithId as createWithIdReleaseEntry } from './release-entry'
-import { normalizeSelect } from './utils'
 import * as releaseEntry from './release-entry'
+import { normalizeSelect } from './utils'
 
 export const get: RestEndpoint<'Entry', 'get'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: GetEntryParams & QueryParams & { releaseId?: string },
+  params: GetSpaceEnvironmentParams & { entryId: string; releaseId?: string } & QueryParams,
   rawData?: unknown,
   headers?: RawAxiosRequestHeaders
 ) => {
@@ -66,7 +61,7 @@ export const getPublished: RestEndpoint<'Entry', 'getPublished'> = <
 
 export const getMany: RestEndpoint<'Entry', 'getMany'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: GetManyEntryParams & QueryParams & { releaseId?: string },
+  params: GetSpaceEnvironmentParams & QueryParams & { releaseId?: string },
   rawData?: unknown,
   headers?: RawAxiosRequestHeaders
 ) => {
@@ -86,7 +81,7 @@ export const getMany: RestEndpoint<'Entry', 'getMany'> = <T extends KeyValueMap 
 
 export const patch: RestEndpoint<'Entry', 'patch'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: PatchEntryParams & QueryParams,
+  params: GetSpaceEnvironmentParams & { entryId: string; version: number; releaseId?: string },
   data: OpPatch[],
   headers?: RawAxiosRequestHeaders
 ) => {
@@ -110,7 +105,7 @@ export const patch: RestEndpoint<'Entry', 'patch'> = <T extends KeyValueMap = Ke
 
 export const update: RestEndpoint<'Entry', 'update'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: UpdateEntryParams & QueryParams,
+  params: GetSpaceEnvironmentParams & { entryId: string; releaseId?: string },
   rawData: EntryProps<T>,
   headers?: RawAxiosRequestHeaders
 ) => {
@@ -209,7 +204,7 @@ export const unarchive: RestEndpoint<'Entry', 'unarchive'> = <T extends KeyValue
 
 export const create: RestEndpoint<'Entry', 'create'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
-  params: GetSpaceEnvironmentParams & { contentTypeId: string; releaseId?: string } & QueryParams,
+  params: GetSpaceEnvironmentParams & { contentTypeId: string; releaseId?: string },
   rawData: CreateEntryProps<T>
 ) => {
   if (params.releaseId) {
@@ -242,21 +237,20 @@ export const createWithId: RestEndpoint<'Entry', 'createWithId'> = <
   rawData: CreateEntryProps<T>
 ) => {
   if (params.releaseId) {
-    return createWithIdReleaseEntry(http, params as CreateWithIdReleaseEntryParams, rawData, {})
-  } else {
-    const data = copy(rawData)
-
-    return raw.put<EntryProps<T>>(
-      http,
-      `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}`,
-      data,
-      {
-        headers: {
-          'X-Contentful-Content-Type': params.contentTypeId,
-        },
-      }
-    )
+    return releaseEntry.createWithId(http, params as CreateWithIdReleaseEntryParams, rawData, {})
   }
+  const data = copy(rawData)
+
+  return raw.put<EntryProps<T>>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}`,
+    data,
+    {
+      headers: {
+        'X-Contentful-Content-Type': params.contentTypeId,
+      },
+    }
+  )
 }
 
 export const references: RestEndpoint<'Entry', 'references'> = (

--- a/lib/adapters/REST/endpoints/release-asset.ts
+++ b/lib/adapters/REST/endpoints/release-asset.ts
@@ -1,29 +1,29 @@
+import type { RawAxiosRequestHeaders } from 'axios'
 import { errorHandler, type AxiosInstance } from 'contentful-sdk-core'
+import copy from 'fast-copy'
+import type { SetOptional } from 'type-fest'
 import type {
+  CollectionProp,
   CreateReleaseAssetParams,
-  GetReleaseAssetParams,
+  CreateWithFilesReleaseAssetParams,
+  CreateWithIdReleaseAssetParams,
   GetManyReleaseAssetParams,
+  GetReleaseAssetParams,
+  Link,
+  ProcessForAllLocalesReleaseAssetParams,
+  ProcessForLocaleReleaseAssetParams,
   QueryParams,
   UpdateReleaseAssetParams,
-  Link,
-  CollectionProp,
-  CreateWithIdReleaseAssetParams,
-  CreateWithFilesReleaseAssetParams,
-  ProcessForLocaleReleaseAssetParams,
-  ProcessForAllLocalesReleaseAssetParams,
 } from '../../../common-types'
 import type {
-  CreateAssetProps,
-  AssetProps,
   AssetFileProp,
   AssetProcessingForLocale,
+  AssetProps,
+  CreateAssetProps,
 } from '../../../entities/asset'
-import copy from 'fast-copy'
+import { getUploadHttpClient } from '../../../upload-http-client'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
-import type { RawAxiosRequestHeaders } from 'axios'
-import type { SetOptional } from 'type-fest'
-import { getUploadHttpClient } from '../../../upload-http-client'
 import { create as createUpload } from './upload'
 import { normalizeSelect } from './utils'
 

--- a/lib/adapters/REST/endpoints/release-entry.ts
+++ b/lib/adapters/REST/endpoints/release-entry.ts
@@ -1,34 +1,34 @@
+import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
+import copy from 'fast-copy'
+import type { OpPatch } from 'json-patch'
+import type { SetOptional } from 'type-fest'
 import type {
+  CollectionProp,
   CreateReleaseEntryParams,
-  GetReleaseEntryParams,
+  CreateWithIdReleaseEntryParams,
   GetManyReleaseEntryParams,
+  GetReleaseEntryParams,
   KeyValueMap,
+  Link,
   PatchReleaseEntryParams,
   QueryParams,
   UpdateReleaseEntryParams,
-  CreateWithIdReleaseEntryParams,
-  Link,
-  CollectionProp,
 } from '../../../common-types'
 import type { CreateEntryProps, EntryProps } from '../../../entities/entry'
-import copy from 'fast-copy'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
-import type { RawAxiosRequestHeaders } from 'axios'
-import type { SetOptional } from 'type-fest'
-import type { OpPatch } from 'json-patch'
 import { normalizeSelect } from './utils'
 
-type ReleaseEntryProps = EntryProps<unknown, { release: Link<'Release'> }>
+type ReleaseEntryProps<T> = EntryProps<T, { release: Link<'Release'> }>
 
-export const get: RestEndpoint<'ReleaseEntry', 'get'> = (
+export const get: RestEndpoint<'ReleaseEntry', 'get'> = <T extends KeyValueMap = KeyValueMap>(
   http: AxiosInstance,
   params: GetReleaseEntryParams & QueryParams,
   rawData?: unknown,
   headers?: RawAxiosRequestHeaders
 ) => {
-  return raw.get<ReleaseEntryProps>(
+  return raw.get<ReleaseEntryProps<T>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries/${params.entryId}`,
     {
@@ -38,13 +38,15 @@ export const get: RestEndpoint<'ReleaseEntry', 'get'> = (
   )
 }
 
-export const getMany: RestEndpoint<'ReleaseEntry', 'getMany'> = (
+export const getMany: RestEndpoint<'ReleaseEntry', 'getMany'> = <
+  T extends KeyValueMap = KeyValueMap
+>(
   http: AxiosInstance,
   params: GetManyReleaseEntryParams & QueryParams,
   rawData?: unknown,
   headers?: RawAxiosRequestHeaders
 ) => {
-  return raw.get<CollectionProp<ReleaseEntryProps>>(
+  return raw.get<CollectionProp<ReleaseEntryProps<T>>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries`,
     {
@@ -62,7 +64,7 @@ export const update: RestEndpoint<'ReleaseEntry', 'update'> = <T extends KeyValu
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
   delete data.sys
-  return raw.put<ReleaseEntryProps>(
+  return raw.put<ReleaseEntryProps<T>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries/${params.entryId}`,
     data,
@@ -81,7 +83,7 @@ export const patch: RestEndpoint<'ReleaseEntry', 'patch'> = <T extends KeyValueM
   data: OpPatch[],
   headers?: RawAxiosRequestHeaders
 ) => {
-  return raw.patch<ReleaseEntryProps>(
+  return raw.patch<ReleaseEntryProps<T>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries/${params.entryId}`,
     data,
@@ -103,7 +105,7 @@ export const create: RestEndpoint<'ReleaseEntry', 'create'> = <T extends KeyValu
 ) => {
   const data = copy(rawData)
 
-  return raw.post<ReleaseEntryProps>(
+  return raw.post<ReleaseEntryProps<T>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries`,
     data,
@@ -126,7 +128,7 @@ export const createWithId: RestEndpoint<'ReleaseEntry', 'createWithId'> = <
 ) => {
   const data = copy(rawData)
 
-  return raw.put<ReleaseEntryProps>(
+  return raw.put<ReleaseEntryProps<T>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/entries/${params.entryId}`,
     data,

--- a/lib/adapters/REST/endpoints/release.ts
+++ b/lib/adapters/REST/endpoints/release.ts
@@ -1,6 +1,6 @@
 import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
-import type { ReleaseEnvironmentParams, GetReleaseParams } from '../../../common-types'
+import type { GetReleaseParams, ReleaseEnvironmentParams } from '../../../common-types'
 import type {
   ReleasePayload,
   ReleasePayloadV2,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1645,21 +1645,21 @@ export type MRActions = {
       return: CollectionProp<EntryProps<any>>
     }
     getMany: {
-      params: GetManyEntryParams & QueryParams & { releaseId?: string }
-      return: CollectionProp<EntryProps<any, any>>
+      params: GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }
+      return: CollectionProp<EntryProps<any>>
     }
     get: {
-      params: GetEntryParams & QueryParams & { releaseId?: string }
-      return: EntryProps<any, any>
+      params: GetSpaceEnvironmentParams & { entryId: string; releaseId?: string } & QueryParams
+      return: EntryProps<any>
     }
     patch: {
-      params: PatchEntryParams & QueryParams & { releaseId?: string }
+      params: GetSpaceEnvironmentParams & { entryId: string; version: number; releaseId?: string }
       payload: OpPatch[]
       headers?: RawAxiosRequestHeaders
       return: EntryProps<any>
     }
     update: {
-      params: UpdateEntryParams & QueryParams & { releaseId?: string }
+      params: GetSpaceEnvironmentParams & { entryId: string; releaseId?: string }
       payload: EntryProps<any>
       headers?: RawAxiosRequestHeaders
       return: EntryProps<any>
@@ -1686,7 +1686,7 @@ export type MRActions = {
       params: GetSpaceEnvironmentParams & {
         contentTypeId: string
         releaseId?: string
-      } & QueryParams
+      }
       payload: CreateEntryProps<any>
       return: EntryProps<any>
     }
@@ -1697,7 +1697,7 @@ export type MRActions = {
         releaseId?: string
       }
       payload: CreateEntryProps<any>
-      return: EntryProps<any, any>
+      return: EntryProps<any>
     }
     references: {
       params: GetSpaceEnvironmentParams & {
@@ -1866,11 +1866,11 @@ export type MRActions = {
       return: ReleaseProps
     }
     query: {
-      params: GetSpaceEnvironmentParams & { query?: ReleaseQueryOptions }
+      params: ReleaseEnvironmentParams & { query?: ReleaseQueryOptions }
       return: CollectionProp<ReleaseProps>
     }
     create: {
-      params: GetSpaceEnvironmentParams
+      params: ReleaseEnvironmentParams
       payload: ReleasePayload | ReleasePayloadV2
       return: ReleaseProps
     }
@@ -1949,12 +1949,12 @@ export type MRActions = {
     get: {
       params: GetReleaseEntryParams & QueryParams
       headers?: RawAxiosRequestHeaders
-      return: EntryProps<any, any>
+      return: EntryProps<any, { release: Link<'Release'> }>
     }
     getMany: {
       params: GetManyReleaseEntryParams & QueryParams
       headers?: RawAxiosRequestHeaders
-      return: CollectionProp<EntryProps<any, any>>
+      return: CollectionProp<EntryProps<any, { release: Link<'Release'> }>>
     }
     update: {
       params: UpdateReleaseEntryParams & QueryParams
@@ -2457,13 +2457,6 @@ export type GetCommentParams = (GetEntryParams | GetCommentParentEntityParams) &
 export type GetContentTypeParams = GetSpaceEnvironmentParams & { contentTypeId: string }
 export type GetEditorInterfaceParams = GetSpaceEnvironmentParams & { contentTypeId: string }
 export type GetEntryParams = GetSpaceEnvironmentParams & { entryId: string }
-export type GetManyEntryParams = GetSpaceEnvironmentParams
-export type PatchEntryParams = GetSpaceEnvironmentParams & {
-  entryId: string
-  version: number
-  releaseId?: string
-}
-export type UpdateEntryParams = GetSpaceEnvironmentParams & { entryId: string; releaseId?: string }
 export type GetExtensionParams = GetSpaceEnvironmentParams & { extensionId: string }
 export type GetEnvironmentTemplateParams = GetOrganizationParams & { environmentTemplateId: string }
 export type GetFunctionParams = GetAppDefinitionParams & { functionId: string }

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -37,7 +37,6 @@ import type {
   ReleasePayload,
   ReleaseQueryOptions,
   ReleaseValidatePayload,
-  ReleasePayloadV2,
 } from './entities/release'
 import { wrapRelease, wrapReleaseCollection } from './entities/release'
 
@@ -398,7 +397,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *
      * // Using Thenables
      * client.getSpace('<space_id>')
-     * .then((space) => space.getEnvironment('<environment-id>'))
+     * .then((space) => space.getEnvironment('<environment_id>'))
      * .then((environment) => environment.createUnpublishBulkAction(payload))
      * .then((bulkAction) => console.log(bulkAction.waitProcessing()))
      * .catch(console.error)
@@ -406,7 +405,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * // Using async/await
      * try {
      *  const space = await clientgetSpace('<space_id>')
-     *  const environment = await space.getEnvironment('<environment-id>')
+     *  const environment = await space.getEnvironment('<environment_id>')
      *  const bulkActionInProgress = await environment.createUnpublishBulkAction(payload)
      *
      *  // You can wait for a recently created BulkAction to be processed by using `bulkAction.waitProcessing()`
@@ -867,7 +866,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      *
      * // Get entry references
      * client.getSpace('<space_id>')
-     * .then((space) => space.getEnvironment('<environment-id>'))
+     * .then((space) => space.getEnvironment('<environment_id>'))
      * .then((environment) => environment.getEntryReferences('<entry_id>', {include: number}))
      * .then((entry) => console.log(entry.includes))
      * // or
@@ -2109,7 +2108,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
       version,
     }: {
       releaseId: string
-      payload: ReleasePayload | ReleasePayloadV2
+      payload: ReleasePayload
       version: number
     }) {
       const raw: EnvironmentProps = this.toPlainObject()
@@ -2482,7 +2481,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * })
      *
      * client.getSpace('<space_id>')
-     * .then((space) => space.getEnvironment('<environment-id>'))
+     * .then((space) => space.getEnvironment('<environment_id>'))
      * .then((environment) => environment.getResourceTypes({limit: 10}))
      * .then((installations) => console.log(installations.items))
      * .catch(console.error)

--- a/lib/entities/release.ts
+++ b/lib/entities/release.ts
@@ -123,7 +123,7 @@ export interface ReleasePayloadV2 extends MakeRequestPayload {
 }
 
 export interface ReleaseValidatePayload {
-  action?: 'publish'
+  action?: 'publish' | 'unpublish'
 }
 
 export interface ReleaseValidateOptions {
@@ -145,7 +145,7 @@ export interface ReleaseApiMethods {
    * */
   unarchive(): Promise<Release>
   /** Updates a Release and returns the updated Release object */
-  update(payload: ReleasePayload | ReleasePayloadV2): Promise<Release>
+  update(payload: ReleasePayload): Promise<Release>
   /** Deletes a Release and all ReleaseActions linked to it (non-reversible) */
   delete(): Promise<void>
   /** Publishes a Release and waits until the asynchronous action is completed */
@@ -196,7 +196,7 @@ function createReleaseApi(makeRequest: MakeRequest): ReleaseApiMethods {
         params,
       }).then((release) => wrapRelease(makeRequest, release))
     },
-    async update(payload: ReleasePayload | ReleasePayloadV2) {
+    async update(payload: ReleasePayload) {
       const params = getParams(this)
 
       return makeRequest({

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -12,9 +12,7 @@ import type {
   EnvironmentTemplateParams,
   GetBulkActionParams,
   GetContentTypeParams,
-  GetEntryParams,
   GetEnvironmentTemplateParams,
-  GetManyEntryParams,
   GetManyReleaseAssetParams,
   GetManyReleaseEntryParams,
   GetOrganizationMembershipParams,
@@ -28,13 +26,11 @@ import type {
   GetSpaceParams,
   KeyValueMap,
   Link,
-  PatchEntryParams,
   PatchReleaseEntryParams,
   ProcessForAllLocalesReleaseAssetParams,
   ProcessForLocaleReleaseAssetParams,
   QueryParams,
   ReleaseEnvironmentParams,
-  UpdateEntryParams,
   UpdateReleaseAssetParams,
   UpdateReleaseEntryParams,
 } from '../common-types'
@@ -293,22 +289,24 @@ export type PlainClientAPI = {
       headers?: RawAxiosRequestHeaders
     ): Promise<CollectionProp<EntryProps<T>>>
     getMany<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<GetManyEntryParams & QueryParams>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }>,
       rawData?: unknown,
       headers?: RawAxiosRequestHeaders
     ): Promise<CollectionProp<EntryProps<T>>>
     get<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<GetEntryParams & QueryParams>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string; releaseId?: string }>,
       rawData?: unknown,
       headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>
     update<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<UpdateEntryParams & QueryParams>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string; releaseId?: string }>,
       rawData: EntryProps<T>,
       headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>
     patch<T extends KeyValueMap = KeyValueMap>(
-      params: OptionalDefaults<PatchEntryParams & QueryParams>,
+      params: OptionalDefaults<
+        GetSpaceEnvironmentParams & { entryId: string; version?: number; releaseId?: string }
+      >,
       rawData: OpPatch[],
       headers?: RawAxiosRequestHeaders
     ): Promise<EntryProps<T>>
@@ -329,7 +327,7 @@ export type PlainClientAPI = {
     ): Promise<EntryProps<T>>
     create<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<
-        GetSpaceEnvironmentParams & { contentTypeId: string; releaseId?: string } & QueryParams
+        GetSpaceEnvironmentParams & { contentTypeId: string; releaseId?: string }
       >,
       rawData: CreateEntryProps<T>
     ): Promise<EntryProps<T>>
@@ -338,20 +336,7 @@ export type PlainClientAPI = {
         GetSpaceEnvironmentParams & { entryId: string; contentTypeId: string; releaseId?: string }
       >,
       rawData: CreateEntryProps<T>
-    ): Promise<
-      EntryProps<
-        T,
-        {
-          release: {
-            sys: {
-              type: 'Link'
-              linkType: 'Entry' | 'Asset'
-              id: string
-            }
-          }
-        }
-      >
-    >
+    ): Promise<EntryProps<T>>
     references(
       params: OptionalDefaults<
         GetSpaceEnvironmentParams & {
@@ -368,17 +353,19 @@ export type PlainClientAPI = {
       headers?: RawAxiosRequestHeaders
     ): Promise<CollectionProp<AssetProps>>
     getMany(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }>,
       rawData?: unknown,
       headers?: RawAxiosRequestHeaders
     ): Promise<CollectionProp<AssetProps>>
     get(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string } & QueryParams>,
+      params: OptionalDefaults<
+        GetSpaceEnvironmentParams & { assetId: string; releaseId?: string } & QueryParams
+      >,
       rawData?: unknown,
       headers?: RawAxiosRequestHeaders
     ): Promise<AssetProps>
     update(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string }>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string; releaseId?: string }>,
       rawData: AssetProps,
       headers?: RawAxiosRequestHeaders
     ): Promise<AssetProps>
@@ -398,24 +385,24 @@ export type PlainClientAPI = {
       params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string }>
     ): Promise<AssetProps>
     create(
-      params: OptionalDefaults<GetSpaceEnvironmentParams>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { releaseId?: string }>,
       rawData: CreateAssetProps
     ): Promise<AssetProps>
     createWithId(
-      params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string }>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { assetId: string; releaseId?: string }>,
       rawData: CreateAssetProps
     ): Promise<AssetProps>
     createFromFiles(
-      params: OptionalDefaults<GetSpaceEnvironmentParams>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { releaseId?: string }>,
       data: Omit<AssetFileProp, 'sys'>
     ): Promise<AssetProps>
     processForAllLocales(
-      params: OptionalDefaults<GetSpaceEnvironmentParams>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { releaseId?: string }>,
       asset: AssetProps,
       processingOptions?: AssetProcessingForLocale
     ): Promise<AssetProps>
     processForLocale(
-      params: OptionalDefaults<GetSpaceEnvironmentParams>,
+      params: OptionalDefaults<GetSpaceEnvironmentParams & { releaseId?: string }>,
       asset: AssetProps,
       locale: string,
       processingOptions?: AssetProcessingForLocale
@@ -534,7 +521,7 @@ export type PlainClientAPI = {
     archive(params: OptionalDefaults<GetReleaseParams & { version: number }>): Promise<ReleaseProps>
     get(params: OptionalDefaults<GetReleaseParams>): Promise<ReleaseProps>
     query(
-      params: OptionalDefaults<GetSpaceEnvironmentParams> & { query?: ReleaseQueryOptions }
+      params: OptionalDefaults<ReleaseEnvironmentParams> & { query?: ReleaseQueryOptions }
     ): Promise<CursorPaginatedCollectionProp<ReleaseProps>>
     create(
       params: OptionalDefaults<ReleaseEnvironmentParams>,

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:types": "npx vitest --project types --run",
     "test:unit-watch": "npx vitest --project unit",
     "test:integration": "npx vitest --project integration --run --no-file-parallelism",
-    "test:integration-watch": "npx vitest --project integration --no-file-parallelism entry-integration",
+    "test:integration-watch": "npx vitest --project integration --no-file-parallelism",
     "test:browser": "npx playwright install && npx vitest --project browser-unit --run && npx vitest --project browser-integration --run",
     "test:version": "grep -r \"0.0.0-determined-by-semantic-release\" ./dist > /dev/null && echo \"version 0.0.0-determined-by-semantic-release found in output\" && exit 1 || exit 0",
     "test:size": "size-limit",

--- a/test/integration/entry-integration.test.ts
+++ b/test/integration/entry-integration.test.ts
@@ -13,11 +13,19 @@ import {
 import type {
   ConceptProps,
   ContentType,
+  EntryProps,
   Environment,
   PlainClientAPI,
+  ReleaseProps,
   Space,
 } from '../../lib/export-types'
 import { TestDefaults } from '../defaults'
+import {
+  createEmptyRelease,
+  createTestEntry,
+  updateReleaseWithEntries,
+  updateReleaseEntryTitle,
+} from './utils/release-entry.utils'
 
 describe('Entry Api', () => {
   afterAll(async () => await timeoutToCalmRateLimiting())
@@ -711,6 +719,176 @@ describe('Entry Api', () => {
       expect(response.items[0].sys.firstPublishedAt).to.not.be.undefined
       expect(response.items[0].sys.publishedVersion).to.not.be.undefined
       expect(response.items[0].sys.publishedAt).to.not.be.undefined
+    })
+  })
+
+  //test releasev2 entry logic
+  describe('plainClientApi with releaseId', () => {
+    let entry: EntryProps
+    let entry2: EntryProps
+    let release: ReleaseProps
+    let createEntryClient: PlainClientAPI
+
+    beforeAll(async () => {
+      // create a v2 release w/ entry to reuse in tests
+      const defaultParams = {
+        environmentId: TestDefaults.environmentId,
+        spaceId: TestDefaults.spaceId,
+        releaseSchemaVersion: 'Release.v2' as const,
+      }
+      createEntryClient = initPlainClient(defaultParams)
+
+      // create release
+      release = await createEmptyRelease(createEntryClient, defaultParams)
+
+      // create entries to add to release
+      entry = await createTestEntry(
+        createEntryClient,
+        defaultParams,
+        TestDefaults.contentType.withCrossSpaceReferenceId
+      )
+      entry2 = await createTestEntry(
+        createEntryClient,
+        defaultParams,
+        TestDefaults.contentType.withCrossSpaceReferenceId
+      )
+      // add entries to release
+      release = await updateReleaseWithEntries(createEntryClient, release, [entry, entry2])
+
+      // update release entry with title
+      await updateReleaseEntryTitle(createEntryClient, release, entry)
+    })
+
+    afterAll(async () => {
+      // cleanup test release
+      await createEntryClient.release.delete({
+        releaseId: release.sys.id,
+      })
+      await createEntryClient.entry.delete({
+        entryId: entry.sys.id,
+      })
+      await createEntryClient.entry.delete({
+        entryId: entry2.sys.id,
+      })
+      await timeoutToCalmRateLimiting()
+    })
+
+    describe('releaseId is provided in params, but not in default params', () => {
+      test('entry.patch works', async () => {
+        const entryToPatch = await createEntryClient.entry.get({
+          entryId: entry.sys.id,
+          releaseId: release.sys.id,
+        })
+
+        const patchedEntry = await createEntryClient.entry.patch(
+          {
+            entryId: entryToPatch.sys.id,
+            releaseId: release.sys.id,
+            version: entryToPatch.sys.version,
+          },
+          [
+            {
+              op: 'replace' as const,
+              path: '/fields/title/en-US',
+              value: 'Entry patched via release',
+            },
+          ]
+        )
+
+        expect(patchedEntry.sys.id).toEqual(entryToPatch.sys.id)
+        expect(patchedEntry.fields.title['en-US']).toEqual('Entry patched via release')
+        expect(patchedEntry.sys.version).toBeGreaterThan(entryToPatch.sys.version)
+        expect((patchedEntry as any).sys.release.sys.id).toEqual(
+          (entryToPatch as any).sys.release.sys.id
+        )
+      })
+
+      test('entry.update works', async () => {
+        const entryToUpdate = await createEntryClient.entry.get({
+          entryId: entry.sys.id,
+          releaseId: release.sys.id,
+        })
+
+        const updatedEntry = await createEntryClient.entry.update(
+          {
+            entryId: entryToUpdate.sys.id,
+            releaseId: release.sys.id,
+          },
+          {
+            ...entryToUpdate,
+            fields: {
+              ...entryToUpdate.fields,
+              title: { 'en-US': 'Entry updated via release' },
+            },
+          }
+        )
+
+        expect(updatedEntry.sys.id).toEqual(entryToUpdate.sys.id)
+        expect(updatedEntry.fields.title['en-US']).toEqual('Entry updated via release')
+        expect(updatedEntry.sys.version).toBeGreaterThan(entryToUpdate.sys.version)
+        expect((updatedEntry as any).sys.release.sys.id).toEqual(
+          (entryToUpdate as any).sys.release.sys.id
+        )
+      })
+    })
+
+    describe('releaseId is provided in default params, but not in params', () => {
+      beforeEach(() => {
+        createEntryClient = initPlainClient({
+          environmentId: TestDefaults.environmentId,
+          spaceId: TestDefaults.spaceId,
+          releaseId: release.sys.id,
+        })
+      })
+
+      test('entry.patch works', async () => {
+        const entryToPatch = await createEntryClient.entry.get({
+          entryId: entry.sys.id,
+        })
+
+        const patchedEntry = await createEntryClient.entry.patch(
+          {
+            entryId: entryToPatch.sys.id,
+            version: entryToPatch.sys.version,
+          },
+          [
+            {
+              op: 'replace',
+              path: '/fields/title/en-US',
+              value: 'Entry patched via default release',
+            },
+          ]
+        )
+
+        expect(patchedEntry.sys.id).toEqual(entryToPatch.sys.id)
+        expect(patchedEntry.fields.title['en-US']).toEqual('Entry patched via default release')
+        expect(patchedEntry.sys.version).toBeGreaterThan(entryToPatch.sys.version)
+        expect((patchedEntry as any).sys.release.sys.id).toEqual(entryToPatch.sys.release.sys.id)
+      })
+
+      test('entry.update works', async () => {
+        const entryToUpdate = await createEntryClient.entry.get({
+          entryId: entry.sys.id,
+        })
+
+        const updatedEntry = await createEntryClient.entry.update(
+          {
+            entryId: entryToUpdate.sys.id,
+          },
+          {
+            ...entryToUpdate,
+            fields: {
+              ...entryToUpdate.fields,
+              title: { 'en-US': 'Entry updated via default release' },
+            },
+          }
+        )
+
+        expect(updatedEntry.sys.id).toEqual(entryToUpdate.sys.id)
+        expect(updatedEntry.fields.title['en-US']).toEqual('Entry updated via default release')
+        expect(updatedEntry.sys.version).toBeGreaterThan(entryToUpdate.sys.version)
+        expect((updatedEntry as any).sys.release.sys.id).toEqual(entryToUpdate.sys.release.sys.id)
+      })
     })
   })
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Some final cleanup items for the releases work in the canary branch.

## Description

I've added some inline comments to explain some of the changes. Overall, here's a summary:

**Changes to types**
- I decided to remove the additional Entry types that we created and instead just added the { releaseId?: string } type inline. My thought here was just to reduce the surface area of what we changed when we merge to master
- We had some areas where QueryParams were added/removed. I cross-referenced this with what's on master to keep them in the right place
- Updated `ReleaseValidatePayload` to reflect the correct values

**General cleanup**
- Organized imports in a few files
- Removed unnecessary change in integration:watch script in `package.json`
- Removed unnecessary change in `lib/create-environment-api.ts`
- Added back some integration tests that were removed in a previous PR

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
