### PR TITLE
locale-integration-test: unskip tests, now that bug has been patched in API [DX-991]

### DIFF
--- a/test/integration/locale-integration.test.ts
+++ b/test/integration/locale-integration.test.ts
@@ -37,11 +37,7 @@ describe('Locale API', () => {
     })
   })
 
-  // FIX ME
-  // https://contentful.atlassian.net/browse/DX-991
-  // regression in locale API: https://contentful.slack.com/archives/C01SQNTQBBM/p1777053859135889
-  // environment id is not being returned in POST and PUT responses
-  it.skip('Creates, gets, updates, and deletes a locale', async () => {
+  it('Creates, gets, updates, and deletes a locale', async () => {
     const createdLocale = await environment.createLocale({
       name: 'German (Austria)',
       code: 'de-AT',
@@ -66,11 +62,7 @@ describe('Locale API', () => {
     await updatedLocale.delete()
   })
 
-  // FIX ME
-  // https://contentful.atlassian.net/browse/DX-991
-  // regression in locale API: https://contentful.slack.com/archives/C01SQNTQBBM/p1777053859135889
-  // environment id is not being returned in POST and PUT responses
-  it.skip('Creates, gets page (respects limit), deletes a locale', async () => {
+  it('Creates, gets page (respects limit), deletes a locale', async () => {
     const createdLocal = await environment.createLocale({
       name: 'Chinese (Simplified, China)',
       code: 'zh-Hans-CN',


### PR DESCRIPTION
As titled
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR unskips two integration tests in the Locale API test suite that were previously disabled due to a bug in the API where environment IDs were not returned in POST and PUT responses. The bug has now been patched, allowing these tests to run and verify locale creation, retrieval, update, and deletion functionality.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes skip directives from two locale integration tests in locale-integration.test.ts, enabling verification of create, get, update, and delete operations for locales.</li>

</ul>
</details>

</div>