### PR TITLE
fix: update params type for release asset process methods [DX-443]

### DIFF
--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -27,8 +27,6 @@ import type {
   KeyValueMap,
   Link,
   PatchReleaseEntryParams,
-  ProcessForAllLocalesReleaseAssetParams,
-  ProcessForLocaleReleaseAssetParams,
   QueryParams,
   ReleaseEnvironmentParams,
   UpdateReleaseAssetParams,
@@ -475,13 +473,13 @@ export type PlainClientAPI = {
         headers?: RawAxiosRequestHeaders,
       ): Promise<AssetProps<{ release: Link<'Release'> }>>
       processForLocale(
-        params: OptionalDefaults<ProcessForLocaleReleaseAssetParams>,
+        params: OptionalDefaults<GetSpaceEnvironmentParams>,
         asset: AssetProps<{ release: Link<'Release'> }>,
         locale: string,
         processingOptions?: AssetProcessingForLocale,
       ): Promise<AssetProps<{ release: Link<'Release'> }>>
       processForAllLocales(
-        params: OptionalDefaults<ProcessForAllLocalesReleaseAssetParams>,
+        params: OptionalDefaults<GetSpaceEnvironmentParams>,
         asset: AssetProps<{ release: Link<'Release'> }>,
         processingOptions?: AssetProcessingForLocale,
       ): Promise<AssetProps<{ release: Link<'Release'> }>>


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

Update `processForLocale` and `processForAllLocales` param types for release assets. 

## Description

Previously, `asset` and `locale` properties were passed in both the `params` property and as their own parameters. This removes the `asset` and `locale` properties from the `params` parameter for these methods. This aligns with these methods for asset processing ([see here](https://github.com/contentful/contentful-management.js/blob/master/lib/plain/common-types.ts#L399-L409)).

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Checklist (check all before merging)

- [ ] Both unit and integration tests are passing
- [ ] There are no breaking changes
- [ ] Changes are reflected in the documentation

When adding a new method:

- [ ] The new method is exported through the default and plain CMA client
- [ ] All new public types are exported from `./lib/export-types.ts`
- [ ] Added a unit test for the new method
- [ ] Added an integration test for the new method
- [ ] The new method is added to the documentation
