### PR TITLE
feat: add Fragment create, update, and delete methods [DX-928]

### DIFF
--- a/lib/adapters/REST/endpoints/fragment.ts
+++ b/lib/adapters/REST/endpoints/fragment.ts
@@ -1,11 +1,18 @@
 import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
+import copy from 'fast-copy'
+import type { SetOptional } from 'type-fest'
 import type {
   CursorPaginatedCollectionProp,
   GetFragmentParams,
   GetSpaceEnvironmentParams,
 } from '../../../common-types'
-import type { FragmentProps, FragmentQueryOptions } from '../../../entities/fragment'
+import type {
+  CreateFragmentProps,
+  FragmentProps,
+  FragmentQueryOptions,
+  UpdateFragmentProps,
+} from '../../../entities/fragment'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
 
@@ -29,4 +36,39 @@ export const get: RestEndpoint<'Fragment', 'get'> = (
   headers?: RawAxiosRequestHeaders,
 ) => {
   return raw.get<FragmentProps>(http, getBaseUrl(params) + `/${params.fragmentId}`, { headers })
+}
+
+export const create: RestEndpoint<'Fragment', 'create'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams,
+  rawData: CreateFragmentProps,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  const data = copy(rawData)
+  return raw.post<FragmentProps>(http, getBaseUrl(params), data, { headers })
+}
+
+export const update: RestEndpoint<'Fragment', 'update'> = (
+  http: AxiosInstance,
+  params: GetFragmentParams,
+  rawData: UpdateFragmentProps,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
+  delete data.sys
+  return raw.put<FragmentProps>(http, getBaseUrl(params) + `/${params.fragmentId}`, data, {
+    headers: {
+      ...(rawData.sys?.version !== undefined && {
+        'X-Contentful-Version': rawData.sys.version,
+      }),
+      ...headers,
+    },
+  })
+}
+
+export const del: RestEndpoint<'Fragment', 'delete'> = (
+  http: AxiosInstance,
+  params: GetFragmentParams,
+) => {
+  return raw.del(http, getBaseUrl(params) + `/${params.fragmentId}`)
 }

--- a/test/unit/adapters/REST/endpoints/fragment.test.ts
+++ b/test/unit/adapters/REST/endpoints/fragment.test.ts
@@ -125,4 +125,84 @@ describe('Rest Fragment', { concurrent: true }, () => {
         )
       })
   })
+
+  test('create calls correct URL with POST', async () => {
+    const mockResponse = {
+      sys: { id: 'fragment123', type: 'Fragment' },
+      name: 'New Fragment',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Fragment',
+        action: 'create',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+        },
+        payload: { name: 'New Fragment' },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.post.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/fragments',
+        )
+      })
+  })
+
+  test('update calls correct URL with PUT and X-Contentful-Version header', async () => {
+    const mockResponse = {
+      sys: { id: 'fragment123', type: 'Fragment', version: 2 },
+      name: 'Updated Fragment',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Fragment',
+        action: 'update',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          fragmentId: 'fragment123',
+        },
+        payload: {
+          sys: { id: 'fragment123', type: 'Fragment', version: 1 },
+          name: 'Updated Fragment',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/fragments/fragment123',
+        )
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
+      })
+  })
+
+  test('delete calls correct URL', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: '' }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Fragment',
+        action: 'delete',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          fragmentId: 'fragment123',
+        },
+      })
+      .then(() => {
+        expect(httpMock.delete.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/fragments/fragment123',
+        )
+      })
+  })
 })


### PR DESCRIPTION
## Summary
- Add `create` (POST), `update` (PUT with `X-Contentful-Version`), and `del` (DELETE) to Fragment REST adapter
- Unit tests for all three methods, including version header verification on update

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npx vitest --project unit --run test/unit/adapters/REST/endpoints/fragment.test.ts` — 7 tests pass

> **Stacked PR** — targets `feat/exo-fragment-get` (DX-927). Will auto-retarget when parent merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)