### PR TITLE
fix(deps): bump axios to ^1.15.0 for v11 [DX-930]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "contentful-sdk-core": "^9.4.4",
         "fast-copy": "^3.0.0",
         "globals": "^15.15.0"
@@ -5557,14 +5557,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-loader": {
@@ -14988,10 +14988,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   ],
   "dependencies": {
     "@contentful/rich-text-types": "^16.6.1",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "contentful-sdk-core": "^9.4.4",
     "fast-copy": "^3.0.0",
     "globals": "^15.15.0"


### PR DESCRIPTION
## Summary
- Backports the axios CVE-2026-40175 fix (#2979) to the v11 release line
- Bumps `axios` from `^1.13.5` to `^1.15.0` — all versions below 1.15.0 have a CVSS 10.0 vulnerability
- Requested by a customer (Kylie Senn) still on `contentful-management@^11.x`

## Notes
This branch is based off `v11.75.0` (latest v11 tag), not master (which is v12). It **cannot be merged into master** — it needs to be published manually or via a maintenance branch in semantic-release.

**Suggested release approach:**
1. Add a `v11.x` maintenance branch to the `release.branches` config, or
2. Manually `npm publish --tag v11` from this branch after review

## Test plan
- [ ] Verify `package.json` has `axios: ^1.15.0`
- [ ] Verify `package-lock.json` resolves to `axios@1.15.0`
- [ ] Confirm existing tests pass on this branch
- [ ] Publish as `contentful-management@11.75.1` under a `v11` dist-tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)