### PR TITLE
fix: move app-action-call status, result, and error to sys [EXT-6783]

### DIFF
--- a/lib/adapters/REST/endpoints/app-action-call.ts
+++ b/lib/adapters/REST/endpoints/app-action-call.ts
@@ -151,9 +151,9 @@ async function pollStructuredAppActionCall(
 
         // If backend has not yet written the record, keep polling up to retries
         // Otherwise, resolve when status is terminal
-        if (result?.status === 'succeeded' || result?.status === 'failed') {
+        if (result?.sys.status === 'succeeded' || result?.sys.status === 'failed') {
           resolve(result)
-        } else if (result?.status === 'processing' && checkCount < retries) {
+        } else if (result?.sys.status === 'processing' && checkCount < retries) {
           checkCount++
           await waitFor(retryInterval)
           poll()

--- a/lib/entities/app-action-call.ts
+++ b/lib/entities/app-action-call.ts
@@ -53,9 +53,6 @@ export type AppActionCallProps = {
    * System metadata
    */
   sys: AppActionCallSys
-  status: AppActionCallStatus
-  result?: JsonValue
-  error?: AppActionCallErrorProps
 }
 
 export type CreateAppActionCallProps = {
@@ -86,6 +83,7 @@ export interface AppActionCallRawResponseProps {
     appInstallation: SysLink
     appAction: SysLink
     createdAt: string
+    createdBy: SysLink
   }
   response: {
     headers?: { contentType?: string }

--- a/test/unit/adapters/REST/endpoints/app-action-call.test.ts
+++ b/test/unit/adapters/REST/endpoints/app-action-call.test.ts
@@ -16,10 +16,9 @@ function setup(promise, mockName, params = {}) {
 }
 
 describe('Rest App Action Call', { concurrent: true }, () => {
-  it('should get structured App Action Call via new route', async () => {
+  it('should get structured App Action Call', async () => {
     const structuredCall: any = {
-      sys: { id: 'call-id', type: 'AppActionCall' },
-      status: 'processing',
+      sys: { id: 'call-id', type: 'AppActionCall', status: 'processing' },
     }
 
     const { httpMock } = setup(Promise.resolve({ data: structuredCall }), 'appActionCallResponse')
@@ -38,7 +37,7 @@ describe('Rest App Action Call', { concurrent: true }, () => {
     )
   })
 
-  it('should get raw response via new route', async () => {
+  it('should get raw response', async () => {
     const rawResponse: any = {
       sys: { id: 'call-id', type: 'AppActionCallResponse' },
       response: { body: 'OK', headers: { contentType: 'application/json' } },
@@ -61,16 +60,13 @@ describe('Rest App Action Call', { concurrent: true }, () => {
   })
 
   it('should create with result and poll until completion', async () => {
-    // First POST returns the created call with sys.id; then GET returns processing, then succeeded
-    const createdCall: any = { sys: { id: 'call-id', type: 'AppActionCall' } }
-    const processing: any = { sys: { id: 'call-id', type: 'AppActionCall' }, status: 'processing' }
+    // First POST and next GET returns processing call with sys.id; , then succeeded
+    const processing: any = { sys: { id: 'call-id', type: 'AppActionCall', status: 'processing' } }
     const succeeded: any = {
-      sys: { id: 'call-id', type: 'AppActionCall' },
-      status: 'succeeded',
-      result: { ok: true },
+      sys: { id: 'call-id', type: 'AppActionCall', status: 'succeeded', result: { ok: true } },
     }
 
-    const { httpMock } = setup(Promise.resolve({ data: createdCall }), 'appActionCallResponse')
+    const { httpMock } = setup(Promise.resolve({ data: processing }), 'appActionCallResponse')
 
     httpMock.get
       .mockImplementationOnce(() => Promise.resolve({ data: processing }))
@@ -105,10 +101,9 @@ describe('Rest App Action Call', { concurrent: true }, () => {
   })
 
   it('createWithResult times out when status stays processing', async () => {
-    const createdCall: any = { sys: { id: 'call-id', type: 'AppActionCall' } }
-    const processing: any = { sys: { id: 'call-id', type: 'AppActionCall' }, status: 'processing' }
+    const processing: any = { sys: { id: 'call-id', type: 'AppActionCall', status: 'processing' } }
 
-    const { httpMock } = setup(Promise.resolve({ data: createdCall }), 'appActionCallResponse')
+    const { httpMock } = setup(Promise.resolve({ data: processing }), 'appActionCallResponse')
 
     // Always return processing to trigger timeout
     httpMock.get.mockImplementation(() => Promise.resolve({ data: processing }))
@@ -140,11 +135,14 @@ describe('Rest App Action Call', { concurrent: true }, () => {
   })
 
   it('createWithResult resolves with failed status and error intact', async () => {
-    const createdCall: any = { sys: { id: 'call-id', type: 'AppActionCall' } }
+    const createdCall: any = { sys: { id: 'call-id', type: 'AppActionCall', status: 'processing' } }
     const failed: any = {
-      sys: { id: 'call-id', type: 'AppActionCall' },
-      status: 'failed',
-      error: { sys: { type: 'Error', id: 'ValidationError' }, message: 'invalid' },
+      sys: {
+        id: 'call-id',
+        type: 'AppActionCall',
+        status: 'failed',
+        error: { sys: { type: 'Error', id: 'ValidationError' }, message: 'invalid' },
+      },
     }
 
     const { httpMock } = setup(Promise.resolve({ data: createdCall }), 'appActionCallResponse')
@@ -167,7 +165,7 @@ describe('Rest App Action Call', { concurrent: true }, () => {
   })
 
   it('createWithResult retries on thrown GET errors then times out', async () => {
-    const createdCall: any = { sys: { id: 'call-id', type: 'AppActionCall' } }
+    const createdCall: any = { sys: { id: 'call-id', type: 'AppActionCall', status: 'processing' } }
     const { httpMock } = setup(Promise.resolve({ data: createdCall }), 'appActionCallResponse')
 
     httpMock.get.mockRejectedValue(new Error('not ready'))


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

- Move status, result, and error fields under sys for AppActionCall
- Update polling logic and tests to check sys.status instead of top-level fields
- Extend raw response props to include createdBy

## Description

<!-- Describe your changes in detail -->

- Refactored AppActionCall entity to align with Contentful conventions: fields that are system-controlled live inside sys
- Updated pollStructuredAppActionCall to resolve based on sys.status values (succeeded, failed, processing)
- Adjusted unit tests accordingly to mock sys.status, sys.result, and sys.error
- Cleaned up redundant top-level fields 

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

- Ensures consistency with how other system-managed fields are represented in Contentful entities
- Reduces risk of user confusion by preventing direct mutation of system-controlled properties
- Brings App Action Call entity and polling behavior in line with long-term design direction

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [x] Changes are reflected in the documentation

