### PR TITLE
fix: narrow ContentProperty.type to enum and remove stale designTokenSet [DX-986]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -19,7 +19,7 @@ export type ComponentTypeViewport = {
 export type ComponentTypeContentProperty = {
   id: string
   name: string
-  type: string
+  type: 'String' | 'Number' | 'Boolean'
   required: boolean
   defaultValue?: unknown
 }
@@ -48,7 +48,6 @@ export type ComponentTypeDesignProperty = {
   validations?: {
     in?: ComponentTypeDesignPropertyValidation[]
   }
-  designTokenSet: string[]
 }
 
 // Dimension key map


### PR DESCRIPTION
[DX-986](https://contentful.atlassian.net/browse/DX-986)

## Summary
- Narrow `ComponentTypeContentProperty.type` from `string` to `'String' | 'Number' | 'Boolean'` to match upstream `experiences-api-schemas` (INTEG-3511, 2026-03-26)
- Remove stale `designTokenSet: string[]` from `ComponentTypeDesignProperty` — field was removed upstream in INTEG-3772 (2026-04-15) as design token grouping moves to taxonomies

## Test plan
- [ ] `tsc --noEmit` passes with no errors
- [ ] No runtime references to `designTokenSet` remain in source files

Generated with [Claude Code](https://claude.com/claude-code)

[DX-986]: https://contentful.atlassian.net/browse/DX-986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ