### PR TITLE
feat: scaffold Fragment entity types and GetFragmentParams [DX-926]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -2958,6 +2958,8 @@ export type GetExperienceParams = GetSpaceEnvironmentParams & { experienceId: st
 /** @internal */
 export type GetDataAssemblyParams = GetSpaceEnvironmentParams & { dataAssemblyId: string }
 /** @internal */
+export type GetFragmentParams = GetSpaceEnvironmentParams & { fragmentId: string }
+/** @internal */
 export type GetTemplateParams = GetSpaceEnvironmentParams & { templateId: string }
 /** @internal */
 export type GetContentTypeParams = GetSpaceEnvironmentParams & { contentTypeId: string }

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -10,7 +10,11 @@ import type {
   DimensionedDesignPropertyValue,
   FragmentNode,
 } from './component-type'
-import type { ExperienceContentBindings, ExperienceDimensionKeyMap, InlineFragmentNode } from './experience'
+import type {
+  ExperienceContentBindings,
+  ExperienceDimensionKeyMap,
+  InlineFragmentNode,
+} from './experience'
 
 export type FragmentSys = {
   id: string

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -9,9 +9,8 @@ import type {
   ComponentTypeViewport,
   DimensionedDesignPropertyValue,
   FragmentNode,
-  TreeNode,
 } from './component-type'
-import type { ExperienceContentBindings, InlineFragmentNode } from './experience'
+import type { ExperienceContentBindings, ExperienceDimensionKeyMap, InlineFragmentNode } from './experience'
 
 export type FragmentSys = {
   id: string
@@ -44,10 +43,10 @@ export type FragmentProps = {
   description: string
   viewports: ComponentTypeViewport[]
   designProperties: Record<string, DimensionedDesignPropertyValue>
-  dimensionKeyMap: { designProperties: Record<string, { breakpoint: string }> }
+  dimensionKeyMap: ExperienceDimensionKeyMap
   contentBindings?: ExperienceContentBindings
   metadata?: ExoMetadataProps
-  slots?: Record<string, Array<TreeNode | FragmentNode | InlineFragmentNode>>
+  slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>
 }
 
 export type CreateFragmentProps = Except<FragmentProps, 'sys'> & {

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -1,0 +1,71 @@
+import type { Except } from 'type-fest'
+import type {
+  CursorPaginatedCollectionProp,
+  CursorPaginationParams,
+  ExoMetadataProps,
+  Link,
+} from '../common-types'
+import type {
+  ComponentTypeViewport,
+  DimensionedDesignPropertyValue,
+  FragmentNode,
+  TreeNode,
+} from './component-type'
+import type { ExperienceContentBindings, InlineFragmentNode } from './experience'
+
+export type FragmentSys = {
+  id: string
+  type: 'Fragment'
+  version: number
+  space: Link<'Space'>
+  environment: Link<'Environment'>
+  componentType: Link<'ComponentType'>
+  archivedAt?: string
+  archivedBy?: Link<'User'>
+  archivedVersion?: number
+  createdAt: string
+  updatedAt: string
+  createdBy: Link<'User'>
+  updatedBy: Link<'User'>
+  variant?: string
+  variantType?: string
+  variantDimension?: string
+  publishedAt?: string
+  publishedVersion?: number
+  publishedCounter?: number
+  firstPublishedAt?: string
+  publishedBy?: Link<'User'> | Link<'AppDefinition'>
+  localeStatus?: Record<string, 'draft' | 'published' | 'changed'>
+}
+
+export type FragmentProps = {
+  sys: FragmentSys
+  name: string
+  description: string
+  viewports: ComponentTypeViewport[]
+  designProperties: Record<string, DimensionedDesignPropertyValue>
+  dimensionKeyMap: { designProperties: Record<string, { breakpoint: string }> }
+  contentBindings?: ExperienceContentBindings
+  metadata?: ExoMetadataProps
+  slots?: Record<string, Array<TreeNode | FragmentNode | InlineFragmentNode>>
+}
+
+export type CreateFragmentProps = Except<FragmentProps, 'sys'> & {
+  componentTypeId: string
+}
+
+export type UpdateFragmentProps = Omit<FragmentProps, 'sys'> & {
+  sys: {
+    id: string
+    type: 'Fragment'
+    version: number
+  }
+  componentTypeId: string
+}
+
+export type FragmentQueryOptions = CursorPaginationParams & {
+  order?: string
+  [key: string]: unknown
+}
+
+export type FragmentCollection = CursorPaginatedCollectionProp<FragmentProps>


### PR DESCRIPTION
## Summary
- Scaffold the `Fragment` entity type layer in `lib/entities/fragment.ts` with `FragmentSys`, `FragmentProps`, `CreateFragmentProps`, `UpdateFragmentProps`, `FragmentQueryOptions`, and `FragmentCollection`
- Add `GetFragmentParams` to `lib/common-types.ts`
- Types aligned with upstream contract (`experiences-api-schemas/src/lib/fragment.ts`)

## Test plan
- [x] `tsc --noEmit` passes on `feat/exo`
- [ ] No REST adapter, plain client, or MRActions — those are in follow-up PRs (DX-927+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)