### PR TITLE
fix: make ExperienceSys.componentType optional for template-backed experiences [DX-980]

### DIFF
--- a/lib/adapters/REST/endpoints/experience.ts
+++ b/lib/adapters/REST/endpoints/experience.ts
@@ -58,7 +58,9 @@ export const update: RestEndpoint<'Experience', 'update'> = (
   headers?: RawAxiosRequestHeaders,
 ) => {
   const data: SetOptional<typeof rawData, 'sys'> & { componentTypeId?: string } = copy(rawData)
-  data.componentTypeId = rawData.sys.componentType.sys.id
+  if (rawData.sys.componentType) {
+    data.componentTypeId = rawData.sys.componentType.sys.id
+  }
   delete data.sys
   return raw.put<ExperienceProps>(http, getBaseUrl(params) + `/${params.experienceId}`, data, {
     headers: {

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -29,7 +29,7 @@ export type ExperienceSys = {
   version: number
   space: Link<'Space'>
   environment: Link<'Environment'>
-  componentType: Link<'ComponentType'>
+  componentType?: Link<'ComponentType'>
   template?: Link<'Template'>
   createdAt: string
   updatedAt: string


### PR DESCRIPTION
[DX-980](https://contentful.atlassian.net/browse/DX-980)

## Summary
- `ExperienceSys.componentType` was typed as required (`Link<'ComponentType'>`), but the upstream schema (`ManagementExperienceSys`) marks it optional via `z.optional(LinkSchema('ComponentType'))`
- Template-backed experiences use `sys.template` instead of `sys.componentType` — the SDK was incorrectly rejecting valid API responses where `componentType` is absent
- Fix: changed field to `componentType?: Link<'ComponentType'>` in `lib/entities/experience.ts`

## Test plan
- [ ] `tsc --noEmit` passes on `feat/exo`
- [ ] Create a template-backed experience and confirm `componentType` being absent in the response is handled correctly
- [ ] No existing tests broken by narrowing this field to optional

Generated with [Claude Code](https://claude.com/claude-code)

[DX-980]: https://contentful.atlassian.net/browse/DX-980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ