### PR TITLE
feat: support templateId in CreateExperienceProps for template-backed experiences [DX-982]

### DIFF
--- a/lib/adapters/REST/endpoints/experience.ts
+++ b/lib/adapters/REST/endpoints/experience.ts
@@ -57,9 +57,14 @@ export const update: RestEndpoint<'Experience', 'update'> = (
   rawData: UpdateExperienceProps,
   headers?: RawAxiosRequestHeaders,
 ) => {
-  const data: SetOptional<typeof rawData, 'sys'> & { componentTypeId?: string } = copy(rawData)
+  const data: SetOptional<typeof rawData, 'sys'> & {
+    componentTypeId?: string
+    templateId?: string
+  } = copy(rawData)
   if (rawData.sys.componentType) {
     data.componentTypeId = rawData.sys.componentType.sys.id
+  } else if (rawData.sys.template) {
+    data.templateId = rawData.sys.template.sys.id
   }
   delete data.sys
   return raw.put<ExperienceProps>(http, getBaseUrl(params) + `/${params.experienceId}`, data, {

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -72,10 +72,10 @@ export type ExperienceQueryOptions = CursorPaginationParams & {
 // Omit the payload entirely for a full publish (all locales).
 export type ExperienceLocalePublishPayload = { add: string[] } | { remove: string[] }
 
-// Create payload — no sys, uses componentTypeId instead of sys.componentType link
-export type CreateExperienceProps = ExperienceCommonProps & {
-  componentTypeId: string
-}
+// Create payload — no sys, uses either componentTypeId (component-type-backed) or
+// templateId (template-backed). The two fields are mutually exclusive.
+export type CreateExperienceProps = ExperienceCommonProps &
+  ({ componentTypeId: string; templateId?: never } | { templateId: string; componentTypeId?: never })
 
 export type UpdateExperienceProps = ExperienceProps
 

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -75,7 +75,10 @@ export type ExperienceLocalePublishPayload = { add: string[] } | { remove: strin
 // Create payload — no sys, uses either componentTypeId (component-type-backed) or
 // templateId (template-backed). The two fields are mutually exclusive.
 export type CreateExperienceProps = ExperienceCommonProps &
-  ({ componentTypeId: string; templateId?: never } | { templateId: string; componentTypeId?: never })
+  (
+    | { componentTypeId: string; templateId?: never }
+    | { templateId: string; componentTypeId?: never }
+  )
 
 export type UpdateExperienceProps = ExperienceProps
 

--- a/lib/plain/entities/experience.ts
+++ b/lib/plain/entities/experience.ts
@@ -60,6 +60,7 @@ export type ExperiencePlainClientAPI = {
    * @internal - Experimental endpoint, subject to breaking changes without notice
    * @example
    * ```javascript
+   * // Component-type-backed experience
    * const experience = await client.experience.create({
    *   spaceId: '<space_id>',
    *   environmentId: '<environment_id>',
@@ -67,6 +68,20 @@ export type ExperiencePlainClientAPI = {
    *   name: 'My Experience',
    *   description: 'A new experience',
    *   componentTypeId: '<component_type_id>',
+   *   viewports: [],
+   *   contentProperties: {},
+   *   designProperties: {},
+   *   dimensionKeyMap: { designProperties: {} },
+   * });
+   *
+   * // Template-backed experience
+   * const experience = await client.experience.create({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   * }, {
+   *   name: 'My Template Experience',
+   *   description: 'A template-backed experience',
+   *   templateId: '<template_id>',
    *   viewports: [],
    *   contentProperties: {},
    *   designProperties: {},

--- a/test/unit/adapters/REST/endpoints/experience.test.ts
+++ b/test/unit/adapters/REST/endpoints/experience.test.ts
@@ -301,6 +301,57 @@ describe('Rest Experience', { concurrent: true }, () => {
       })
   })
 
+  test('update sends templateId when experience is template-backed', async () => {
+    const mockResponse = {
+      sys: { id: 'experience123', type: 'Experience', version: 2 },
+      name: 'Updated Experience',
+      description: 'A template-backed experience',
+      viewports: [],
+      contentProperties: {},
+      designProperties: {},
+      dimensionKeyMap: { designProperties: {} },
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Experience',
+        action: 'update',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          experienceId: 'experience123',
+        },
+        payload: {
+          sys: {
+            version: 1,
+            template: {
+              sys: { type: 'Link', linkType: 'Template', id: 'tmpl-456' },
+            },
+          },
+          name: 'Updated Experience',
+          description: 'A template-backed experience',
+          viewports: [],
+          contentProperties: {},
+          designProperties: {},
+          dimensionKeyMap: { designProperties: {} },
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experiences/experience123',
+        )
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
+        const body = httpMock.put.mock.calls[0][1]
+        expect(body.templateId).to.eql('tmpl-456')
+        expect(body.componentTypeId).to.be.undefined
+        expect(body.sys).to.be.undefined
+      })
+  })
+
   test('delete calls correct URL', async () => {
     const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: {} }))
 

--- a/test/unit/adapters/REST/endpoints/experience.test.ts
+++ b/test/unit/adapters/REST/endpoints/experience.test.ts
@@ -251,6 +251,55 @@ describe('Rest Experience', { concurrent: true }, () => {
       })
   })
 
+  test('create sends templateId when creating a template-backed experience', async () => {
+    const mockResponse = {
+      sys: { id: 'new-experience-456', type: 'Experience', version: 1 },
+      name: 'Template Experience',
+      description: 'A template-backed experience',
+      viewports: [],
+      contentProperties: {},
+      designProperties: {},
+      dimensionKeyMap: { designProperties: {} },
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Experience',
+        action: 'create',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+        },
+        payload: {
+          name: 'Template Experience',
+          description: 'A template-backed experience',
+          templateId: 'tmpl-789',
+          viewports: [],
+          contentProperties: {},
+          designProperties: {},
+          dimensionKeyMap: { designProperties: {} },
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.post.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experiences',
+        )
+        expect(httpMock.post.mock.calls[0][1]).to.eql({
+          name: 'Template Experience',
+          description: 'A template-backed experience',
+          templateId: 'tmpl-789',
+          viewports: [],
+          contentProperties: {},
+          designProperties: {},
+          dimensionKeyMap: { designProperties: {} },
+        })
+      })
+  })
+
   test('update calls correct URL with version header', async () => {
     const mockResponse = {
       sys: { id: 'experience123', type: 'Experience', version: 2 },


### PR DESCRIPTION
[DX-982](https://contentful.atlassian.net/browse/DX-982)

## Summary
- Extends `CreateExperienceProps` to a discriminated union accepting either `componentTypeId` (component-type-backed) or `templateId` (template-backed), mirroring the upstream `ExperienceConfigSchema`
- Fixes the `update` REST adapter to extract `templateId` from `sys.template.sys.id` when updating a template-backed experience (previously only `componentTypeId` was handled)
- Updates the plain client `create` JSDoc example to document both creation paths

## Test plan
- [ ] `tsc --noEmit` passes on `feat/exo`
- [ ] Unit test: `create` with `templateId` sends correct body
- [ ] Unit test: `update` with `sys.template` sends `templateId` (not `componentTypeId`) in body
- [ ] `npm run test:unit` — all 818 tests pass

Generated with [Claude Code](https://claude.com/claude-code)

[DX-982]: https://contentful.atlassian.net/browse/DX-982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ