### PR TITLE
chore(ci): allow failed test jobs to restore the cache on retry [EXT-00]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,4 +36,4 @@ jobs:
         with:
           path: |
             dist            
-          key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
+          key: build-cache-${{ github.run_id }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           path: |
             dist 
-          key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
+          key: build-cache-${{ github.run_id }}
           fail-on-cache-miss: true
 
       - name: Run linter

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           path: |
             dist
-          key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
+          key: build-cache-${{ github.run_id }}
           fail-on-cache-miss: true
 
       - name: Run Release

--- a/.github/workflows/test-demo-projects.yaml
+++ b/.github/workflows/test-demo-projects.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           path: |
             dist 
-          key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
+          key: build-cache-${{ github.run_id }}
           fail-on-cache-miss: true
           
       - name: Run integration tests

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           path: |
             dist 
-          key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
+          key: build-cache-${{ github.run_id }}
           fail-on-cache-miss: true
 
       - name: Run integration tests

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           path: |
             dist 
-          key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
+          key: build-cache-${{ github.run_id }}
           fail-on-cache-miss: true
 
       - name: Run integration tests


### PR DESCRIPTION
## Summary

Fix the CI build cache key so rerunning failed jobs can restore the existing `dist` cache.

## Description

This removes `github.run_attempt` from the build cache key in the reusable workflows, while keeping the cache scoped to the current workflow run via `github.run_id`.

## Motivation and Context

Our integration jobs could not be rerun in GitHub because the cache restore step was using an attempt-specific key with `fail-on-cache-miss: true`. This keeps the same run-scoped cache available across reruns of failed jobs.

> [!TIP]
> This is safe because the cache is still scoped to the current workflow run via `github.run_id`. We’re only removing `github.run_attempt` so rerun attempts can reuse the original build output instead of failing on a cache miss. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR updates build cache key configuration across five reusable GitHub Actions workflows. By retaining `github.run_id` while removing `github.run_attempt`, failed jobs can reuse the existing `dist` cache when rerun within the same workflow execution.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Changes the cache key in build.yaml so the generated `dist` artifacts are saved under the run-scoped `build-cache-${{ github.run_id }}` key.</li>

<li>Aligns cache restoration in check.yaml, release.yaml, test-demo-projects.yaml, and test-integration.yaml with the build cache key, allowing jobs configured with `fail-on-cache-miss: true` to find artifacts from earlier attempts.</li>

<li>Preserves cache isolation between separate workflow runs because `github.run_id` remains part of the key; only retry-attempt differentiation is removed.</li>

</ul>
</details>

</div>