### PR TITLE
fix(component-type): sync design property value types with upstream schema [DX-907]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -25,11 +25,17 @@ export type ComponentTypeContentProperty = {
 }
 
 // Design property validation option
-export type ComponentTypeDesignPropertyValidation = {
-  value: string | number | boolean
-  name: string
-  description?: string
-}
+export type ComponentTypeDesignPropertyValidation =
+  | {
+      type: 'ManualDesignValue'
+      value: string | number | boolean
+      name?: string
+    }
+  | {
+      type: 'DesignToken'
+      value: string
+      name?: string
+    }
 
 // Design property definition
 export type ComponentTypeDesignProperty = {
@@ -38,11 +44,11 @@ export type ComponentTypeDesignProperty = {
   type: 'Symbol' | 'Number' | 'Boolean'
   required: boolean
   description?: string
-  defaultValue?: unknown
+  defaultValue?: DesignPropertyDefinitionValue
   validations?: {
-    in: ComponentTypeDesignPropertyValidation[]
+    in?: ComponentTypeDesignPropertyValidation[]
   }
-  designTokenSet?: string[]
+  designTokenSet: string[]
 }
 
 // Dimension key map
@@ -61,14 +67,21 @@ export type DesignPropertyPointerValue = `$designProperties/${string}`
 // Design property value types
 export type ManualDesignValue = {
   type: 'ManualDesignValue'
-  value: string | number | boolean | Record<string, unknown>
+  value: string | number | boolean
 }
 
 export type DesignTokenValue = {
   type: 'DesignToken'
+  /** Must be non-empty (min length 1) */
   value: string
 }
 
+// For designProperties[].defaultValue (definition level)
+// Upstream: DesignPropertyValueSchema (schema line 86-91)
+export type DesignPropertyDefinitionValue = ManualDesignValue | DesignTokenValue
+
+// For componentTree node designProperties (tree-node level)
+// Upstream: ComponentTreeDesignPropertyValueSchema (schema line 101-104)
 export type DesignPropertyValue =
   | ManualDesignValue
   | DesignTokenValue


### PR DESCRIPTION
[DX-907](https://contentful.atlassian.net/browse/DX-907)

## Summary
- The SDK had several type mismatches in `lib/entities/component-type.ts` vs the upstream assemblies schema
- Fixes six issues: restricts `ManualDesignValue.value` to primitives, splits definition-level vs tree-node-level `DesignPropertyValue` into separate types, converts `ComponentTypeDesignPropertyValidation` to a discriminated union, makes `validations.in` optional, makes `designTokenSet` required, and adds a JSDoc min-length note to `DesignTokenValue.value`
- All changes are type-only — no runtime behavior changes

## Test plan
- [ ] `npx tsc --noEmit` passes clean
- [ ] Unit tests pass: `npx vitest run test/unit/adapters/REST/endpoints/component-type.test.ts`

Generated with [Claude Code](https://claude.com/claude-code)

[DX-907]: https://contentful.atlassian.net/browse/DX-907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ