### PR TITLE
Revert "feat: add types for cursor base pagination [CAPI-2270]"

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@
   - [Authentication](#authentication)
   - [Using ES6 import](#using-es6-import)
   - [Your first Request](#your-first-request)
-  - [Cursor based pagination](#cursor-based-pagination)
   - [Alternative plain API](#alternative-plain-api)
 - [App Framework](#app-framework)
 - [Troubleshooting](#troubleshooting)
@@ -227,18 +226,6 @@ The benefits of using the "plain" version of the client, over the legacy version
 - All returned objects are simple Javascript objects without any wrappers. They can be easily serialized without an additional `toPlainObject` function call.
 - The ability to scope CMA client instance to a specific `spaceId`, `environmentId`, and `organizationId` when initializing the client.
   - You can pass a concrete values to `defaults` and omit specifying these params in actual CMA methods calls.
-
-## Cursor Based Pagination
-
-Cursor-based pagination is supported on collection endpoints for content types, entries, and assets. To use cursor-based pagination, pass the `cursor: true` parameter in your query:
-
-```js
-const response = await environment.getEntries({ cursor: true, limit: 10 });
-console.log(response.items); // Array of items
-console.log(response.pages?.next); // Cursor for next page
-```
-
-Use the value from `response.pages.next` to fetch the next page.
 
 ## Legacy Client Interface
 

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -368,15 +368,6 @@ interface CursorPaginationBase {
   limit?: number
 }
 
-export type OptionalCursorApi<P, T, TPlain> = {
-  (
-    query: P & CursorBasedParams['query'] & { cursor: true; skip?: never },
-  ): Promise<CursorPaginatedCollection<T, TPlain>>
-  (query?: P & { cursor?: false | undefined | never }): Promise<Collection<T, TPlain>>
-  (query?: P): Promise<Collection<T, TPlain>>
-}
-
-type WithCursorPagination<O> = O & { params: { query: { cursor: true } } }
 // Interfaces for each “exclusive” shape
 interface CursorPaginationPageNext extends CursorPaginationBase {
   pageNext: string
@@ -495,13 +486,7 @@ type MRInternal<UA extends boolean> = {
     opts: MROpts<'AppInstallation', 'getForOrganization', UA>,
   ): MRReturn<'AppInstallation', 'getForOrganization'>
 
-  (
-    opts: WithCursorPagination<MROpts<'Asset', 'getMany', UA>>,
-  ): Promise<CursorPaginatedCollectionProp<AssetProps>>
   (opts: MROpts<'Asset', 'getMany', UA>): MRReturn<'Asset', 'getMany'>
-  (
-    opts: WithCursorPagination<MROpts<'Asset', 'getPublished', UA>>,
-  ): Promise<CursorPaginatedCollectionProp<AssetProps>>
   (opts: MROpts<'Asset', 'getPublished', UA>): MRReturn<'Asset', 'getPublished'>
   (opts: MROpts<'Asset', 'get', UA>): MRReturn<'Asset', 'get'>
   (opts: MROpts<'Asset', 'update', UA>): MRReturn<'Asset', 'update'>
@@ -581,9 +566,6 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'ConceptScheme', 'delete', UA>): MRReturn<'ConceptScheme', 'delete'>
 
   (opts: MROpts<'ContentType', 'get', UA>): MRReturn<'ContentType', 'get'>
-  (
-    opts: WithCursorPagination<MROpts<'ContentType', 'getMany', UA>>,
-  ): Promise<CursorPaginatedCollectionProp<ConceptProps>>
   (opts: MROpts<'ContentType', 'getMany', UA>): MRReturn<'ContentType', 'getMany'>
   (opts: MROpts<'ContentType', 'update', UA>): MRReturn<'ContentType', 'update'>
   (opts: MROpts<'ContentType', 'create', UA>): MRReturn<'ContentType', 'create'>
@@ -593,9 +575,6 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'ContentType', 'unpublish', UA>): MRReturn<'ContentType', 'unpublish'>
 
   (opts: MROpts<'EditorInterface', 'get', UA>): MRReturn<'EditorInterface', 'get'>
-  (
-    opts: WithCursorPagination<MROpts<'EditorInterface', 'getMany', UA>>,
-  ): Promise<CursorPaginatedCollectionProp<EditorInterfaceProps>>
   (opts: MROpts<'EditorInterface', 'getMany', UA>): MRReturn<'EditorInterface', 'getMany'>
   (opts: MROpts<'EditorInterface', 'update', UA>): MRReturn<'EditorInterface', 'update'>
 
@@ -636,13 +615,7 @@ type MRInternal<UA extends boolean> = {
     opts: MROpts<'EnvironmentTemplateInstallation', 'getForEnvironment', UA>,
   ): MRReturn<'EnvironmentTemplateInstallation', 'getForEnvironment'>
 
-  (
-    opts: WithCursorPagination<MROpts<'Entry', 'getMany', UA>>,
-  ): Promise<CursorPaginatedCollectionProp<EntryProps>>
   (opts: MROpts<'Entry', 'getMany', UA>): MRReturn<'Entry', 'getMany'>
-  (
-    opts: WithCursorPagination<MROpts<'Entry', 'getPublished', UA>>,
-  ): Promise<CursorPaginatedCollectionProp<EntryProps>>
   (opts: MROpts<'Entry', 'getPublished', UA>): MRReturn<'Entry', 'getPublished'>
   (opts: MROpts<'Entry', 'get', UA>): MRReturn<'Entry', 'get'>
   (opts: MROpts<'Entry', 'patch', UA>): MRReturn<'Entry', 'patch'>

--- a/lib/common-utils.ts
+++ b/lib/common-utils.ts
@@ -8,7 +8,6 @@ import type {
   CursorPaginatedCollection,
   CursorPaginatedCollectionProp,
   MakeRequest,
-  OptionalCursorApi,
 } from './common-types'
 
 /**
@@ -23,20 +22,6 @@ export const wrapCollection =
     // @ts-expect-error
     return collectionData
   }
-
-/**
- * @private
- * Function for endpoints allowing `?cursor=true` wrapping the call
- * to ensure the correct return type for cursor based pagination
- * when `cursor: true`.
- */
-export const withOptionalCursorApi = <P, T, TPlain>(
-  fn: OptionalCursorApi<P, T, TPlain>,
-): OptionalCursorApi<P, T, TPlain> => {
-  return function (args) {
-    return fn.call(this, args)
-  }
-}
 
 export const wrapCursorPaginatedCollection =
   <R, T, Rest extends any[]>(fn: (makeRequest: MakeRequest, entity: T, ...rest: Rest) => R) =>

--- a/lib/create-environment-api.ts
+++ b/lib/create-environment-api.ts
@@ -61,7 +61,6 @@ import type { CreateAppAccessTokenProps } from './entities/app-access-token'
 import type { ResourceQueryOptions } from './entities/resource'
 import type { AiActionInvocationType } from './entities/ai-action-invocation'
 import { wrapAiActionInvocation } from './entities/ai-action-invocation'
-import { withOptionalCursorApi } from './common-utils'
 
 /**
  * @private
@@ -481,7 +480,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    getContentTypes: withOptionalCursorApi(function (query: QueryOptions = {}) {
+    getContentTypes(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
       return makeRequest({
         entityType: 'ContentType',
@@ -492,7 +491,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
           query: createRequestConfig({ query }).params,
         },
       }).then((data) => wrapContentTypeCollection(makeRequest, data))
-    }),
+    },
     /**
      * Creates a Content Type
      * @param data - Object representation of the Content Type to be created
@@ -728,7 +727,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    getEntries: withOptionalCursorApi(function (query: QueryOptions = {}) {
+    getEntries(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
       return makeRequest({
         entityType: 'Entry',
@@ -739,7 +738,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
           query: createRequestConfig({ query: query }).params,
         },
       }).then((data) => wrapEntryCollection(makeRequest, data))
-    }),
+    },
 
     /**
      * Gets a collection of published Entries
@@ -759,7 +758,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    getPublishedEntries: withOptionalCursorApi(function (query: QueryOptions = {}) {
+    getPublishedEntries(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
       return makeRequest({
         entityType: 'Entry',
@@ -770,7 +769,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
           query: createRequestConfig({ query: query }).params,
         },
       }).then((data) => wrapEntryCollection(makeRequest, data))
-    }),
+    },
 
     /**
      * Creates a Entry
@@ -944,7 +943,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    getAssets: withOptionalCursorApi(function (query: QueryOptions = {}) {
+    getAssets(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
       return makeRequest({
         entityType: 'Asset',
@@ -955,7 +954,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
           query: createRequestConfig({ query: query }).params,
         },
       }).then((data) => wrapAssetCollection(makeRequest, data))
-    }),
+    },
     /**
      * Gets a collection of published Assets
      * @param query - Object with search parameters. Check the <a href="https://www.contentful.com/developers/docs/javascript/tutorials/using-js-cda-sdk/#retrieving-entries-with-search-parameters">JS SDK tutorial</a> and the <a href="https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters">REST API reference</a> for more details.
@@ -974,7 +973,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    getPublishedAssets: withOptionalCursorApi(function (query: QueryOptions = {}) {
+    getPublishedAssets(query: QueryOptions = {}) {
       const raw = this.toPlainObject() as EnvironmentProps
       return makeRequest({
         entityType: 'Asset',
@@ -985,7 +984,7 @@ export default function createEnvironmentApi(makeRequest: MakeRequest) {
           query: createRequestConfig({ query: query }).params,
         },
       }).then((data) => wrapAssetCollection(makeRequest, data))
-    }),
+    },
     /**
      * Creates a Asset. After creation, call asset.processForLocale or asset.processForAllLocales to start asset processing.
      * @param data - Object representation of the Asset to be created. Note that the field object should have an upload property on asset creation, which will be removed and replaced with an url property when processing is finished.

--- a/lib/plain/common-types.ts
+++ b/lib/plain/common-types.ts
@@ -140,8 +140,6 @@ import type { FunctionLogPlainClientAPI } from './entities/function-log'
 import type { AiActionPlainClientAPI } from './entities/ai-action'
 import type { AiActionInvocationPlainClientAPI } from './entities/ai-action-invocation'
 
-type WithCursorBasedPagination<T> = T & { query: { cursor: true } }
-
 export type PlainClientAPI = {
   raw: {
     getDefaultParams(): DefaultParams | undefined
@@ -226,6 +224,7 @@ export type PlainClientAPI = {
         environmentTemplateId: string
         organizationId: string
         spaceId?: string
+        latestOnly?: boolean
       },
       headers?: RawAxiosRequestHeaders,
     ): Promise<CursorPaginatedCollectionProp<EnvironmentTemplateInstallationProps>>
@@ -273,9 +272,6 @@ export type PlainClientAPI = {
   contentType: {
     get(params: OptionalDefaults<GetContentTypeParams & QueryParams>): Promise<ContentTypeProps>
     getMany(
-      params: WithCursorBasedPagination<OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>>,
-    ): Promise<CursorPaginatedCollectionProp<ContentTypeProps>>
-    getMany(
       params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>,
     ): Promise<CollectionProp<ContentTypeProps>>
     update(
@@ -306,28 +302,15 @@ export type PlainClientAPI = {
   user: UserPlainClientAPI
   entry: {
     getPublished<T extends KeyValueMap = KeyValueMap>(
-      params: WithCursorBasedPagination<OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>>,
-      rawData?: unknown,
-      headers?: RawAxiosRequestHeaders,
-    ): Promise<CursorPaginatedCollectionProp<EntryProps<T>>>
-    getPublished<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>,
       rawData?: unknown,
       headers?: RawAxiosRequestHeaders,
     ): Promise<CollectionProp<EntryProps<T>>>
     getMany<T extends KeyValueMap = KeyValueMap>(
-      params: WithCursorBasedPagination<
-        OptionalDefaults<GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }>
-      >,
-      rawData?: unknown,
-      headers?: RawAxiosRequestHeaders,
-    ): Promise<CursorPaginatedCollectionProp<EntryProps<T>>>
-    getMany<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }>,
       rawData?: unknown,
       headers?: RawAxiosRequestHeaders,
     ): Promise<CollectionProp<EntryProps<T>>>
-
     get<T extends KeyValueMap = KeyValueMap>(
       params: OptionalDefaults<GetSpaceEnvironmentParams & { entryId: string; releaseId?: string }>,
       rawData?: unknown,
@@ -383,22 +366,10 @@ export type PlainClientAPI = {
   }
   asset: {
     getPublished(
-      params: WithCursorBasedPagination<OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>>,
-      rawData?: unknown,
-      headers?: RawAxiosRequestHeaders,
-    ): Promise<CursorPaginatedCollectionProp<AssetProps>>
-    getPublished(
       params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams>,
       rawData?: unknown,
       headers?: RawAxiosRequestHeaders,
     ): Promise<CollectionProp<AssetProps>>
-    getMany(
-      params: WithCursorBasedPagination<
-        OptionalDefaults<GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }>
-      >,
-      rawData?: unknown,
-      headers?: RawAxiosRequestHeaders,
-    ): Promise<CursorPaginatedCollectionProp<AssetProps>>
     getMany(
       params: OptionalDefaults<GetSpaceEnvironmentParams & QueryParams & { releaseId?: string }>,
       rawData?: unknown,

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -216,11 +216,7 @@ export const createPlainClient = (
     },
     contentType: {
       get: wrap(wrapParams, 'ContentType', 'get'),
-      getMany: wrap(
-        wrapParams,
-        'ContentType',
-        'getMany',
-      ) as PlainClientAPI['contentType']['getMany'],
+      getMany: wrap(wrapParams, 'ContentType', 'getMany'),
       update: wrap(wrapParams, 'ContentType', 'update'),
       delete: wrap(wrapParams, 'ContentType', 'delete'),
       publish: wrap(wrapParams, 'ContentType', 'publish'),
@@ -249,12 +245,8 @@ export const createPlainClient = (
       delete: wrap(wrapParams, 'Task', 'delete'),
     },
     entry: {
-      getPublished: wrap(
-        wrapParams,
-        'Entry',
-        'getPublished',
-      ) as PlainClientAPI['entry']['getPublished'],
-      getMany: wrap(wrapParams, 'Entry', 'getMany') as PlainClientAPI['entry']['getMany'],
+      getPublished: wrap(wrapParams, 'Entry', 'getPublished'),
+      getMany: wrap(wrapParams, 'Entry', 'getMany'),
       get: wrap(wrapParams, 'Entry', 'get'),
       update: wrap(wrapParams, 'Entry', 'update'),
       patch: wrap(wrapParams, 'Entry', 'patch'),
@@ -268,12 +260,8 @@ export const createPlainClient = (
       references: wrap(wrapParams, 'Entry', 'references'),
     },
     asset: {
-      getPublished: wrap(
-        wrapParams,
-        'Asset',
-        'getPublished',
-      ) as PlainClientAPI['asset']['getPublished'],
-      getMany: wrap(wrapParams, 'Asset', 'getMany') as PlainClientAPI['asset']['getMany'],
+      getPublished: wrap(wrapParams, 'Asset', 'getPublished'),
+      getMany: wrap(wrapParams, 'Asset', 'getMany'),
       get: wrap(wrapParams, 'Asset', 'get'),
       update: wrap(wrapParams, 'Asset', 'update'),
       delete: wrap(wrapParams, 'Asset', 'delete'),

--- a/test/integration/asset-integration.test.ts
+++ b/test/integration/asset-integration.test.ts
@@ -11,7 +11,6 @@ import {
   getTestOrganizationId,
 } from '../helpers'
 import type { ConceptProps, Environment, PlainClientAPI, Space } from '../../lib/export-types'
-import { TestDefaults } from '../defaults'
 
 describe('Asset API - Read', () => {
   let space: Space
@@ -43,43 +42,6 @@ describe('Asset API - Read', () => {
   test('Gets published assets', async () => {
     const response = await environment.getPublishedAssets()
     expect(response.items).toBeTruthy()
-  })
-
-  test('Gets assets cursor', async () => {
-    const response = await environment.getAssets({ cursor: true, limit: 1 })
-    expect(response.items).toBeTruthy()
-    expect(response.pages?.next).to.be.string
-  })
-
-  test('Gets published assets cursor', async () => {
-    const response = await environment.getPublishedAssets({ cursor: true, limit: 1 })
-    expect(response.items).toBeTruthy()
-    expect(response.pages?.next).to.be.string
-  })
-})
-
-describe('read plainClientApi', () => {
-  const createEntryClient = initPlainClient({
-    environmentId: TestDefaults.environmentId,
-    spaceId: TestDefaults.spaceId,
-  })
-
-  test('getMany cursor', async () => {
-    const response = await createEntryClient.asset.getMany({ query: { cursor: true, limit: 1 } })
-    expect(response.items).lengthOf(1)
-    expect(response.pages?.next).to.be.string
-  })
-
-  test('getMany published cursor', async () => {
-    const response = await createEntryClient.asset.getPublished({
-      query: {
-        cursor: true,
-        limit: 1,
-      },
-    })
-
-    expect(response.items).lengthOf(1)
-    expect(response.pages?.next).to.be.string
   })
 })
 

--- a/test/integration/content-type-integration.test.ts
+++ b/test/integration/content-type-integration.test.ts
@@ -6,10 +6,8 @@ import {
   generateRandomId,
   getDefaultSpace,
   timeoutToCalmRateLimiting,
-  initPlainClient,
 } from '../helpers'
 import type { Environment, ContentType, Space } from '../../lib/export-types'
-import { TestDefaults } from '../defaults'
 
 describe('ContentType Api', () => {
   let readSpace: Space
@@ -52,12 +50,6 @@ describe('ContentType Api', () => {
     it('Gets content types', async () => {
       const response = await readEnvironment.getContentTypes()
       expect(response.items).toBeTruthy()
-    })
-
-    it('Gets content types cursor', async () => {
-      const response = await readEnvironment.getContentTypes({ cursor: true, limit: 1 })
-      expect(response.items).toHaveLength(1)
-      expect(response.pages?.next).toBeTruthy()
     })
   })
 
@@ -142,24 +134,6 @@ describe('ContentType Api', () => {
       expect(contentType.name).toBe('testentitywithid')
 
       await contentType.delete()
-    })
-  })
-
-  describe('read plainClientApi', () => {
-    const createEntryClient = initPlainClient({
-      environmentId: TestDefaults.environmentId,
-      spaceId: TestDefaults.spaceId,
-    })
-
-    describe('read', () => {
-      it('getMany cursor', async () => {
-        const response = await createEntryClient.contentType.getMany({
-          query: { cursor: true, limit: 1 },
-        })
-
-        expect(response.items).toHaveLength(1)
-        expect(response.pages?.next).toBeTruthy()
-      })
     })
   })
 })

--- a/test/integration/entry-integration.test.ts
+++ b/test/integration/entry-integration.test.ts
@@ -78,24 +78,6 @@ describe('Entry Api', () => {
         })
     })
 
-    test('Gets entries with a cursor parameter', async () => {
-      return environment.getEntries({ cursor: true, limit: 1 }).then(async (response) => {
-        expect(response.items, 'items').ok
-        expect(response.items).lengthOf(1)
-        expect(response.items).lengthOf(1)
-        expect(response.pages?.next).to.be.string
-      })
-    })
-
-    test('Gets published entries with a cursor parameter', async () => {
-      return environment.getPublishedEntries({ cursor: true, limit: 1 }).then(async (response) => {
-        expect(response.items, 'items').ok
-        expect(response.items).lengthOf(1)
-        expect(response.items).lengthOf(1)
-        expect(response.pages?.next).to.be.string
-      })
-    })
-
     test('Gets entries with a skip parameter', async () => {
       return environment
         .getEntries({
@@ -732,32 +714,11 @@ describe('Entry Api', () => {
     beforeAll(async () => {
       plainClient = initPlainClient({ spaceId: TestDefaults.spaceId })
     })
-
     test('getPublished', async () => {
       const response = await plainClient.entry.getPublished({ environmentId: 'master' })
       expect(response.items[0].sys.firstPublishedAt).to.not.be.undefined
       expect(response.items[0].sys.publishedVersion).to.not.be.undefined
       expect(response.items[0].sys.publishedAt).to.not.be.undefined
-    })
-
-    test('getMany cursor', async () => {
-      const response = await plainClient.entry.getMany({
-        environmentId: 'master',
-        query: { limit: 1, cursor: true },
-      })
-
-      expect(response.items).toHaveLength(1)
-      expect(response.pages?.next).to.be.string
-    })
-
-    test('getPublished cursor', async () => {
-      const response = await plainClient.entry.getPublished({
-        environmentId: 'master',
-        query: { limit: 1, cursor: true },
-      })
-
-      expect(response.items).toHaveLength(1)
-      expect(response.pages?.next).to.be.string
     })
   })
 


### PR DESCRIPTION
Reverts contentful/contentful-management.js#2792 as it was breaking the types 