### PR TITLE
fix(ci): upstream npm self-upgrade regression [EXT-00]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,10 @@ jobs:
           cache: 'npm'
 
       - name: Install latest npm
-        run: npm install -g npm@latest
+        run: |
+          # Work around the npm self-upgrade regression on Node 22.22.2.
+          npm install -g npm@11.11.1
+          npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.
-->

## Summary

There is an upstream npm self-upgrade regression on Node 22.22.2: direct `npm install -g npm@latest` fails with the missing promise-retry module. That’s tracked in [npm/cli#9151](https://github.com/npm/cli/issues/9151), with the underlying fix described in [npm/cli#9152](https://github.com/npm/cli/pull/9152). 

<!-- Give a short summary what your PR is introducing/fixing. -->


## Description

I reproduced the failure in an isolated temp install of Node v22.22.2: direct `npm install -g npm@latest` failed with the same promise-retry stack trace.

I then verified the workaround in that same isolated environment: npm@11.11.1 installed successfully, then npm@latest upgraded successfully to 11.12.1.

<!-- Describe your changes in detail -->

## Motivation and Context

This is preventing releases from going out. We need to keep the npm upgrade because the release path is using trusted publishing guidance from semantic-release’s [GitHub Actions recipe](https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions), dropping the upgrade entirely would be a riskier change. 

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>There is an upstream npm self-upgrade regression on Node 22.22.2: direct `npm install -g npm@latest` fails with the missing promise-retry module. That’s tracked in [npm/cli#9151](https://github.com/npm/cli/issues/9151), with the underlying fix described in [npm/cli#9152](https://github.com/npm/cli/pull/9152). This pull request fixes the issue by modifying the release workflow to use a workaround that first installs npm@11.11.1 before upgrading to the latest version.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces a multi-step npm installation process in the release workflow to bypass the promise-retry module issue on Node 22.22.2, with an explanatory comment added for clarity.</li>

</ul>
</details>

</div>