### PR TITLE
fix: tighten sys link types for ComponentTypeSys and DataAssemblySys [DX-909]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -1,5 +1,5 @@
 import type { Except } from 'type-fest'
-import type { CursorPaginationParams, Link, MetadataProps, SysLink } from '../common-types'
+import type { CursorPaginationParams, Link, MetadataProps } from '../common-types'
 
 // Query options for getMany - cursor-based pagination with mutual exclusivity & query filters
 export type ComponentTypeQueryOptions = CursorPaginationParams & {
@@ -150,8 +150,8 @@ export type ComponentTypeSys = {
   id: string
   type: 'ComponentType'
   version: number
-  space: SysLink
-  environment: SysLink
+  space: Link<'Space'>
+  environment: Link<'Environment'>
   fieldStatus?: Record<string, Record<string, 'draft' | 'published' | 'changed'>>
   publishedAt?: string
   publishedVersion?: number
@@ -159,10 +159,12 @@ export type ComponentTypeSys = {
   firstPublishedAt?: string
   publishedBy?: Link<'User'> | Link<'AppDefinition'>
   variant?: string
-  createdAt?: string
-  createdBy?: Link<'User'>
-  updatedAt?: string
-  updatedBy?: Link<'User'>
+  variantType?: string
+  variantDimension?: string
+  createdAt: string
+  createdBy: Link<'User'>
+  updatedAt: string
+  updatedBy: Link<'User'>
 }
 
 // Main ComponentType props

--- a/lib/entities/data-assembly.ts
+++ b/lib/entities/data-assembly.ts
@@ -46,8 +46,8 @@ export type DataAssemblySys = {
   type: 'DataAssembly'
   dataType: DataAssemblyDataTypeField[]
   version: number
-  space: Link<string>
-  environment: Link<string>
+  space: Link<'Space'>
+  environment: Link<'Environment'>
   createdBy: Link<string>
   createdAt: string | Date
   updatedAt: string | Date

--- a/lib/entities/data-assembly.ts
+++ b/lib/entities/data-assembly.ts
@@ -1,4 +1,5 @@
 import type { CursorPaginationParams, Link, MetadataProps } from '../common-types'
+import { User } from './user'
 
 export type DataAssemblyDataTypeField = {
   id: string
@@ -48,15 +49,15 @@ export type DataAssemblySys = {
   version: number
   space: Link<'Space'>
   environment: Link<'Environment'>
-  createdBy: Link<string>
+  createdBy: Link<'User'>
   createdAt: string | Date
   updatedAt: string | Date
-  updatedBy?: Link<string>
+  updatedBy?: Link<'User'>
   publishedAt?: string | Date
   publishedVersion?: number
   publishedCounter?: number
   firstPublishedAt?: string | Date
-  publishedBy?: Link<string>
+  publishedBy?: Link<'User'> | Link<'AppDefinition'>
   variant?: string
 }
 


### PR DESCRIPTION
[DX-909](https://contentful.atlassian.net/browse/DX-909)

## Summary
- Tightens `ComponentTypeSys.space`/`.environment` from loose `SysLink` to `Link<'Space'>`/`Link<'Environment'>`, matching the upstream schema and existing `ExperienceSys` pattern; removes now-unused `SysLink` import
- Tightens `DataAssemblySys.space`/`.environment` from generic `Link<string>` to `Link<'Space'>`/`Link<'Environment'>`
- Makes `ComponentTypeSys` audit fields (`createdAt`, `updatedAt`, `createdBy`, `updatedBy`) required per upstream SPA-3821, and adds missing `variantType?`/`variantDimension?` fields; `TemplateSys` equivalent changes already landed in feat/exo via PR #2971

## Test plan
- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] 816 unit tests pass (`npm test`)
- [ ] No `SysLink` or `Link<string>` remains for `space`/`environment` in ExO entity sys types
- [ ] `ComponentTypeSys` has `variantType?: string` and `variantDimension?: string`
- [ ] `ComponentTypeSys` audit fields are required (no `?`)

Generated with [Claude Code](https://claude.com/claude-code)

[DX-909]: https://contentful.atlassian.net/browse/DX-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ