### PR TITLE
fix: AppActionCallProps result xor error [EXT-6783]

### DIFF
--- a/lib/entities/app-action-call.ts
+++ b/lib/entities/app-action-call.ts
@@ -1,6 +1,6 @@
 import copy from 'fast-copy'
 import { toPlainObject } from 'contentful-sdk-core'
-import type { Except } from 'type-fest'
+import type { Except, JsonValue } from 'type-fest'
 import type {
   BasicMetaSysProps,
   AppActionCallRetryOptions,
@@ -21,7 +21,7 @@ type AppActionCallSys = Except<BasicMetaSysProps, 'version'> & {
   environment: SysLink
   action: SysLink
   appActionCallResponse?: SysLink
-}
+} & (AppActionCallSucceeded | AppActionCallProcessing | AppActionCallFailed)
 
 type RetryOptions = AppActionCallRetryOptions
 
@@ -34,16 +34,27 @@ export interface AppActionCallErrorProps {
   statusCode?: number
 }
 
+export type AppActionCallSucceeded = {
+  status: 'succeeded'
+  result: JsonValue
+}
+
+export type AppActionCallProcessing = {
+  status: 'processing'
+}
+
+export type AppActionCallFailed = {
+  status: 'failed'
+  error: AppActionCallErrorProps
+}
+
 export type AppActionCallProps = {
   /**
    * System metadata
    */
   sys: AppActionCallSys
-  /** The execution status of the app action call, if available */
-  status?: AppActionCallStatus
-  /** Structured result when execution succeeded */
-  result?: unknown
-  /** Structured error when execution failed */
+  status: AppActionCallStatus
+  result?: JsonValue
   error?: AppActionCallErrorProps
 }
 
@@ -88,7 +99,7 @@ export interface AppActionCallResponseData
     DefaultElements<AppActionCallResponse>,
     AppActionCallApi {}
 
-export interface AppActionCall extends AppActionCallProps, DefaultElements<AppActionCallProps> {}
+export type AppActionCall = AppActionCallProps & DefaultElements<AppActionCallProps>
 
 /**
  * @private


### PR DESCRIPTION
## Summary

AppActionCallProps should allow one of (but not both) of `result` and `error`.  This is an intermediate change. We will have a quick follow to remove the duplicate `result`  and `error`  fields from the root level, in favor of having them contained at `sys.result`  and `sys.error `. This will align with consistent org-wide usage of the `sys` field: as fields that cannot be altered by the client.

## Description

Discriminating union of `result` and `error` field:
```
export type AppActionCallProps = {
  /**
   * System metadata
   */
  sys: AppActionCallSys
  /** The execution status of the app action call, if available */
  status?: AppActionCallStatus
  & (
    | { /** Structured result when execution succeeded */ result: unknown; error?: never }
    | { /** Structured error when execution failed */ error: AppActionCallErrorProps; result?: never }
  )
}
```

## Motivation and Context
This prevents unsuitable states from being represented via the content-management SDK.

## Checklist (check all before merging)

- [X] Both unit and integration tests are passing
- [X] There are no breaking changes
- [ ] Changes are reflected in the documentation (this will be done as a fast follow in the next PR)
