### PR TITLE
feat: expose referencingEntryId on resources [ARC-727] 

### DIFF
--- a/lib/entities/resource.ts
+++ b/lib/entities/resource.ts
@@ -12,11 +12,13 @@ export type ResourceQueryOptions = LookupQueryOptions | SearchQueryOptions
 type LookupQueryOptions = {
   'sys.urn[in]': string
   locale?: string
+  referencingEntryId?: string
 } & BasicCursorPaginationOptions
 
 type SearchQueryOptions = {
   query: string
   locale?: string
+  referencingEntryId?: string
 } & BasicCursorPaginationOptions
 
 export type ResourceProps = {

--- a/test/unit/plain/resource.test.ts
+++ b/test/unit/plain/resource.test.ts
@@ -30,4 +30,83 @@ describe('Resource', () => {
       `/spaces/spaceId/environments/envId/resource_types/${resourceTypeId}/resources`,
     )
   })
+
+  test('getMany with referencingEntryId parameter', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(
+      Promise.resolve({ data: { items: [resourceMock] } }),
+    )
+    const plainClient = createClient({ apiAdapter: adapterMock }, { type: 'plain' })
+    const response = await plainClient.resource.getMany({
+      spaceId,
+      environmentId,
+      resourceTypeId,
+      query: {
+        query: 'test',
+        referencingEntryId: 'entry-123',
+      },
+    })
+
+    expect(response).toBeInstanceOf(Object)
+    expect(httpMock.get.mock.calls[0][0]).toBe(
+      `/spaces/spaceId/environments/envId/resource_types/${resourceTypeId}/resources`,
+    )
+    expect(httpMock.get.mock.calls[0][1]).toMatchObject({
+      params: {
+        query: 'test',
+        referencingEntryId: 'entry-123',
+      },
+    })
+  })
+
+  test('getMany with locale parameter', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(
+      Promise.resolve({ data: { items: [resourceMock] } }),
+    )
+    const plainClient = createClient({ apiAdapter: adapterMock }, { type: 'plain' })
+    const response = await plainClient.resource.getMany({
+      spaceId,
+      environmentId,
+      resourceTypeId,
+      query: {
+        'sys.urn[in]': '123,456',
+        locale: 'en-US',
+      },
+    })
+
+    expect(response).toBeInstanceOf(Object)
+    expect(httpMock.get.mock.calls[0][1]).toMatchObject({
+      params: {
+        'sys.urn[in]': '123,456',
+        locale: 'en-US',
+      },
+    })
+  })
+
+  test('getMany with multiple optional parameters', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(
+      Promise.resolve({ data: { items: [resourceMock] } }),
+    )
+    const plainClient = createClient({ apiAdapter: adapterMock }, { type: 'plain' })
+    const response = await plainClient.resource.getMany({
+      spaceId,
+      environmentId,
+      resourceTypeId,
+      query: {
+        query: 'search term',
+        locale: 'de-DE',
+        referencingEntryId: 'entry-456',
+        limit: 10,
+      },
+    })
+
+    expect(response).toBeInstanceOf(Object)
+    expect(httpMock.get.mock.calls[0][1]).toMatchObject({
+      params: {
+        query: 'search term',
+        locale: 'de-DE',
+        referencingEntryId: 'entry-456',
+        limit: 10,
+      },
+    })
+  })
 })


### PR DESCRIPTION
## Summary
Exposing referencingEntryId for resources on contentful management client

## Description

The Extensibility API exposes referencingEntryId to enable passing to invoked functions for customers to do additional computation, however it is not exposed on this client which is used in other places to invoke the call to the management API. This PR exposes this new optional field on the management client.

## Motivation and Context

Customers sometimes want to pass on the referencingEntryId for Native External References to do additional lookups or computation.

## PR Checklist

- [X] I have read the `CONTRIBUTING.md` file
- [X] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Documentation is updated (if necessary)
- [X] PR doesn't contain any sensitive information
- [X] There are no breaking changes
