### PR TITLE
feat: split ExoMetadataProps into base and Experience-extended variants [DX-987]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -377,14 +377,21 @@ export interface MetadataProps {
 }
 
 /**
- * Metadata shape for ExO entities (ComponentType, Experience/View, Template).
+ * Base metadata shape for ExO entities (ComponentType, Template).
+ * Mirrors upstream MetadataSchema: tags and concepts only.
  * - tags: optional (upstream MetadataSchema.tags is z.optional as of SPA-3821)
  * - concepts: optional taxonomy concept links
- * - name: optional display name for variant labeling (SPA-3939)
  */
 export interface ExoMetadataProps {
   tags?: Link<'Tag'>[]
   concepts?: Link<'TaxonomyConcept'>[]
+}
+
+/**
+ * Extended metadata shape for Experience entities only.
+ * Adds name? for variant labeling (SPA-3939), mirroring upstream ExperienceMetadata.
+ */
+export interface ExperienceMetadataProps extends ExoMetadataProps {
   name?: string
 }
 

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -1,4 +1,4 @@
-import type { CursorPaginationParams, ExoMetadataProps, Link } from '../common-types'
+import type { CursorPaginationParams, ExperienceMetadataProps, Link } from '../common-types'
 import type {
   ComponentTypeViewport,
   DimensionedDesignPropertyValue,
@@ -49,7 +49,7 @@ type ExperienceCommonProps = {
   designProperties: Record<string, DimensionedDesignPropertyValue>
   dimensionKeyMap: ExperienceDimensionKeyMap
   contentBindings?: ExperienceContentBindings
-  metadata?: ExoMetadataProps
+  metadata?: ExperienceMetadataProps
   slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>
 }
 


### PR DESCRIPTION
[DX-987](https://contentful.atlassian.net/browse/DX-987)

## Summary
- Split `ExoMetadataProps` into two types: base (tags + concepts, used by ComponentType and Template) and `ExperienceMetadataProps` which extends the base with `name?` (used only by Experience)
- Aligns the SDK with the upstream `experiences-api-schemas` which defines a base `MetadataSchema` and a separate `ExperienceMetadata` that adds `name`
- `ExperienceCommonProps.metadata` now uses `ExperienceMetadataProps`; ComponentType and Template are unchanged

## Test plan
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] Unit tests pass: `npm run test:unit`
- [ ] Confirm `ExoMetadataProps` no longer has `name` field
- [ ] Confirm `ExperienceMetadataProps` extends `ExoMetadataProps` and adds `name?`
- [ ] Confirm assigning `{ name: 'foo' }` to `ExoMetadataProps` produces a type error

Generated with [Claude Code](https://claude.com/claude-code)

[DX-987]: https://contentful.atlassian.net/browse/DX-987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ