### PR TITLE
feat: add Fragment publish and unpublish methods [DX-929]

### DIFF
--- a/lib/adapters/REST/endpoints/fragment.ts
+++ b/lib/adapters/REST/endpoints/fragment.ts
@@ -72,3 +72,34 @@ export const del: RestEndpoint<'Fragment', 'delete'> = (
 ) => {
   return raw.del(http, getBaseUrl(params) + `/${params.fragmentId}`)
 }
+
+export const publish: RestEndpoint<'Fragment', 'publish'> = (
+  http: AxiosInstance,
+  params: GetFragmentParams & { version: number },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.put<FragmentProps>(
+    http,
+    getBaseUrl(params) + `/${params.fragmentId}/published`,
+    null,
+    {
+      headers: {
+        'X-Contentful-Version': params.version,
+        ...headers,
+      },
+    },
+  )
+}
+
+export const unpublish: RestEndpoint<'Fragment', 'unpublish'> = (
+  http: AxiosInstance,
+  params: GetFragmentParams & { version: number },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.del<FragmentProps>(http, getBaseUrl(params) + `/${params.fragmentId}/published`, {
+    headers: {
+      'X-Contentful-Version': params.version,
+      ...headers,
+    },
+  })
+}

--- a/test/unit/adapters/REST/endpoints/fragment.test.ts
+++ b/test/unit/adapters/REST/endpoints/fragment.test.ts
@@ -205,4 +205,62 @@ describe('Rest Fragment', { concurrent: true }, () => {
         )
       })
   })
+
+  test('publish calls correct URL with PUT and X-Contentful-Version header', async () => {
+    const mockResponse = {
+      sys: { id: 'fragment123', type: 'Fragment', version: 2, publishedVersion: 1 },
+      name: 'Test Fragment',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Fragment',
+        action: 'publish',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          fragmentId: 'fragment123',
+          version: 1,
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/fragments/fragment123/published',
+        )
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
+      })
+  })
+
+  test('unpublish calls correct URL with DELETE and X-Contentful-Version header', async () => {
+    const mockResponse = {
+      sys: { id: 'fragment123', type: 'Fragment', version: 3 },
+      name: 'Test Fragment',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Fragment',
+        action: 'unpublish',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          fragmentId: 'fragment123',
+          version: 2,
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.delete.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/fragments/fragment123/published',
+        )
+        expect(httpMock.delete.mock.calls[0][1].headers['X-Contentful-Version']).to.eql(2)
+      })
+  })
 })


### PR DESCRIPTION
## Summary
- Add `publish` (PUT `/fragments/:id/published`) and `unpublish` (DELETE `/fragments/:id/published`) to Fragment REST adapter
- Both send `X-Contentful-Version` header for optimistic locking
- Unit tests for both methods, verifying URL and version header

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npx vitest --project unit --run test/unit/adapters/REST/endpoints/fragment.test.ts` — 9 tests pass (full Fragment suite)

> **Stacked PR** — targets `feat/exo-fragment-crud` (DX-928). Will auto-retarget when parent merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)