### PR TITLE
fix(release-asset): invalid query for getMany []

### DIFF
--- a/lib/adapters/REST/endpoints/release-asset.ts
+++ b/lib/adapters/REST/endpoints/release-asset.ts
@@ -51,8 +51,6 @@ export const getMany: RestEndpoint<'ReleaseAsset', 'getMany'> = (
   rawData?: unknown,
   headers?: RawAxiosRequestHeaders,
 ) => {
-  params.query = { ...params.query, 'sys.schemaVersion': 'Release.V2' }
-
   return raw.get<CollectionProp<ReleaseAssetProps>>(
     http,
     `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/assets`,


### PR DESCRIPTION
## Summary

Invalid query is created for release.asset.getMany as it adds the schemaVersion

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes


