### PR TITLE
fix(types): for cursor paginated calls [NONE]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -344,11 +344,7 @@ export interface CursorPaginatedCollection<T, TPlain>
   extends CursorPaginatedCollectionProp<T>,
     DefaultElements<CursorPaginatedCollectionProp<TPlain>> {}
 
-type CursorLiteralTrue<T> = [T] extends [never]
-  ? false
-  : [T] extends [true]
-    ? true
-    : false
+type CursorLiteralTrue<T> = [T] extends [never] ? false : [T] extends [true] ? true : false
 
 export type CursorQueryEnabled<T> = T extends undefined
   ? false
@@ -359,7 +355,7 @@ export type CursorQueryEnabled<T> = T extends undefined
       : false
 
 export type OptionalCursorReturnType<P, CursorResult, DefaultResult> = <
-  Params extends P | undefined = undefined
+  Params extends P | undefined = undefined,
 >(
   params?: Params,
 ) => Promise<CursorQueryEnabled<Params> extends true ? CursorResult : DefaultResult>
@@ -400,7 +396,7 @@ export type OptionalCursorCollectionPropApi<P, T> = OptionalCursorReturnType<
   CollectionProp<T>
 >
 
-type WithCursorPagination<O> = O & { params: { query: { cursor: true } } }
+type CursorAwareCollectionProp<T> = CollectionProp<T> | CursorPaginatedCollectionProp<T>
 // Interfaces for each “exclusive” shape
 interface CursorPaginationPageNext extends CursorPaginationBase {
   pageNext: string
@@ -519,13 +515,7 @@ type MRInternal<UA extends boolean> = {
     opts: MROpts<'AppInstallation', 'getForOrganization', UA>,
   ): MRReturn<'AppInstallation', 'getForOrganization'>
 
-  (
-    opts: WithCursorPagination<MROpts<'Asset', 'getMany', UA>>,
-  ): Promise<CursorPaginatedCollectionProp<AssetProps>>
   (opts: MROpts<'Asset', 'getMany', UA>): MRReturn<'Asset', 'getMany'>
-  (
-    opts: WithCursorPagination<MROpts<'Asset', 'getPublished', UA>>,
-  ): Promise<CursorPaginatedCollectionProp<AssetProps>>
   (opts: MROpts<'Asset', 'getPublished', UA>): MRReturn<'Asset', 'getPublished'>
   (opts: MROpts<'Asset', 'get', UA>): MRReturn<'Asset', 'get'>
   (opts: MROpts<'Asset', 'update', UA>): MRReturn<'Asset', 'update'>
@@ -605,9 +595,6 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'ConceptScheme', 'delete', UA>): MRReturn<'ConceptScheme', 'delete'>
 
   (opts: MROpts<'ContentType', 'get', UA>): MRReturn<'ContentType', 'get'>
-  (
-    opts: WithCursorPagination<MROpts<'ContentType', 'getMany', UA>>,
-  ): Promise<CursorPaginatedCollectionProp<ConceptProps>>
   (opts: MROpts<'ContentType', 'getMany', UA>): MRReturn<'ContentType', 'getMany'>
   (opts: MROpts<'ContentType', 'update', UA>): MRReturn<'ContentType', 'update'>
   (opts: MROpts<'ContentType', 'create', UA>): MRReturn<'ContentType', 'create'>
@@ -617,9 +604,6 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'ContentType', 'unpublish', UA>): MRReturn<'ContentType', 'unpublish'>
 
   (opts: MROpts<'EditorInterface', 'get', UA>): MRReturn<'EditorInterface', 'get'>
-  (
-    opts: WithCursorPagination<MROpts<'EditorInterface', 'getMany', UA>>,
-  ): Promise<CursorPaginatedCollectionProp<EditorInterfaceProps>>
   (opts: MROpts<'EditorInterface', 'getMany', UA>): MRReturn<'EditorInterface', 'getMany'>
   (opts: MROpts<'EditorInterface', 'update', UA>): MRReturn<'EditorInterface', 'update'>
 
@@ -660,13 +644,7 @@ type MRInternal<UA extends boolean> = {
     opts: MROpts<'EnvironmentTemplateInstallation', 'getForEnvironment', UA>,
   ): MRReturn<'EnvironmentTemplateInstallation', 'getForEnvironment'>
 
-  (
-    opts: WithCursorPagination<MROpts<'Entry', 'getMany', UA>>,
-  ): Promise<CursorPaginatedCollectionProp<EntryProps>>
   (opts: MROpts<'Entry', 'getMany', UA>): MRReturn<'Entry', 'getMany'>
-  (
-    opts: WithCursorPagination<MROpts<'Entry', 'getPublished', UA>>,
-  ): Promise<CursorPaginatedCollectionProp<EntryProps>>
   (opts: MROpts<'Entry', 'getPublished', UA>): MRReturn<'Entry', 'getPublished'>
   (opts: MROpts<'Entry', 'get', UA>): MRReturn<'Entry', 'get'>
   (opts: MROpts<'Entry', 'patch', UA>): MRReturn<'Entry', 'patch'>
@@ -1278,12 +1256,12 @@ export type MRActions = {
     getPublished: {
       params: GetSpaceEnvironmentParams & QueryParams
       headers?: RawAxiosRequestHeaders
-      return: CollectionProp<AssetProps>
+      return: CursorAwareCollectionProp<AssetProps>
     }
     getMany: {
       params: GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }
       headers?: RawAxiosRequestHeaders
-      return: CollectionProp<AssetProps>
+      return: CursorAwareCollectionProp<AssetProps>
     }
     get: {
       params: GetSpaceEnvironmentParams & { assetId: string; releaseId?: string } & QueryParams
@@ -1531,7 +1509,7 @@ export type MRActions = {
     get: { params: GetContentTypeParams & QueryParams; return: ContentTypeProps }
     getMany: {
       params: GetSpaceEnvironmentParams & QueryParams
-      return: CollectionProp<ContentTypeProps>
+      return: CursorAwareCollectionProp<ContentTypeProps>
     }
     create: {
       params: GetSpaceEnvironmentParams
@@ -1557,7 +1535,7 @@ export type MRActions = {
     get: { params: GetEditorInterfaceParams; return: EditorInterfaceProps }
     getMany: {
       params: GetSpaceEnvironmentParams & QueryParams
-      return: CollectionProp<EditorInterfaceProps>
+      return: CursorAwareCollectionProp<EditorInterfaceProps>
     }
     update: {
       params: GetEditorInterfaceParams
@@ -1695,11 +1673,11 @@ export type MRActions = {
   Entry: {
     getPublished: {
       params: GetSpaceEnvironmentParams & QueryParams
-      return: CollectionProp<EntryProps<any>>
+      return: CursorAwareCollectionProp<EntryProps<any>>
     }
     getMany: {
       params: GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }
-      return: CollectionProp<EntryProps<any>>
+      return: CursorAwareCollectionProp<EntryProps<any>>
     }
     get: {
       params: GetSpaceEnvironmentParams & { entryId: string; releaseId?: string } & QueryParams

--- a/lib/common-utils.ts
+++ b/lib/common-utils.ts
@@ -18,9 +18,23 @@ export const wrapCollection =
   <R, T, Rest extends any[]>(fn: (makeRequest: MakeRequest, entity: T, ...rest: Rest) => R) =>
   (makeRequest: MakeRequest, data: CollectionProp<T>, ...rest: Rest): Collection<R, T> => {
     const collectionData = toPlainObject(copy(data))
-    // @ts-expect-error
+    // @ts-expect-error - items are re-wrapped to include entity methods at runtime
     collectionData.items = collectionData.items.map((entity) => fn(makeRequest, entity, ...rest))
-    // @ts-expect-error
+    // @ts-expect-error - resulting collection shape exceeds static typing
+    return collectionData
+  }
+
+export const wrapOptionalCursorCollection =
+  <R, T, Rest extends any[]>(fn: (makeRequest: MakeRequest, entity: T, ...rest: Rest) => R) =>
+  (
+    makeRequest: MakeRequest,
+    data: CollectionProp<T> | CursorPaginatedCollectionProp<T>,
+    ...rest: Rest
+  ): Collection<R, T> | CursorPaginatedCollection<R, T> => {
+    const collectionData = toPlainObject(copy(data))
+    // @ts-expect-error - items are re-wrapped to include entity methods at runtime
+    collectionData.items = collectionData.items.map((entity) => fn(makeRequest, entity, ...rest))
+    // @ts-expect-error - resulting collection shape exceeds static typing
     return collectionData
   }
 
@@ -46,9 +60,9 @@ export const wrapCursorPaginatedCollection =
     ...rest: Rest
   ): CursorPaginatedCollection<R, T> => {
     const collectionData = toPlainObject(copy(data))
-    // @ts-expect-error
+    // @ts-expect-error - items are re-wrapped to include entity methods at runtime
     collectionData.items = collectionData.items.map((entity) => fn(makeRequest, entity, ...rest))
-    // @ts-expect-error
+    // @ts-expect-error - resulting collection shape exceeds static typing
     return collectionData
   }
 export function isSuccessful(statusCode: number) {

--- a/lib/entities/asset.ts
+++ b/lib/entities/asset.ts
@@ -9,7 +9,7 @@ import type {
   MetadataProps,
   MakeRequest,
 } from '../common-types'
-import { wrapCollection } from '../common-utils'
+import { wrapOptionalCursorCollection } from '../common-utils'
 import * as checks from '../plain/checks'
 
 export type AssetProps<S = {}> = {
@@ -409,4 +409,4 @@ export function wrapAsset(makeRequest: MakeRequest, data: AssetProps): Asset {
 /**
  * @private
  */
-export const wrapAssetCollection = wrapCollection(wrapAsset)
+export const wrapAssetCollection = wrapOptionalCursorCollection(wrapAsset)

--- a/lib/entities/content-type.ts
+++ b/lib/entities/content-type.ts
@@ -10,7 +10,7 @@ import type {
   QueryOptions,
   SysLink,
 } from '../common-types'
-import { wrapCollection } from '../common-utils'
+import { wrapOptionalCursorCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
 import { isDraft, isPublished, isUpdated } from '../plain/checks'
 import type { ContentFields } from './content-type-fields'
@@ -358,4 +358,4 @@ export function wrapContentType(makeRequest: MakeRequest, data: ContentTypeProps
 /**
  * @private
  */
-export const wrapContentTypeCollection = wrapCollection(wrapContentType)
+export const wrapContentTypeCollection = wrapOptionalCursorCollection(wrapContentType)

--- a/lib/entities/editor-interface.ts
+++ b/lib/entities/editor-interface.ts
@@ -2,7 +2,7 @@ import copy from 'fast-copy'
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import enhanceWithMethods from '../enhance-with-methods'
 import type { MetaSysProps, MetaLinkProps, DefaultElements, MakeRequest } from '../common-types'
-import { wrapCollection } from '../common-utils'
+import { wrapOptionalCursorCollection } from '../common-utils'
 import type { DefinedParameters } from './widget-parameters'
 
 interface WidgetConfig {
@@ -216,4 +216,4 @@ export function wrapEditorInterface(
 /**
  * @private
  */
-export const wrapEditorInterfaceCollection = wrapCollection(wrapEditorInterface)
+export const wrapEditorInterfaceCollection = wrapOptionalCursorCollection(wrapEditorInterface)

--- a/lib/entities/entry.ts
+++ b/lib/entities/entry.ts
@@ -8,7 +8,7 @@ import type {
   MakeRequest,
   MetadataProps,
 } from '../common-types'
-import { wrapCollection } from '../common-utils'
+import { wrapOptionalCursorCollection } from '../common-utils'
 import type { ContentfulEntryApi } from '../create-entry-api'
 import createEntryApi from '../create-entry-api'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -70,4 +70,4 @@ export function wrapEntry(makeRequest: MakeRequest, data: EntryProps): Entry {
  * Data is also mixed in with link getters if links exist and includes were requested
  * @private
  */
-export const wrapEntryCollection = wrapCollection(wrapEntry)
+export const wrapEntryCollection = wrapOptionalCursorCollection(wrapEntry)

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -141,9 +141,8 @@ import type { FunctionLogPlainClientAPI } from './entities/function-log'
 import type { AiActionPlainClientAPI } from './entities/ai-action'
 import type { AiActionInvocationPlainClientAPI } from './entities/ai-action-invocation'
 
-type CursorResult<Params, CursorReturn, DefaultReturn> = CursorQueryEnabled<Params> extends true
-  ? CursorReturn
-  : DefaultReturn
+type CursorResult<Params, CursorReturn, DefaultReturn> =
+  CursorQueryEnabled<Params> extends true ? CursorReturn : DefaultReturn
 
 export type PlainClientAPI = {
   raw: {
@@ -319,7 +318,7 @@ export type PlainClientAPI = {
       T extends KeyValueMap = KeyValueMap,
       Params extends OptionalDefaults<GetSpaceEnvironmentParams & QueryParams> = OptionalDefaults<
         GetSpaceEnvironmentParams & QueryParams
-      >
+      >,
     >(
       params: Params,
       rawData?: unknown,
@@ -335,7 +334,7 @@ export type PlainClientAPI = {
       T extends KeyValueMap = KeyValueMap,
       Params extends OptionalDefaults<
         GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }
-      > = OptionalDefaults<GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }>
+      > = OptionalDefaults<GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }>,
     >(
       params: Params,
       rawData?: unknown,
@@ -406,7 +405,7 @@ export type PlainClientAPI = {
       T extends KeyValueMap = KeyValueMap,
       Params extends OptionalDefaults<GetSpaceEnvironmentParams & QueryParams> = OptionalDefaults<
         GetSpaceEnvironmentParams & QueryParams
-      >
+      >,
     >(
       params: Params,
       rawData?: unknown,
@@ -422,7 +421,7 @@ export type PlainClientAPI = {
       T extends KeyValueMap = KeyValueMap,
       Params extends OptionalDefaults<
         GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }
-      > = OptionalDefaults<GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }>
+      > = OptionalDefaults<GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }>,
     >(
       params: Params,
       rawData?: unknown,

--- a/lib/plain/entities/editor-interface.ts
+++ b/lib/plain/entities/editor-interface.ts
@@ -1,6 +1,8 @@
 import type { RawAxiosRequestHeaders } from 'axios'
 import type {
   CollectionProp,
+  CursorPaginatedCollectionProp,
+  CursorQueryEnabled,
   GetEditorInterfaceParams,
   GetSpaceEnvironmentParams,
   QueryParams,
@@ -37,9 +39,17 @@ export type EditorInterfacePlainClientAPI = {
    * });
    * ```
    */
-  getMany(
-    params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>,
-  ): Promise<CollectionProp<EditorInterfaceProps>>
+  getMany<
+    Params extends OptionalDefaults<GetSpaceEnvironmentParams & QueryParams> = OptionalDefaults<
+      GetSpaceEnvironmentParams & QueryParams
+    >,
+  >(
+    params: Params,
+  ): Promise<
+    CursorQueryEnabled<Params> extends true
+      ? CursorPaginatedCollectionProp<EditorInterfaceProps>
+      : CollectionProp<EditorInterfaceProps>
+  >
   /**
    * Update an Editor Interface
    * @param params entity IDs to identify the Editor Interface

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -1,6 +1,7 @@
 import type { GetContentTypeParams, GetSpaceEnvironmentParams, MakeRequest } from '../common-types'
 import { omitAndDeleteField } from '../methods/content-type'
 import type { PlainClientAPI } from './common-types'
+import type { EditorInterfacePlainClientAPI } from './entities/editor-interface'
 import type { DefaultParams } from './wrappers/wrap'
 import { wrap } from './wrappers/wrap'
 
@@ -155,7 +156,11 @@ export const createPlainClient = (
     },
     editorInterface: {
       get: wrap(wrapParams, 'EditorInterface', 'get'),
-      getMany: wrap(wrapParams, 'EditorInterface', 'getMany'),
+      getMany: wrap(
+        wrapParams,
+        'EditorInterface',
+        'getMany',
+      ) as EditorInterfacePlainClientAPI['getMany'],
       update: wrap(wrapParams, 'EditorInterface', 'update'),
     },
     space: {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.
-->

## Summary
Fixes an issue where the inferred type from a client instance method didn't match the previous shape, and therefore introduced a breaking change on the type level. 

cc @mrlaessig what do you think?