### PR TITLE
fix: bump axios to 1.12.2 [DX-430]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.11.0",
+        "axios": "^1.12.2",
         "contentful-sdk-core": "^9.0.1",
         "fast-copy": "^3.0.0",
         "globals": "^15.15.0"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   ],
   "dependencies": {
     "@contentful/rich-text-types": "^16.6.1",
-    "axios": "^1.11.0",
+    "axios": "^1.12.2",
     "contentful-sdk-core": "^9.0.1",
     "fast-copy": "^3.0.0",
     "globals": "^15.15.0"


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

Bump axios to 1.12.2 to address security vuln

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Addresses concern first notified in contentful.js that also uses axios: https://github.com/contentful/contentful.js/issues/2567

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
