### PR TITLE
feat: add 'agent' app location type (internal) [EXT-6969]

### DIFF
--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -24,7 +24,8 @@ export interface NavigationItem {
 
 /**
  * These locations are currently restricted to internal Contentful apps only.
- * If you are interested in using these locations for your app, please reach out to Contentful Support.
+ * If you are interested in using these locations for your app,
+ * please reach out to Contentful Support (https://www.contentful.com/support/).
  */
 type InternalLocationType = 'agent'
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

Internal Contentful apps will soon be able to leverage the “agent” app location. While this location is currently limited to internal use, we’re exploring opportunities to extend this capability to customers building AI-powered apps. If you’re interested in creating your own AI Agent app, please contact Contentful Support to discuss your use case and upcoming possibilities.

## Description

<!-- Describe your changes in detail -->

Adds `agent` as a valid app location for app definitions, denoting via comment and type name that this is only available for internal Contentful apps at this time. Users are prevented at runtime by the CMA from setting this location for their apps, and this location will explicitly not be added to the [create-contentful-app CLI prompt menu](https://github.com/contentful/create-contentful-app/blob/main/packages/contentful--app-scripts/src/location-prompts.ts#L3-L15). 

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

[create-contentful-app](https://github.com/contentful/create-contentful-app/tree/main/packages/contentful--app-scripts) leverages `AppLocation['location'][]` from the contentful-management package.

## Checklist (check all before merging)

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes
- [ ] Changes are reflected in the documentation