### PR TITLE
feat(app-definition): support agent property (currently internal-only) [EXT-7294]

### DIFF
--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -22,6 +22,10 @@ export interface NavigationItem {
   path: string
 }
 
+export interface AppDefinitionAgent {
+  id: string
+}
+
 /**
  * These locations are currently restricted to internal Contentful apps only.
  * If you are interested in using these locations for your app,
@@ -66,6 +70,12 @@ export type AppDefinitionProps = {
    * App name
    */
   name: string
+  /**
+   * This property is currently restricted to internal Contentful apps only.
+   * If you are interested in building agents using the App Framework,
+   * please reach out to Contentful Support (https://www.contentful.com/support/).
+   */
+  agent?: AppDefinitionAgent
   /**
    * URL where the root HTML document of the app can be found
    */

--- a/test/unit/entities/app-definition.test.ts
+++ b/test/unit/entities/app-definition.test.ts
@@ -40,6 +40,20 @@ describe('Entity AppDefinition', () => {
     })
   })
 
+  test('AppDefinition update preserves internal agent payload', async () => {
+    const { makeRequest, entityMock } = setup(Promise.resolve(appDefinitionMock))
+    const entity = wrapAppDefinition(makeRequest, entityMock)
+
+    entity.agent = { id: 'mocked-agent-id' }
+
+    await entity.update()
+
+    expect(makeRequest.mock.calls[0][0].payload).toMatchObject({
+      agent: { id: 'mocked-agent-id' },
+      name: appDefinitionMock.name,
+    })
+  })
+
   test('AppDefinition update fails', async () => {
     return failingVersionActionTest(setup, {
       wrapperMethod: wrapAppDefinition,

--- a/test/unit/mocks/entities.ts
+++ b/test/unit/mocks/entities.ts
@@ -339,6 +339,9 @@ const appDefinitionMock: AppDefinitionProps = {
     shared: true,
   }),
   name: 'AI Image Tagging',
+  agent: {
+    id: 'mocked-agent-id',
+  },
   src: 'https://ai-image-tagging.app-host.com/frontend/',
   locations: [
     {


### PR DESCRIPTION
## Summary

Preserve app definition metadata during JS client round-trips.

## Description

This PR updates the app definition types so the JS client retains metadata that may already be present on an app definition when it is fetched, modified, and sent back through create/update flows.

There is no breaking change here, and no broader runtime behavior change beyond preserving existing data more reliably.

> [!NOTE]
> If this area is interesting to you, especially around building agents using the App Framework, please reach out to Contentful Support. We’d be happy to learn more about your use case.

## Motivation and Context

Some app definitions can include additional metadata that should survive a read/modify/write cycle in the JS client.

Without type coverage for that metadata, typed usage can unintentionally drop it even though the underlying request flow already supports carrying it through. This change makes those round-trips safer and more predictable.

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR updates the app definition types to include support for an optional agent property, allowing the JS client to retain metadata that may be present on app definitions during fetch, modify, and update flows, ensuring safer and more predictable round-trips without introducing breaking changes or altering broader runtime behavior.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces new AppDefinitionAgent interface with id property in lib/entities/app-definition.ts</li>

<li>Adds optional agent property to AppDefinitionProps type with internal-only documentation</li>

<li>Updates appDefinitionMock in test/unit/mocks/entities.ts to include agent data</li>

<li>Adds test in test/unit/entities/app-definition.test.ts to verify agent payload preservation during updates</li>

</ul>
</details>

</div>