### PR TITLE
feat(environment-templates): add forTemplatedSpaces query param [FUS-958]

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -69,7 +69,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      */
     getEnvironmentTemplates: function getEnvironmentTemplates(
       organizationId: string,
-      query: BasicCursorPaginationOptions & { select?: string } = {},
+      query: BasicCursorPaginationOptions & { select?: string; forTemplatedSpaces?: boolean } = {},
     ): Promise<CursorPaginatedCollection<EnvironmentTemplate, EnvironmentTemplateProps>> {
       return makeRequest({
         entityType: 'EnvironmentTemplate',

--- a/lib/create-organization-api.ts
+++ b/lib/create-organization-api.ts
@@ -6,7 +6,6 @@ import type { CreateTeamProps } from './entities/team'
 import type { CreateOrganizationInvitationProps } from './entities/organization-invitation'
 import type {
   AcceptsQueryOptions,
-  AcceptsQueryParams,
   BasicQueryOptions,
   MakeRequest,
   QueryOptions,

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -158,7 +158,7 @@ export type PlainClientAPI = {
     ): Promise<EnvironmentTemplateProps>
     getMany(
       params: GetOrganizationParams & {
-        query?: BasicCursorPaginationOptions & { select?: string }
+        query?: BasicCursorPaginationOptions & { select?: string; forTemplatedSpaces?: boolean }
       },
       headers?: RawAxiosRequestHeaders,
     ): Promise<CursorPaginatedCollectionProp<EnvironmentTemplateProps>>

--- a/test/integration/environment-template-integration.test.ts
+++ b/test/integration/environment-template-integration.test.ts
@@ -99,6 +99,16 @@ describe('Environment template API', () => {
       expect(firstTemplate).toEqual({ description: templateDescription })
     })
 
+    it('gets a collection of environment templates with forTemplatedSpaces filter applied', async () => {
+      const draftTemplate = createDraftTemplate()
+      await client.createEnvironmentTemplate(orgId, draftTemplate)
+      const { items: templates } = await client.getEnvironmentTemplates(orgId, {
+        forTemplatedSpaces: true,
+      })
+
+      expect(templates).toHaveLength(0)
+    })
+
     it('updates an environment template', async () => {
       const draftTemplate = createDraftTemplate()
       const template = await client.createEnvironmentTemplate(orgId, draftTemplate)


### PR DESCRIPTION
Align with new API capability to filter template collections by field `forTemplatedSpaces`

Follow-up to https://github.com/contentful/contentful-management.js/pull/2753

