### PR TITLE
feat: axios patch, agent run resume, app-definition agent support [DX-972, DX-975]

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
     secrets: inherit
 
   release:
-    if: github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/beta", "refs/heads/canary", "refs/heads/dev"]'), github.ref)
+    if: github.event_name == 'push' && (contains(fromJSON('["refs/heads/master", "refs/heads/beta", "refs/heads/canary", "refs/heads/dev"]'), github.ref) || endsWith(github.ref, '.x'))
     needs: [build, check, test-demo-projects, test-integration]
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ In addition, there may be some experimental features in the main build of this S
 
 ### Current experimental features
 
-- **AI Agents**: The Agent and Agent Run APIs (`getAgent`, `getAgents`, `getAgentRun`, `getAgentRuns`, `generateWithAgent`) are experimental and subject to breaking changes without notice.
+- **AI Agents**: The Agent and Agent Run APIs (`getAgent`, `getAgents`, `getAgentRun`, `getAgentRuns`, `generateWithAgent`, `resumeAgentRun`) are experimental and subject to breaking changes without notice.
 - **Component Types**: The Component Type `getMany` endpoint (`componentType.getMany`) is experimental and subject to breaking changes without notice.
 
 ## Reach out to us

--- a/lib/adapters/REST/endpoints/agent-run.ts
+++ b/lib/adapters/REST/endpoints/agent-run.ts
@@ -1,7 +1,12 @@
 import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import type { CollectionProp, GetSpaceEnvironmentParams } from '../../../common-types'
-import type { AgentRunProps, AgentRunQueryOptions } from '../../../entities/agent-run'
+import type {
+  AgentGenerateResponse,
+  AgentResumeRunPayload,
+  AgentRunProps,
+  AgentRunQueryOptions,
+} from '../../../entities/agent-run'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
 
@@ -36,6 +41,25 @@ export const getMany: RestEndpoint<'AgentRun', 'getMany'> = (
     `/spaces/${params.spaceId}/environments/${params.environmentId}/ai/agents/runs`,
     {
       params: params.query,
+      headers: {
+        ...AgentRunAlphaHeaders,
+        ...headers,
+      },
+    },
+  )
+}
+
+export const resumeRun: RestEndpoint<'AgentRun', 'resumeRun'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams & { runId: string },
+  data: AgentResumeRunPayload,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.post<AgentGenerateResponse>(
+    http,
+    `/spaces/${params.spaceId}/environments/${params.environmentId}/ai/agents/runs/${params.runId}/resume`,
+    data,
+    {
       headers: {
         ...AgentRunAlphaHeaders,
         ...headers,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -195,6 +195,7 @@ import type {
 import type { AgentGeneratePayload, AgentProps } from './entities/agent'
 import type {
   AgentGenerateResponse,
+  AgentResumeRunPayload,
   AgentRunProps,
   AgentRunQueryOptions,
 } from './entities/agent-run'
@@ -484,6 +485,7 @@ type MRInternal<UA extends boolean> = {
 
   (opts: MROpts<'AgentRun', 'get', UA>): MRReturn<'AgentRun', 'get'>
   (opts: MROpts<'AgentRun', 'getMany', UA>): MRReturn<'AgentRun', 'getMany'>
+  (opts: MROpts<'AgentRun', 'resumeRun', UA>): MRReturn<'AgentRun', 'resumeRun'>
 
   (opts: MROpts<'AppAction', 'get', UA>): MRReturn<'AppAction', 'get'>
   (opts: MROpts<'AppAction', 'getMany', UA>): MRReturn<'AppAction', 'getMany'>
@@ -1101,6 +1103,12 @@ export type MRActions = {
       params: GetSpaceEnvironmentParams & { query?: AgentRunQueryOptions }
       headers?: RawAxiosRequestHeaders
       return: CollectionProp<AgentRunProps>
+    }
+    resumeRun: {
+      params: GetSpaceEnvironmentParams & { runId: string }
+      payload: AgentResumeRunPayload
+      headers?: RawAxiosRequestHeaders
+      return: AgentGenerateResponse
     }
   }
   AutomationDefinition: {

--- a/lib/entities/agent-run.ts
+++ b/lib/entities/agent-run.ts
@@ -13,6 +13,10 @@ export type AgentGenerateResponse = {
   }
 }
 
+export type AgentResumeRunPayload<TResumePayload = Record<string, unknown>> = {
+  resumePayload: TResumePayload
+}
+
 export type AgentRunMessageRole = 'system' | 'user' | 'assistant' | 'tool'
 
 export type AgentRunMessageTextPart = {

--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -22,6 +22,10 @@ export interface NavigationItem {
   path: string
 }
 
+export interface AppDefinitionAgent {
+  id: string
+}
+
 /**
  * These locations are currently restricted to internal Contentful apps only.
  * If you are interested in using these locations for your app,
@@ -66,6 +70,12 @@ export type AppDefinitionProps = {
    * App name
    */
   name: string
+  /**
+   * This property is currently restricted to internal Contentful apps only.
+   * If you are interested in building agents using the App Framework,
+   * please reach out to Contentful Support (https://www.contentful.com/support/).
+   */
+  agent?: AppDefinitionAgent
   /**
    * URL where the root HTML document of the app can be found
    */

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -15,6 +15,7 @@ export type { AiActionInvocation, AiActionInvocationProps } from './entities/ai-
 export type { Agent, AgentGeneratePayload, AgentProps, AgentToolLink } from './entities/agent'
 export type {
   AgentGenerateResponse,
+  AgentResumeRunPayload,
   AgentRun,
   AgentRunMessage,
   AgentRunMessagePart,

--- a/lib/plain/entities/agent-run.ts
+++ b/lib/plain/entities/agent-run.ts
@@ -1,6 +1,11 @@
 import type { RawAxiosRequestHeaders } from 'axios'
 import type { CollectionProp, GetSpaceEnvironmentParams } from '../../common-types'
-import type { AgentRunProps, AgentRunQueryOptions } from '../../entities/agent-run'
+import type {
+  AgentGenerateResponse,
+  AgentResumeRunPayload,
+  AgentRunProps,
+  AgentRunQueryOptions,
+} from '../../entities/agent-run'
 import type { OptionalDefaults } from '../wrappers/wrap'
 
 export type AgentRunPlainClientAPI = {
@@ -27,4 +32,19 @@ export type AgentRunPlainClientAPI = {
     params: OptionalDefaults<GetSpaceEnvironmentParams & { query?: AgentRunQueryOptions }>,
     headers?: Partial<RawAxiosRequestHeaders>,
   ): Promise<CollectionProp<AgentRunProps>>
+  /**
+   * Resumes a suspended AI Agent Run that is in PENDING_REVIEW status.
+   * @param params Entity IDs to identify the AI Agent Run.
+   *               Must include spaceId, environmentId, and runId.
+   * @param payload The resume payload containing data needed to resume the run.
+   * @param headers Optional headers for the request.
+   * @returns A promise resolving with a simplified response containing `sys.id`, `sys.type`, and `sys.status`.
+   *          Use `agentRun.get()` with the returned `sys.id` to poll for full results.
+   * @throws if the request fails or the AI Agent Run is not found.
+   */
+  resumeRun(
+    params: OptionalDefaults<GetSpaceEnvironmentParams & { runId: string }>,
+    payload: AgentResumeRunPayload,
+    headers?: Partial<RawAxiosRequestHeaders>,
+  ): Promise<AgentGenerateResponse>
 }

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -79,6 +79,7 @@ export const createPlainClient = (
     agentRun: {
       get: wrap(wrapParams, 'AgentRun', 'get'),
       getMany: wrap(wrapParams, 'AgentRun', 'getMany'),
+      resumeRun: wrap(wrapParams, 'AgentRun', 'resumeRun'),
     },
     automationDefinition: {
       get: wrap(wrapParams, 'AutomationDefinition', 'get'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -5557,14 +5557,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-loader": {
@@ -14988,10 +14988,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "contentful-sdk-core": "^9.4.4",
         "fast-copy": "^3.0.0",
         "globals": "^15.15.0"

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
   },
   "release": {
     "branches": [
+      "+([0-9])?(.{+([0-9]),x}).x",
       "master",
       {
         "name": "beta",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   ],
   "dependencies": {
     "@contentful/rich-text-types": "^16.6.1",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "contentful-sdk-core": "^9.4.4",
     "fast-copy": "^3.0.0",
     "globals": "^15.15.0"

--- a/test/unit/entities/app-definition.test.ts
+++ b/test/unit/entities/app-definition.test.ts
@@ -40,6 +40,20 @@ describe('Entity AppDefinition', () => {
     })
   })
 
+  test('AppDefinition update preserves internal agent payload', async () => {
+    const { makeRequest, entityMock } = setup(Promise.resolve(appDefinitionMock))
+    const entity = wrapAppDefinition(makeRequest, entityMock)
+
+    entity.agent = { id: 'mocked-agent-id' }
+
+    await entity.update()
+
+    expect(makeRequest.mock.calls[0][0].payload).toMatchObject({
+      agent: { id: 'mocked-agent-id' },
+      name: appDefinitionMock.name,
+    })
+  })
+
   test('AppDefinition update fails', async () => {
     return failingVersionActionTest(setup, {
       wrapperMethod: wrapAppDefinition,

--- a/test/unit/mocks/entities.ts
+++ b/test/unit/mocks/entities.ts
@@ -324,6 +324,9 @@ const appDefinitionMock: AppDefinitionProps = {
     shared: true,
   }),
   name: 'AI Image Tagging',
+  agent: {
+    id: 'mocked-agent-id',
+  },
   src: 'https://ai-image-tagging.app-host.com/frontend/',
   locations: [
     {

--- a/test/unit/plain/agent-run.test.ts
+++ b/test/unit/plain/agent-run.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest'
+import type { AgentResumeRunPayload } from '../../../lib/entities/agent-run'
 import { createClient } from '../../../lib/contentful-management'
 import setupRestAdapter from '../adapters/REST/helpers/setupRestAdapter'
 
@@ -90,6 +91,47 @@ describe('AgentRun', () => {
       expect.objectContaining({
         baseURL: 'https://api.contentful.com',
         params: { statusIn: ['COMPLETED'] },
+        headers: expect.objectContaining({
+          'x-contentful-enable-alpha-feature': 'agents-api',
+        }),
+      }),
+    )
+  })
+
+  test('resumeRun', async () => {
+    const mockResponse = {
+      sys: {
+        id: runId,
+        type: 'AgentRun' as const,
+        status: 'IN_PROGRESS' as const,
+      },
+    }
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+    const plainClient = createClient({ apiAdapter: adapterMock }, { type: 'plain' })
+
+    type CustomResumePayload = {
+      someKey: string
+    }
+
+    const payload: AgentResumeRunPayload<CustomResumePayload> = {
+      resumePayload: { someKey: 'someValue' },
+    }
+
+    const response = await plainClient.agentRun.resumeRun(
+      { spaceId, environmentId, runId },
+      payload,
+    )
+
+    expect(response).toBeInstanceOf(Object)
+    expect(response.sys.id).toBe(runId)
+    expect(response.sys.type).toBe('AgentRun')
+    expect(response.sys.status).toBe('IN_PROGRESS')
+
+    expect(httpMock.post).toHaveBeenCalledWith(
+      `/spaces/${spaceId}/environments/${environmentId}/ai/agents/runs/${runId}/resume`,
+      payload,
+      expect.objectContaining({
+        baseURL: 'https://api.contentful.com',
         headers: expect.objectContaining({
           'x-contentful-enable-alpha-feature': 'agents-api',
         }),


### PR DESCRIPTION
## Summary

- Cherry-picks semantic-release maintenance branch config (`+([0-9])?(.{+([0-9]),x}).x` glob + GHA `endsWith(.x)` condition) so this `11.x` branch can auto-release
- Cherry-picks the axios `^1.15.0` bump to address CVE-2026-40175
- Cherry-picks agent run resume support (`resumeRun` endpoint + types) from PIC-981 for teams that cannot upgrade to CMA v12 yet
- Cherry-picks app-definition `agent` property support (internal-only) from EXT-7294

## Context

Backporting critical fixes and features to CMA v11 per our [SUPPORT.md](https://github.com/contentful/contentful-management.js/blob/master/SUPPORT.md) maintenance policy. The semantic-release config change is needed first so that merges into `11.x` actually publish to npm under the v11 dist-tag.

The `resumeRun` and app-definition `agent` property backports unblock the Google Docs app and other consumers still on v11 that need agent platform support.

**Jira**: [DX-972](https://contentful.atlassian.net/browse/DX-972), [DX-975](https://contentful.atlassian.net/browse/DX-975)

## Test plan

- [ ] CI passes on this branch
- [ ] After merge, verify semantic-release publishes as `v11.76.0` (minor bump from maintenance branch feat commit)
- [ ] Confirm `npm info contentful-management dist-tags` shows the v11 dist-tag
- [ ] `resumeRun` types and endpoint are accessible from the v11 published package
- [ ] `AppDefinitionProps.agent` typing is present in the v11 published package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DX-972]: https://contentful.atlassian.net/browse/DX-972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-975]: https://contentful.atlassian.net/browse/DX-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ