### PR TITLE
feat: update AI action invocation variable types to sys-nested format [BBEE-2227]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         run: ls -la dist/
 
       - name: Save Build folders
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             dist            

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -24,7 +24,7 @@ jobs:
         run: npm ci
 
       - name: Restore the build folders
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             dist 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
         run: npm ci
 
       - name: Restore the build folders
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             dist

--- a/.github/workflows/test-demo-projects.yaml
+++ b/.github/workflows/test-demo-projects.yaml
@@ -29,7 +29,7 @@ jobs:
         run: npm ci
 
       - name: Restore the build folders
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             dist 

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -29,7 +29,7 @@ jobs:
         run: npm ci
 
       - name: Restore the build folders
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             dist 

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -193,6 +193,7 @@ import type { AiActionProps, AiActionQueryOptions, CreateAiActionProps } from '.
 import type {
   AiActionInvocationProps,
   AiActionInvocationType,
+  AiActionInvocationVariable,
 } from './entities/ai-action-invocation'
 import type { AgentGeneratePayload, AgentProps } from './entities/agent'
 import type {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -193,7 +193,6 @@ import type { AiActionProps, AiActionQueryOptions, CreateAiActionProps } from '.
 import type {
   AiActionInvocationProps,
   AiActionInvocationType,
-  AiActionInvocationVariable,
 } from './entities/ai-action-invocation'
 import type { AgentGeneratePayload, AgentProps } from './entities/agent'
 import type {

--- a/lib/entities/ai-action-invocation.ts
+++ b/lib/entities/ai-action-invocation.ts
@@ -49,30 +49,53 @@ export type AiActionInvocationProps = {
   result?: InvocationResult
 }
 
+export type AiActionTextVariable = {
+  id: string
+  value: string
+}
+
+export type AiActionEntityLinkVariable = {
+  id: string
+  value: {
+    sys: {
+      type: 'Link'
+      linkType: 'Entry' | 'Asset' | 'ResourceLink'
+      id: string
+      release?: SysLink
+      entityPaths?: Array<string>
+    }
+  }
+}
+
+/** @deprecated Use `AiActionEntityLinkVariable` with the sys-nested format instead. */
+export type AiActionLegacyEntityPathVariable = {
+  id: string
+  value: {
+    entityPath: string
+    entityType: 'Entry' | 'Asset' | 'ResourceLink'
+    entityId: string
+  }
+}
+
+/** @deprecated Use `AiActionEntityLinkVariable` with the sys-nested format instead. */
+export type AiActionLegacyEntityPathsVariable = {
+  id: string
+  value: {
+    entityPaths: Array<string>
+    entityType: 'Entry'
+    entityId: string
+  }
+}
+
+export type AiActionInvocationVariable =
+  | AiActionTextVariable
+  | AiActionEntityLinkVariable
+  | AiActionLegacyEntityPathVariable
+  | AiActionLegacyEntityPathsVariable
+
 export type AiActionInvocationType = {
   outputFormat?: 'RichText' | 'Markdown' | 'PlainText'
-  variables?: Array<
-    | {
-        value: string
-        id: string
-      }
-    | {
-        value: {
-          entityPath: string
-          entityType: 'Entry' | 'Asset' | 'ResourceLink'
-          entityId: string
-        }
-        id: string
-      }
-    | {
-        value: {
-          entityPaths: Array<string>
-          entityType: 'Entry'
-          entityId: string
-        }
-        id: string
-      }
-  >
+  variables?: Array<AiActionInvocationVariable>
 }
 
 /**

--- a/lib/entities/ai-action-invocation.ts
+++ b/lib/entities/ai-action-invocation.ts
@@ -62,6 +62,7 @@ export type AiActionEntityLinkVariable = {
       linkType: 'Entry' | 'Asset' | 'ResourceLink'
       id: string
       release?: SysLink
+      /** JSON Pointers to entity fields, e.g. `"/fields/title/en-US"` */
       entityPaths?: Array<string>
     }
   }

--- a/lib/entities/ai-action.ts
+++ b/lib/entities/ai-action.ts
@@ -22,12 +22,17 @@ export type ReferenceVariableConfiguration = {
   allowedEntities: Array<'Entry'>
 }
 
+export type LocaleVariableConfiguration = {
+  localeType: 'Target' | 'Source'
+}
+
 export type VariableConfiguration =
   | {
       strict: boolean
       in: Array<string>
     }
   | ReferenceVariableConfiguration
+  | LocaleVariableConfiguration
 
 export type Variable = {
   configuration?: VariableConfiguration

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -13,7 +13,11 @@ export type {
   CreateAppAccessTokenProps,
 } from './entities/app-access-token'
 export type { AiAction, AiActionProps, CreateAiActionProps } from './entities/ai-action'
-export type { AiActionInvocation, AiActionInvocationProps } from './entities/ai-action-invocation'
+export type {
+  AiActionInvocation,
+  AiActionInvocationProps,
+  AiActionInvocationVariable,
+} from './entities/ai-action-invocation'
 export type { Agent, AgentGeneratePayload, AgentProps, AgentToolLink } from './entities/agent'
 export type {
   AgentGenerateResponse,


### PR DESCRIPTION
## Summary
- Updates `AiActionInvocationType` variable types to use the standard `sys`-nested link structure (`type`, `linkType`, `id`, optional `release`, optional `entityPaths`) instead of the old flat `entityId`/`entityType`/`entityPath(s)` format
- Extracts `AiActionInvocationVariable` as a reusable exported type
- Re-exports the new type from `common-types.ts` and `export-types.ts`

## Test plan
- [ ] Type check passes (`npx tsc --noEmit`)
- [ ] Verify consumers using the old flat format are updated to the new `sys`-nested format

Closes [BBEE-2227](https://contentful.atlassian.net/browse/BBEE-2227)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BBEE-2227]: https://contentful.atlassian.net/browse/BBEE-2227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR modernizes AI Action Invocation variable types by transitioning from legacy flat format (entityId/entityType/entityPath) to the standard sys-nested link structure, extracts AiActionInvocationVariable as a reusable exported type, adds LocaleVariableConfiguration support for locale variables, and upgrades GitHub Actions cache versions for Node.js 24 compatibility.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces `AiActionEntityLinkVariable` with sys-nested format in ai-action-invocation.ts, replacing flat entity properties with `value.sys` containing `type`, `linkType`, `id`, optional `release`, and optional `entityPaths` for JSON Pointers to entity fields</li>

<li>Extracts `AiActionInvocationVariable` as a reusable union type and updates `AiActionInvocationType.variables` to use it, simplifying type definitions while maintaining backward compatibility through deprecated legacy types</li>

<li>Adds `LocaleVariableConfiguration` type in ai-action.ts with 'Target' | 'Source' localeType support, extending the `VariableConfiguration` union to handle output and input locale distinction</li>

<li>Re-exports `AiActionInvocationVariable` from export-types.ts for SDK-wide usage and adds the type to common-types.ts imports</li>

<li>Upgrades actions/cache from v4 to v5 in all five GitHub workflow files to fix Node.js 24 runner compatibility</li>

</ul>
</details>

</div>