### PR TITLE
fix(experience): use DimensionedDesignPropertyValue for designProperties [DX-923]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -75,6 +75,8 @@ export type DesignPropertyValue =
   | DesignPropertyPointerValue
   | Record<string, ManualDesignValue | DesignTokenValue | DesignPropertyPointerValue>
 
+export type DimensionedDesignPropertyValue = Record<string, DesignPropertyValue>
+
 // Tree node types for component tree
 export type ComponentNode = {
   id: string

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -1,5 +1,5 @@
 import type { CursorPaginationParams, Link, MetadataProps } from '../common-types'
-import type { ComponentTypeViewport, DesignPropertyValue, FragmentNode } from './component-type'
+import type { ComponentTypeViewport, DimensionedDesignPropertyValue, FragmentNode } from './component-type'
 
 export type ExperienceDimensionKeyMap = {
   designProperties: Record<string, { breakpoint: string }>
@@ -42,7 +42,7 @@ type ExperienceCommonProps = {
   description: string
   viewports: ComponentTypeViewport[]
   contentProperties: Record<string, unknown>
-  designProperties: Record<string, DesignPropertyValue>
+  designProperties: Record<string, DimensionedDesignPropertyValue>
   dimensionKeyMap: ExperienceDimensionKeyMap
   contentBindings?: ExperienceContentBindings
   metadata?: Pick<MetadataProps, 'tags'>
@@ -74,7 +74,7 @@ export type InlineFragmentNode = {
   id: string
   nodeType: 'InlineFragment'
   componentTypeId: string
-  designProperties: Record<string, DesignPropertyValue>
+  designProperties: Record<string, DimensionedDesignPropertyValue>
   contentBindings?: ExperienceContentBindings
   slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>
 }

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -1,5 +1,9 @@
 import type { CursorPaginationParams, Link, MetadataProps } from '../common-types'
-import type { ComponentTypeViewport, DimensionedDesignPropertyValue, FragmentNode } from './component-type'
+import type {
+  ComponentTypeViewport,
+  DimensionedDesignPropertyValue,
+  FragmentNode,
+} from './component-type'
 
 export type ExperienceDimensionKeyMap = {
   designProperties: Record<string, { breakpoint: string }>


### PR DESCRIPTION
[DX-923](https://contentful.atlassian.net/browse/DX-923)

## Summary
- The SDK was typing `designProperties` on `ExperienceCommonProps` and `InlineFragmentNode` as `Record<string, DesignPropertyValue>` — a flat map
- The upstream schema uses a dimensioned type: each design property maps a dimension key (e.g., viewport ID) to a value, i.e. `Record<string, Record<string, DesignPropertyValue>>`
- Adds `DimensionedDesignPropertyValue = Record<string, DesignPropertyValue>` to `component-type.ts` and updates both `designProperties` fields in `experience.ts` to use it

## Test plan
- [ ] `tsc --noEmit` passes clean
- [ ] Unit tests pass (`vitest run test/unit/adapters/REST/endpoints/experience.test.ts`)
- [ ] Existing test fixtures (`designProperties: {}`) remain compatible with the new type

Generated with [Claude Code](https://claude.com/claude-code)

[DX-923]: https://contentful.atlassian.net/browse/DX-923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ