### PR TITLE
fix: narrow UpdateTemplateProps.sys to minimal write shape [DX-934]

### DIFF
--- a/lib/entities/template.ts
+++ b/lib/entities/template.ts
@@ -49,7 +49,13 @@ export type TemplateProps = {
 
 export type CreateTemplateProps = Except<TemplateProps, 'sys'>
 
-export type UpdateTemplateProps = TemplateProps
+export type UpdateTemplateProps = Omit<TemplateProps, 'sys'> & {
+  sys: {
+    id: string
+    type: 'Template'
+    version: number
+  }
+}
 
 // Query options for getMany - cursor-based pagination with filter support
 export type TemplateQueryOptions = CursorPaginationParams & {


### PR DESCRIPTION
[DX-934](https://contentful.atlassian.net/browse/DX-934)

## Summary
- `UpdateTemplateProps` previously aliased the full `TemplateProps`, leaking read-only `TemplateSys` fields (space, environment, publishedAt, etc.) into a write payload type
- Narrows `sys` to `{ id, type, version }` following the existing `UpdateDataAssemblyProps` pattern
- No runtime change — the REST adapter already strips `sys` before the PUT body and only reads `sys.version` for the `X-Contentful-Version` header; callers passing a full `TemplateProps` object continue to compile (TypeScript allows a superset)

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [x] All unit tests pass (`test/unit/adapters/REST/endpoints/template.test.ts`)
- [ ] Verify existing call sites (plain client `update()`) continue to compile with a full `TemplateProps` object

Generated with [Claude Code](https://claude.com/claude-code)

[DX-934]: https://contentful.atlassian.net/browse/DX-934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ