### PR TITLE
fix: remove stale $contentBindings pointer variant from ContentPropertyPointerValue [DX-906]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -57,9 +57,7 @@ export type ComponentTypeDimensionKeyMap = {
 }
 
 // Content property pointer value types
-export type ContentPropertyPointerValue =
-  | `$contentProperties/${string}`
-  | `$contentBindings/${string}`
+export type ContentPropertyPointerValue = `$contentProperties/${string}`
 
 // Design property pointer value types
 export type DesignPropertyPointerValue = `$designProperties/${string}`


### PR DESCRIPTION
[DX-906](https://contentful.atlassian.net/browse/DX-906)

## Summary
- Removes the `$contentBindings/${string}` variant from `ContentPropertyPointerValue` in `lib/entities/component-type.ts` — this variant does not exist in the upstream schema (`ContentPropertyValueSchema` only defines `$contentProperties/`)
- `ContentPropertyPointerValue` is now the single template literal type `` `$contentProperties/${string}` ``
- The other `contentBindings` fields in the file (`ComponentTypeContentBindings`, `contentBindings?: ComponentTypeContentBindings`) are unrelated struct fields and are untouched

## Test plan
- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] 816 unit tests pass (`npm test`)
- [ ] No `$contentBindings/` pointer usages exist anywhere in lib or test files

Generated with [Claude Code](https://claude.com/claude-code)

[DX-906]: https://contentful.atlassian.net/browse/DX-906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ