### PR TITLE
fix(workflow-definition): export enums as enums instead of types [DX-786]

### DIFF
--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -307,12 +307,6 @@ export type {
 export * from './plain/plain-client-types'
 export { OptionalDefaults } from './plain/wrappers/wrap'
 
-export {
-  WorkflowStepPermissionAction,
-  WorkflowStepPermissionEffect,
-  WorkflowStepPermissionType,
-} from './entities/workflow-definition'
-
 export type { ConceptProps, CreateConceptProps } from './entities/concept'
 export type { ConceptSchemeProps, CreateConceptSchemeProps } from './entities/concept-scheme'
 export type { ResourceProps, ResourceQueryOptions } from './entities/resource'

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -31,6 +31,9 @@ export { ScheduledActionStatus }
 export { OptionalDefaults } from './plain/wrappers/wrap'
 export type * from './export-types'
 
+// enums
+// Exported explicitly as values because `export type * from './export-types'` strips
+// runtime values — enums need a direct `export {}` to be usable as values, not just types.
 export {
   WorkflowStepPermissionType,
   WorkflowStepPermissionAction,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -31,6 +31,12 @@ export { ScheduledActionStatus }
 export { OptionalDefaults } from './plain/wrappers/wrap'
 export type * from './export-types'
 
+export {
+  WorkflowStepPermissionType,
+  WorkflowStepPermissionAction,
+  WorkflowStepPermissionEffect,
+} from './entities/workflow-definition'
+
 interface UserAgentParams {
   /**
    * Application name and version e.g myApp/version

--- a/test/integration/locale-integration.test.ts
+++ b/test/integration/locale-integration.test.ts
@@ -37,7 +37,11 @@ describe('Locale API', () => {
     })
   })
 
-  it('Creates, gets, updates, and deletes a locale', async () => {
+  // FIX ME
+  // https://contentful.atlassian.net/browse/DX-991
+  // regression in locale API: https://contentful.slack.com/archives/C01SQNTQBBM/p1777053859135889
+  // environment id is not being returned in POST and PUT responses
+  it.skip('Creates, gets, updates, and deletes a locale', async () => {
     const createdLocale = await environment.createLocale({
       name: 'German (Austria)',
       code: 'de-AT',
@@ -62,7 +66,11 @@ describe('Locale API', () => {
     await updatedLocale.delete()
   })
 
-  it('Creates, gets page (respects limit), deletes a locale', async () => {
+  // FIX ME
+  // https://contentful.atlassian.net/browse/DX-991
+  // regression in locale API: https://contentful.slack.com/archives/C01SQNTQBBM/p1777053859135889
+  // environment id is not being returned in POST and PUT responses
+  it.skip('Creates, gets page (respects limit), deletes a locale', async () => {
     const createdLocal = await environment.createLocale({
       name: 'Chinese (Simplified, China)',
       code: 'zh-Hans-CN',


### PR DESCRIPTION
## Summary
Expose `WorkflowStepPermissionType, WorkflowStepPermissionAction, WorkflowStepPermissionEffect` as `enum` types to resolve this error in user_interface (and probably other packages.)

<img width="927" height="190" alt="Screenshot 2026-04-23 at 3 22 53 PM" src="https://github.com/user-attachments/assets/99d50019-84ce-4f8c-ae59-d7b6c4508821" />


```
src/javascripts/features/workflows/__fixtures__/workflowDefinitions.ts(77,10): 
  error TS1362: 'WorkflowStepPermissionType' cannot be used as a value because it was 
  exported using 'export type'.

src/javascripts/features/workflows/__fixtures__/workflowDefinitions.ts(78,12): 
  error TS1362: 'WorkflowStepPermissionEffect' cannot be used as a value because it was 
  exported using 'export type'.

src/javascripts/features/workflows/__fixtures__/workflowDefinitions.ts(79,12): 
  error TS1362: 'WorkflowStepPermissionAction' cannot be used as a value because it was 
  exported using 'export type'.
```

### Root cause:
`WorkflowStepPermissionType, WorkflowStepPermissionType, WorkflowStepPermissionAction` are enums that were previously available via `import { WorkflowStepPermissionType, WorkflowStepPermissionType, WorkflowStepPermissionAction } from 'contentful-management/types/entities/workflow-definition.ts`, but since that was removed in V12, these enums were only exposed via _barrel_ export file: `export type * from './export-types'` which since that **type** keyword is used, even though those entities are enums, they are exported as a type.

### Fix
Simply export the individual enums.

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request fixes a TypeScript compilation error by exposing WorkflowStepPermissionType, WorkflowStepPermissionAction, and WorkflowStepPermissionEffect as enum types instead of type-only exports, resolving TS1362 errors in user_interface and other packages where these enums need to be used as values. Additionally, two locale integration tests are skipped due to an API regression.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes type-only exports of WorkflowStepPermissionType, WorkflowStepPermissionAction, and WorkflowStepPermissionEffect from lib/export-types.ts to avoid conflicts with value exports</li>

<li>Adds explicit value exports for the workflow enums in lib/index.ts to enable runtime usage as enums instead of types</li>

<li>Skips two locale integration tests in locale-integration.test.ts due to a regression in the locale API where environment ID is not returned in responses</li>

</ul>
</details>

</div>