### PR TITLE
feat: add collection response types for ComponentType, Template, and Experience [DX-933]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -61,6 +61,7 @@ import type {
   UpdateCommentProps,
 } from './entities/comment'
 import type {
+  ComponentTypeCollection,
   ComponentTypeProps,
   ComponentTypeQueryOptions,
   CreateComponentTypeProps,
@@ -68,12 +69,14 @@ import type {
 } from './entities/component-type'
 import type {
   CreateTemplateProps,
+  TemplateCollection,
   TemplateProps,
   TemplateQueryOptions,
   UpdateTemplateProps,
 } from './entities/template'
 import type {
   CreateExperienceProps,
+  ExperienceCollection,
   UpdateExperienceProps,
   ExperienceLocalePublishPayload,
   ExperienceProps,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -61,7 +61,6 @@ import type {
   UpdateCommentProps,
 } from './entities/comment'
 import type {
-  ComponentTypeCollection,
   ComponentTypeProps,
   ComponentTypeQueryOptions,
   CreateComponentTypeProps,
@@ -69,14 +68,12 @@ import type {
 } from './entities/component-type'
 import type {
   CreateTemplateProps,
-  TemplateCollection,
   TemplateProps,
   TemplateQueryOptions,
   UpdateTemplateProps,
 } from './entities/template'
 import type {
   CreateExperienceProps,
-  ExperienceCollection,
   UpdateExperienceProps,
   ExperienceLocalePublishPayload,
   ExperienceProps,

--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -1,5 +1,5 @@
 import type { Except } from 'type-fest'
-import type { CursorPaginationParams, ExoMetadataProps, Link } from '../common-types'
+import type { CursorPaginatedCollectionProp, CursorPaginationParams, ExoMetadataProps, Link } from '../common-types'
 
 // Query options for getMany - cursor-based pagination with mutual exclusivity & query filters
 export type ComponentTypeQueryOptions = CursorPaginationParams & {
@@ -184,3 +184,5 @@ export type ComponentTypeProps = {
 export type CreateComponentTypeProps = Except<ComponentTypeProps, 'sys'>
 
 export type UpdateComponentTypeProps = ComponentTypeProps
+
+export type ComponentTypeCollection = CursorPaginatedCollectionProp<ComponentTypeProps>

--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -1,5 +1,10 @@
 import type { Except } from 'type-fest'
-import type { CursorPaginatedCollectionProp, CursorPaginationParams, ExoMetadataProps, Link } from '../common-types'
+import type {
+  CursorPaginatedCollectionProp,
+  CursorPaginationParams,
+  ExoMetadataProps,
+  Link,
+} from '../common-types'
 
 // Query options for getMany - cursor-based pagination with mutual exclusivity & query filters
 export type ComponentTypeQueryOptions = CursorPaginationParams & {

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -1,4 +1,9 @@
-import type { CursorPaginatedCollectionProp, CursorPaginationParams, ExoMetadataProps, Link } from '../common-types'
+import type {
+  CursorPaginatedCollectionProp,
+  CursorPaginationParams,
+  ExoMetadataProps,
+  Link,
+} from '../common-types'
 import type {
   ComponentTypeViewport,
   DimensionedDesignPropertyValue,

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -1,4 +1,4 @@
-import type { CursorPaginationParams, ExoMetadataProps, Link } from '../common-types'
+import type { CursorPaginatedCollectionProp, CursorPaginationParams, ExoMetadataProps, Link } from '../common-types'
 import type {
   ComponentTypeViewport,
   DimensionedDesignPropertyValue,
@@ -82,3 +82,5 @@ export type InlineFragmentNode = {
   contentBindings?: ExperienceContentBindings
   slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>
 }
+
+export type ExperienceCollection = CursorPaginatedCollectionProp<ExperienceProps>

--- a/lib/entities/template.ts
+++ b/lib/entities/template.ts
@@ -1,5 +1,10 @@
 import type { Except } from 'type-fest'
-import type { CursorPaginatedCollectionProp, CursorPaginationParams, ExoMetadataProps, Link } from '../common-types'
+import type {
+  CursorPaginatedCollectionProp,
+  CursorPaginationParams,
+  ExoMetadataProps,
+  Link,
+} from '../common-types'
 import type {
   ComponentTypeContentProperty,
   ComponentTypeDesignProperty,

--- a/lib/entities/template.ts
+++ b/lib/entities/template.ts
@@ -1,5 +1,5 @@
 import type { Except } from 'type-fest'
-import type { CursorPaginationParams, ExoMetadataProps, Link } from '../common-types'
+import type { CursorPaginatedCollectionProp, CursorPaginationParams, ExoMetadataProps, Link } from '../common-types'
 import type {
   ComponentTypeContentProperty,
   ComponentTypeDesignProperty,
@@ -56,3 +56,5 @@ export type TemplateQueryOptions = CursorPaginationParams & {
   order?: string
   [key: string]: unknown
 }
+
+export type TemplateCollection = CursorPaginatedCollectionProp<TemplateProps>

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -357,3 +357,6 @@ export type {
   WorkflowsChangelogEntryProps,
   WorkflowsChangelogQueryOptions,
 } from './entities/workflows-changelog-entry'
+export type { ComponentTypeCollection } from './entities/component-type'
+export type { TemplateCollection } from './entities/template'
+export type { ExperienceCollection } from './entities/experience'


### PR DESCRIPTION
[DX-933](https://contentful.atlassian.net/browse/DX-933)

## Summary
- Adds `ComponentTypeCollection`, `TemplateCollection`, and `ExperienceCollection` type aliases — each wrapping `CursorPaginatedCollectionProp<X>` — giving SDK consumers a named type to reference at `getMany` call sites
- Adds `CursorPaginatedCollectionProp` to the import in each entity file (no new dependency — already defined in `scheduled-action.ts` and re-exported from `common-types`)
- Exports all three collection types from the SDK's public type surface via `export-types.ts`

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [x] All unit tests pass (node environment)
- [x] Confirm `ComponentTypeCollection`, `TemplateCollection`, `ExperienceCollection` are accessible from a consumer importing the SDK

Generated with [Claude Code](https://claude.com/claude-code)

[DX-933]: https://contentful.atlassian.net/browse/DX-933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ