### PR TITLE
feat: add missing archive fields to ExperienceSys [DX-981]

### DIFF
--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -35,6 +35,9 @@ export type ExperienceSys = {
   updatedAt: string
   createdBy: Link<'User'>
   updatedBy: Link<'User'>
+  archivedAt?: string
+  archivedBy?: Link<'User'>
+  archivedVersion?: number
   variant?: string
   variantType?: string
   variantDimension?: string


### PR DESCRIPTION
[DX-981](https://contentful.atlassian.net/browse/DX-981)

## Summary
- Adds three optional fields (`archivedAt`, `archivedBy`, `archivedVersion`) to `ExperienceSys` to match the upstream `ExperienceSysCommon` type in `experiences-api-schemas`
- Without these fields, SDK consumers silently lose archive state from API responses

## Test plan
- [ ] `tsc --noEmit` passes on `feat/exo`
- [ ] No existing test fixtures broken (all fields are optional, no constructions change)

Generated with [Claude Code](https://claude.com/claude-code)

[DX-981]: https://contentful.atlassian.net/browse/DX-981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ