### PR TITLE
feat: add Fragment getMany and get methods [DX-927]

### DIFF
--- a/lib/adapters/REST/endpoints/fragment.ts
+++ b/lib/adapters/REST/endpoints/fragment.ts
@@ -1,0 +1,32 @@
+import type { RawAxiosRequestHeaders } from 'axios'
+import type { AxiosInstance } from 'contentful-sdk-core'
+import type {
+  CursorPaginatedCollectionProp,
+  GetFragmentParams,
+  GetSpaceEnvironmentParams,
+} from '../../../common-types'
+import type { FragmentProps, FragmentQueryOptions } from '../../../entities/fragment'
+import type { RestEndpoint } from '../types'
+import * as raw from './raw'
+
+const getBaseUrl = (params: GetSpaceEnvironmentParams) =>
+  `/spaces/${params.spaceId}/environments/${params.environmentId}/fragments`
+
+export const getMany: RestEndpoint<'Fragment', 'getMany'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams & { query: FragmentQueryOptions },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.get<CursorPaginatedCollectionProp<FragmentProps>>(http, getBaseUrl(params), {
+    params: params.query,
+    headers,
+  })
+}
+
+export const get: RestEndpoint<'Fragment', 'get'> = (
+  http: AxiosInstance,
+  params: GetFragmentParams,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.get<FragmentProps>(http, getBaseUrl(params) + `/${params.fragmentId}`, { headers })
+}

--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -34,6 +34,7 @@ import * as EnvironmentAlias from './environment-alias'
 import * as EnvironmentTemplate from './environment-template'
 import * as EnvironmentTemplateInstallation from './environment-template-installation'
 import * as Extension from './extension'
+import * as Fragment from './fragment'
 import * as Function from './function'
 import * as FunctionLog from './function-log'
 import * as Http from './http'
@@ -118,6 +119,7 @@ export default {
   EnvironmentTemplate,
   EnvironmentTemplateInstallation,
   Extension,
+  Fragment,
   Function,
   FunctionLog,
   Http,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -968,6 +968,8 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Fragment', 'create', UA>): MRReturn<'Fragment', 'create'>
   (opts: MROpts<'Fragment', 'update', UA>): MRReturn<'Fragment', 'update'>
   (opts: MROpts<'Fragment', 'delete', UA>): MRReturn<'Fragment', 'delete'>
+  (opts: MROpts<'Fragment', 'publish', UA>): MRReturn<'Fragment', 'publish'>
+  (opts: MROpts<'Fragment', 'unpublish', UA>): MRReturn<'Fragment', 'unpublish'>
 
   (opts: MROpts<'Template', 'getMany', UA>): MRReturn<'Template', 'getMany'>
   (opts: MROpts<'Template', 'get', UA>): MRReturn<'Template', 'get'>

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -67,6 +67,12 @@ import type {
   UpdateComponentTypeProps,
 } from './entities/component-type'
 import type {
+  CreateFragmentProps,
+  FragmentProps,
+  FragmentQueryOptions,
+  UpdateFragmentProps,
+} from './entities/fragment'
+import type {
   CreateTemplateProps,
   TemplateProps,
   TemplateQueryOptions,
@@ -956,6 +962,12 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'TeamSpaceMembership', 'create', UA>): MRReturn<'TeamSpaceMembership', 'create'>
   (opts: MROpts<'TeamSpaceMembership', 'update', UA>): MRReturn<'TeamSpaceMembership', 'update'>
   (opts: MROpts<'TeamSpaceMembership', 'delete', UA>): MRReturn<'TeamSpaceMembership', 'delete'>
+
+  (opts: MROpts<'Fragment', 'getMany', UA>): MRReturn<'Fragment', 'getMany'>
+  (opts: MROpts<'Fragment', 'get', UA>): MRReturn<'Fragment', 'get'>
+  (opts: MROpts<'Fragment', 'create', UA>): MRReturn<'Fragment', 'create'>
+  (opts: MROpts<'Fragment', 'update', UA>): MRReturn<'Fragment', 'update'>
+  (opts: MROpts<'Fragment', 'delete', UA>): MRReturn<'Fragment', 'delete'>
 
   (opts: MROpts<'Template', 'getMany', UA>): MRReturn<'Template', 'getMany'>
   (opts: MROpts<'Template', 'get', UA>): MRReturn<'Template', 'get'>
@@ -2642,6 +2654,38 @@ export type MRActions = {
       return: TeamSpaceMembershipProps
     }
     delete: { params: GetTeamSpaceMembershipParams; return: any }
+  }
+  Fragment: {
+    getMany: {
+      params: GetSpaceEnvironmentParams & { query: FragmentQueryOptions }
+      return: CursorPaginatedCollectionProp<FragmentProps>
+    }
+    get: {
+      params: GetFragmentParams
+      return: FragmentProps
+    }
+    create: {
+      params: GetSpaceEnvironmentParams
+      payload: CreateFragmentProps
+      return: FragmentProps
+    }
+    update: {
+      params: GetFragmentParams
+      payload: UpdateFragmentProps
+      return: FragmentProps
+    }
+    delete: {
+      params: GetFragmentParams
+      return: void
+    }
+    publish: {
+      params: GetFragmentParams & { version: number }
+      return: FragmentProps
+    }
+    unpublish: {
+      params: GetFragmentParams & { version: number }
+      return: FragmentProps
+    }
   }
   Template: {
     getMany: {

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -9,6 +9,7 @@ import type {
   ComponentTypeViewport,
   DimensionedDesignPropertyValue,
   FragmentNode,
+  TreeNode,
 } from './component-type'
 import type {
   ExperienceContentBindings,
@@ -50,7 +51,7 @@ export type FragmentProps = {
   dimensionKeyMap: ExperienceDimensionKeyMap
   contentBindings?: ExperienceContentBindings
   metadata?: ExoMetadataProps
-  slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>
+  slots?: Record<string, Array<TreeNode | FragmentNode | InlineFragmentNode>>
 }
 
 export type CreateFragmentProps = Except<FragmentProps, 'sys'> & {

--- a/lib/plain/entities/fragment.ts
+++ b/lib/plain/entities/fragment.ts
@@ -1,0 +1,154 @@
+import type {
+  CursorPaginatedCollectionProp,
+  GetFragmentParams,
+  GetSpaceEnvironmentParams,
+} from '../../common-types'
+import type {
+  CreateFragmentProps,
+  FragmentProps,
+  FragmentQueryOptions,
+  UpdateFragmentProps,
+} from '../../entities/fragment'
+import type { OptionalDefaults } from '../wrappers/wrap'
+
+export type FragmentPlainClientAPI = {
+  /**
+   * Fetches all fragments for a space and environment
+   * @param params the space, environment IDs and query options (see {@link FragmentQueryOptions})
+   * @returns a collection of fragments
+   * @throws if the request fails, or the space or environment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const fragments = await client.fragment.getMany({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   query: {
+   *     limit: 10,
+   *   },
+   * });
+   * ```
+   */
+  getMany(
+    params: OptionalDefaults<GetSpaceEnvironmentParams & { query: FragmentQueryOptions }>,
+  ): Promise<CursorPaginatedCollectionProp<FragmentProps>>
+
+  /**
+   * Fetches a single fragment by ID
+   * @param params the space, environment, and fragment IDs
+   * @returns the fragment
+   * @throws if the request fails, or the space, environment, or fragment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const fragment = await client.fragment.get({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   fragmentId: '<fragment_id>',
+   * });
+   * ```
+   */
+  get(params: OptionalDefaults<GetFragmentParams>): Promise<FragmentProps>
+
+  /**
+   * Creates a new fragment
+   * @param params the space and environment IDs
+   * @param data the fragment data
+   * @returns the created fragment
+   * @throws if the request fails, or the space or environment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const fragment = await client.fragment.create({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   * }, {
+   *   name: 'My Fragment',
+   *   description: 'A new fragment',
+   *   componentTypeId: '<component_type_id>',
+   *   viewports: [],
+   *   designProperties: {},
+   *   dimensionKeyMap: { designProperties: {} },
+   * });
+   * ```
+   */
+  create(
+    params: OptionalDefaults<GetSpaceEnvironmentParams>,
+    data: CreateFragmentProps,
+  ): Promise<FragmentProps>
+
+  /**
+   * Updates a fragment
+   * @param params the space, environment, and fragment IDs
+   * @param data the fragment data (including sys.version)
+   * @returns the updated fragment
+   * @throws if the request fails, or the space, environment, or fragment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const fragment = await client.fragment.update({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   fragmentId: '<fragment_id>',
+   * }, fragmentData);
+   * ```
+   */
+  update(
+    params: OptionalDefaults<GetFragmentParams>,
+    data: UpdateFragmentProps,
+  ): Promise<FragmentProps>
+
+  /**
+   * Deletes a fragment
+   * @param params the space, environment, and fragment IDs
+   * @throws if the request fails, or the space, environment, or fragment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * await client.fragment.delete({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   fragmentId: '<fragment_id>',
+   * });
+   * ```
+   */
+  delete(params: OptionalDefaults<GetFragmentParams>): Promise<void>
+
+  /**
+   * Publishes a fragment
+   * @param params the space, environment, and fragment IDs, plus the current version
+   * @returns the published fragment
+   * @throws if the request fails, or the space, environment, or fragment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const fragment = await client.fragment.publish({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   fragmentId: '<fragment_id>',
+   *   version: 1,
+   * });
+   * ```
+   */
+  publish(params: OptionalDefaults<GetFragmentParams & { version: number }>): Promise<FragmentProps>
+
+  /**
+   * Unpublishes a fragment
+   * @param params the space, environment, and fragment IDs, plus the current version
+   * @returns the unpublished fragment
+   * @throws if the request fails, or the space, environment, or fragment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const fragment = await client.fragment.unpublish({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   fragmentId: '<fragment_id>',
+   *   version: 2,
+   * });
+   * ```
+   */
+  unpublish(
+    params: OptionalDefaults<GetFragmentParams & { version: number }>,
+  ): Promise<FragmentProps>
+}

--- a/lib/plain/plain-client-types.ts
+++ b/lib/plain/plain-client-types.ts
@@ -125,6 +125,7 @@ import type { TaskPlainClientAPI } from './entities/task'
 import type { TeamPlainClientAPI } from './entities/team'
 import type { TeamMembershipPlainClientAPI } from './entities/team-membership'
 import type { TeamSpaceMembershipPlainClientAPI } from './entities/team-space-membership'
+import type { FragmentPlainClientAPI } from './entities/fragment'
 import type { TemplatePlainClientAPI } from './entities/template'
 import type { UIConfigPlainClientAPI } from './entities/ui-config'
 import type { UploadPlainClientAPI } from './entities/upload'
@@ -730,6 +731,7 @@ export type PlainClientAPI = {
   team: TeamPlainClientAPI
   teamMembership: TeamMembershipPlainClientAPI
   teamSpaceMembership: TeamSpaceMembershipPlainClientAPI
+  fragment: FragmentPlainClientAPI
   template: TemplatePlainClientAPI
   uiConfig: UIConfigPlainClientAPI
   userUIConfig: UserUIConfigPlainClientAPI

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -627,6 +627,15 @@ export const createPlainClient = (
       update: wrap(wrapParams, 'TeamSpaceMembership', 'update'),
       delete: wrap(wrapParams, 'TeamSpaceMembership', 'delete'),
     },
+    fragment: {
+      getMany: wrap(wrapParams, 'Fragment', 'getMany'),
+      get: wrap(wrapParams, 'Fragment', 'get'),
+      create: wrap(wrapParams, 'Fragment', 'create'),
+      update: wrap(wrapParams, 'Fragment', 'update'),
+      delete: wrap(wrapParams, 'Fragment', 'delete'),
+      publish: wrap(wrapParams, 'Fragment', 'publish'),
+      unpublish: wrap(wrapParams, 'Fragment', 'unpublish'),
+    },
     template: {
       getMany: wrap(wrapParams, 'Template', 'getMany'),
       get: wrap(wrapParams, 'Template', 'get'),

--- a/test/unit/adapters/REST/endpoints/fragment.test.ts
+++ b/test/unit/adapters/REST/endpoints/fragment.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect } from 'vitest'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+
+describe('Rest Fragment', { concurrent: true }, () => {
+  test('getMany calls correct URL', async () => {
+    const mockResponse = {
+      sys: { type: 'Array' },
+      limit: 100,
+      items: [],
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Fragment',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          query: {},
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/fragments',
+        )
+        expect(httpMock.get.mock.calls[0][1].params).to.eql({})
+      })
+  })
+
+  test('getMany passes pagination query parameters', async () => {
+    const mockResponse = {
+      sys: { type: 'Array' },
+      limit: 20,
+      items: [],
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Fragment',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          query: {
+            limit: 20,
+            pageNext: 'next-page-token',
+          },
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/fragments',
+        )
+        expect(httpMock.get.mock.calls[0][1].params).to.eql({
+          limit: 20,
+          pageNext: 'next-page-token',
+        })
+      })
+  })
+
+  test('getMany passes filter query parameters', async () => {
+    const mockResponse = {
+      sys: { type: 'Array' },
+      limit: 100,
+      items: [],
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Fragment',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          query: {
+            order: 'sys.createdAt',
+          },
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/fragments',
+        )
+        expect(httpMock.get.mock.calls[0][1].params).to.eql({
+          order: 'sys.createdAt',
+        })
+      })
+  })
+
+  test('get calls correct URL', async () => {
+    const mockResponse = {
+      sys: { id: 'fragment123', type: 'Fragment' },
+      name: 'Test Fragment',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Fragment',
+        action: 'get',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          fragmentId: 'fragment123',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/fragments/fragment123',
+        )
+      })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `getMany` and `get` REST adapter endpoints for Fragment (`GET /fragments`, `GET /fragments/:id`)
- Create `FragmentPlainClientAPI` interface with all method signatures (getMany, get, create, update, delete, publish, unpublish)
- Wire `Fragment` MRActions block, MakeRequest overloads, and plain client registration
- Unit tests for getMany (empty query, pagination, order filter) and get

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npx vitest --project unit --run test/unit/adapters/REST/endpoints/fragment.test.ts` — 4 tests pass
- [ ] create/update/delete/publish/unpublish REST implementations follow in DX-928 and DX-929

> **Stacked PR** — targets `feat/exo-fragment-types` (DX-926). Will auto-retarget to `feat/exo` when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)