### PR TITLE
feat: introduce ExoMetadataProps and align ExO entity metadata types [DX-908]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -376,6 +376,18 @@ export interface MetadataProps {
   concepts?: Link<'TaxonomyConcept'>[]
 }
 
+/**
+ * Metadata shape for ExO entities (ComponentType, Experience/View, Template).
+ * - tags: optional (upstream MetadataSchema.tags is z.optional as of SPA-3821)
+ * - concepts: optional taxonomy concept links
+ * - name: optional display name for variant labeling (SPA-3939)
+ */
+export interface ExoMetadataProps {
+  tags?: Link<'Tag'>[]
+  concepts?: Link<'TaxonomyConcept'>[]
+  name?: string
+}
+
 export interface SysLink {
   sys: MetaLinkProps
 }

--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -1,5 +1,5 @@
 import type { Except } from 'type-fest'
-import type { CursorPaginationParams, Link, MetadataProps, SysLink } from '../common-types'
+import type { CursorPaginationParams, ExoMetadataProps, Link, SysLink } from '../common-types'
 
 // Query options for getMany - cursor-based pagination with mutual exclusivity & query filters
 export type ComponentTypeQueryOptions = CursorPaginationParams & {
@@ -177,7 +177,7 @@ export type ComponentTypeProps = {
   componentTree?: TreeNode[]
   contentBindings?: ComponentTypeContentBindings
   slots?: ComponentTypeSlotDefinition[]
-  metadata?: Pick<MetadataProps, 'tags'>
+  metadata?: ExoMetadataProps
   dataAssemblies?: DataAssemblyLink[]
 }
 

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -1,4 +1,4 @@
-import type { CursorPaginationParams, Link, MetadataProps } from '../common-types'
+import type { CursorPaginationParams, ExoMetadataProps, Link } from '../common-types'
 import type {
   ComponentTypeViewport,
   DimensionedDesignPropertyValue,
@@ -26,10 +26,10 @@ export type ExperienceSys = {
   environment: Link<'Environment'>
   componentType: Link<'ComponentType'>
   template?: Link<'Template'>
-  createdAt?: string
-  updatedAt?: string
-  createdBy?: Link<'User'>
-  updatedBy?: Link<'User'>
+  createdAt: string
+  updatedAt: string
+  createdBy: Link<'User'>
+  updatedBy: Link<'User'>
   variant?: string
   variantType?: string
   variantDimension?: string
@@ -49,7 +49,7 @@ type ExperienceCommonProps = {
   designProperties: Record<string, DimensionedDesignPropertyValue>
   dimensionKeyMap: ExperienceDimensionKeyMap
   contentBindings?: ExperienceContentBindings
-  metadata?: Pick<MetadataProps, 'tags'>
+  metadata?: ExoMetadataProps
   slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>
 }
 

--- a/lib/entities/template.ts
+++ b/lib/entities/template.ts
@@ -1,5 +1,5 @@
 import type { Except } from 'type-fest'
-import type { CursorPaginationParams, Link, MetadataProps } from '../common-types'
+import type { CursorPaginationParams, ExoMetadataProps, Link } from '../common-types'
 import type {
   ComponentTypeContentProperty,
   ComponentTypeDesignProperty,
@@ -43,7 +43,7 @@ export type TemplateProps = {
   dimensionKeyMap: ComponentTypeDimensionKeyMap
   componentTree?: TreeNode[]
   slots?: ComponentTypeSlotDefinition[]
-  metadata?: Pick<MetadataProps, 'tags'>
+  metadata?: ExoMetadataProps
   dataAssemblies?: DataAssemblyLink[]
 }
 


### PR DESCRIPTION
[DX-908](https://contentful.atlassian.net/browse/DX-908)

## Summary
- Adds `ExoMetadataProps` to `lib/common-types.ts` — a new metadata interface for ExO entities with optional `tags?`, `concepts?`, and `name?` fields (replacing the narrower `Pick<MetadataProps, 'tags'>` pattern)
- Updates `ComponentTypeCommonProps`, `ExperienceCommonProps`, and `TemplateCommonProps` to use `ExoMetadataProps`, aligning with upstream SPA-3821 (tags now optional) and SPA-3939 (adds `name` for variant labeling)
- Makes `ExperienceSys` audit fields (`createdAt`, `updatedAt`, `createdBy`, `updatedBy`) required per SPA-3821; leaves `DataAssemblyCommonProps.metadata` and `MetadataProps` (used by Entry/Asset) unchanged

## Test plan
- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] Unit tests pass (`npm test` — 110 unit test files, 2 type test files)
- [ ] `ExoMetadataProps` is exported via `export-types.ts` (`export * from './common-types'`)
- [ ] `DataAssemblyCommonProps.metadata` unchanged (`Pick<MetadataProps, 'tags'>`, required tags only)
- [ ] `MetadataProps` unchanged (required `tags`, optional `concepts`)

Generated with [Claude Code](https://claude.com/claude-code)

[DX-908]: https://contentful.atlassian.net/browse/DX-908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ