### PR TITLE
fix: bump axios to ^1.15.0 to address CVE-2026-40175 [DX-930]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "contentful-sdk-core": "^9.4.4",
         "fast-copy": "^3.0.0",
         "globals": "^15.15.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   ],
   "dependencies": {
     "@contentful/rich-text-types": "^16.6.1",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "contentful-sdk-core": "^9.4.4",
     "fast-copy": "^3.0.0",
     "globals": "^15.15.0",


### PR DESCRIPTION
## Summary

- Bumps `axios` from `^1.13.5` to `^1.15.0` in `dependencies`
- All axios versions below `1.15.0` are affected by CVE-2026-40175 (CVSS 10.0)
- Consumers no longer need to use `npm overrides` / `yarn resolutions` as a workaround

## Test plan

- [ ] CI passes (unit + integration)
- [ ] Verify `axios@>=1.15.0` resolves in the lockfile
- [ ] No behavior changes expected — this is a lower-bound bump within the existing `^1.x` range

Fixes JSDK-57

🤖 Generated with [Claude Code](https://claude.com/claude-code)