### PR TITLE
feat: add org filter and cursor pagination to getSpaces [HEJO-8559]

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,12 +4,7 @@ permissions:
 
 on:
   push:
-    branches:
-      - master
-      - beta
-      - canary
-      - dev
-      - '*.x'
+    branches: ['**']
   pull_request:
     branches: ['**']
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,12 @@ permissions:
 
 on:
   push:
-    branches: ['**']
+    branches:
+      - master
+      - beta
+      - canary
+      - dev
+      - '*.x'
   pull_request:
     branches: ['**']
 

--- a/lib/adapters/REST/endpoints/space.ts
+++ b/lib/adapters/REST/endpoints/space.ts
@@ -3,6 +3,7 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
 import type {
+  BasicCursorPaginationOptions,
   CollectionProp,
   GetOrganizationParams,
   GetSpaceParams,
@@ -17,7 +18,7 @@ export const get: RestEndpoint<'Space', 'get'> = (http: AxiosInstance, params: G
 
 export const getMany: RestEndpoint<'Space', 'getMany'> = (
   http: AxiosInstance,
-  params: QueryParams & { organizationId?: string },
+  params: (QueryParams | BasicCursorPaginationOptions) & { organizationId?: string },
 ) =>
   raw.get<CollectionProp<SpaceProps>>(http, `/spaces`, {
     params: params.query,

--- a/lib/adapters/REST/endpoints/space.ts
+++ b/lib/adapters/REST/endpoints/space.ts
@@ -17,10 +17,13 @@ export const get: RestEndpoint<'Space', 'get'> = (http: AxiosInstance, params: G
 
 export const getMany: RestEndpoint<'Space', 'getMany'> = (
   http: AxiosInstance,
-  params: QueryParams,
+  params: QueryParams & { organizationId?: string },
 ) =>
   raw.get<CollectionProp<SpaceProps>>(http, `/spaces`, {
     params: params.query,
+    headers: params.organizationId
+      ? { 'X-Contentful-Organization': params.organizationId }
+      : undefined,
   })
 
 export const getManyForOrganization: RestEndpoint<'Space', 'getManyForOrganization'> = (

--- a/lib/adapters/REST/endpoints/space.ts
+++ b/lib/adapters/REST/endpoints/space.ts
@@ -3,7 +3,6 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
 import type {
-  BasicCursorPaginationOptions,
   CollectionProp,
   GetOrganizationParams,
   GetSpaceParams,
@@ -18,7 +17,7 @@ export const get: RestEndpoint<'Space', 'get'> = (http: AxiosInstance, params: G
 
 export const getMany: RestEndpoint<'Space', 'getMany'> = (
   http: AxiosInstance,
-  params: (QueryParams | BasicCursorPaginationOptions) & { organizationId?: string },
+  params: QueryParams & { organizationId?: string },
 ) =>
   raw.get<CollectionProp<SpaceProps>>(http, `/spaces`, {
     params: params.query,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -2355,7 +2355,11 @@ export type MRActions = {
   }
   Space: {
     get: { params: GetSpaceParams; return: SpaceProps }
-    getMany: { params: QueryParams; return: CollectionProp<SpaceProps> }
+    getMany: {
+      params: QueryParams & { organizationId?: string }
+      headers?: RawAxiosRequestHeaders
+      return: CollectionProp<SpaceProps>
+    }
     getManyForOrganization: {
       params: GetOrganizationParams & QueryParams
       return: CollectionProp<SpaceProps>

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -2356,7 +2356,7 @@ export type MRActions = {
   Space: {
     get: { params: GetSpaceParams; return: SpaceProps }
     getMany: {
-      params: (QueryParams | BasicCursorPaginationOptions) & { organizationId?: string }
+      params: QueryParams & { organizationId?: string }
       return: CollectionProp<SpaceProps> | CursorPaginatedCollectionProp<SpaceProps>
     }
     getManyForOrganization: {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -2356,8 +2356,8 @@ export type MRActions = {
   Space: {
     get: { params: GetSpaceParams; return: SpaceProps }
     getMany: {
-      params: QueryParams & { organizationId?: string }
-      return: CollectionProp<SpaceProps>
+      params: (QueryParams | BasicCursorPaginationOptions) & { organizationId?: string }
+      return: CollectionProp<SpaceProps> | CursorPaginatedCollectionProp<SpaceProps>
     }
     getManyForOrganization: {
       params: GetOrganizationParams & QueryParams

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -2357,7 +2357,6 @@ export type MRActions = {
     get: { params: GetSpaceParams; return: SpaceProps }
     getMany: {
       params: QueryParams & { organizationId?: string }
-      headers?: RawAxiosRequestHeaders
       return: CollectionProp<SpaceProps>
     }
     getManyForOrganization: {

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -14,7 +14,10 @@ import type {
   GetOAuthApplicationParams,
   GetUserParams,
 } from './common-types'
-import { normalizeCursorPaginationResponse } from './common-utils'
+import {
+  normalizeCursorPaginationParameters,
+  normalizeCursorPaginationResponse,
+} from './common-utils'
 import {
   wrapSpace,
   wrapSpaceCollection,
@@ -179,11 +182,14 @@ export default function createClientApi(makeRequest: MakeRequest) {
       query: (QueryOptions | BasicCursorPaginationOptions) & { cursor?: boolean } = {},
       organizationId?: string,
     ): Promise<Collection<Space, SpaceProps> | CursorPaginatedCollection<Space, SpaceProps>> {
-      const { cursor } = query
+      const { cursor, ...rest } = query
+      const normalizedQuery = cursor
+        ? normalizeCursorPaginationParameters(rest as BasicCursorPaginationOptions)
+        : rest
       return makeRequest({
         entityType: 'Space',
         action: 'getMany',
-        params: { query: createRequestConfig({ query }).params, organizationId },
+        params: { query: createRequestConfig({ query: normalizedQuery }).params, organizationId },
       }).then((data) =>
         cursor
           ? wrapSpaceCursorPaginatedCollection(
@@ -192,6 +198,15 @@ export default function createClientApi(makeRequest: MakeRequest) {
             )
           : wrapSpaceCollection(makeRequest, data as CollectionProp<SpaceProps>),
       )
+    } as {
+      (
+        query?: QueryOptions & { cursor?: false },
+        organizationId?: string,
+      ): Promise<Collection<Space, SpaceProps>>
+      (
+        query: BasicCursorPaginationOptions & { cursor: true },
+        organizationId?: string,
+      ): Promise<CursorPaginatedCollection<Space, SpaceProps>>
     },
 
     /**

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -191,6 +191,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
         action: 'getMany',
         params: { query: createRequestConfig({ query: normalizedQuery }).params, organizationId },
       }).then((data) =>
+        // makeRequest returns the union type; cursor determines which branch is present at runtime so the casts are required
         cursor
           ? wrapSpaceCursorPaginatedCollection(
               makeRequest,

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -169,12 +169,13 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * ```
      */
     getSpaces: function getSpaces(
-      query: QueryOptions = {},
-    ): Promise<Collection<Space, SpaceProps>> {
+      query: (QueryOptions | BasicCursorPaginationOptions) & { cursor?: boolean } = {},
+      organizationId?: string,
+    ): Promise<Collection<Space, SpaceProps> | CursorPaginatedCollection<Space, SpaceProps>> {
       return makeRequest({
         entityType: 'Space',
         action: 'getMany',
-        params: { query: createRequestConfig({ query: query }).params },
+        params: { query: createRequestConfig({ query }).params, organizationId },
       }).then((data) => wrapSpaceCollection(makeRequest, data))
     },
 

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -1,6 +1,8 @@
 import { createRequestConfig } from 'contentful-sdk-core'
 import type {
   Collection,
+  CollectionProp,
+  CursorPaginatedCollectionProp,
   MakeRequest,
   PaginationQueryParams,
   QueryOptions,
@@ -12,7 +14,12 @@ import type {
   GetOAuthApplicationParams,
   GetUserParams,
 } from './common-types'
-import { wrapSpace, wrapSpaceCollection } from './entities/space'
+import { normalizeCursorPaginationResponse } from './common-utils'
+import {
+  wrapSpace,
+  wrapSpaceCollection,
+  wrapSpaceCursorPaginatedCollection,
+} from './entities/space'
 import { wrapUser } from './entities/user'
 import {
   wrapPersonalAccessToken,
@@ -172,11 +179,19 @@ export default function createClientApi(makeRequest: MakeRequest) {
       query: (QueryOptions | BasicCursorPaginationOptions) & { cursor?: boolean } = {},
       organizationId?: string,
     ): Promise<Collection<Space, SpaceProps> | CursorPaginatedCollection<Space, SpaceProps>> {
+      const { cursor } = query
       return makeRequest({
         entityType: 'Space',
         action: 'getMany',
         params: { query: createRequestConfig({ query }).params, organizationId },
-      }).then((data) => wrapSpaceCollection(makeRequest, data))
+      }).then((data) =>
+        cursor
+          ? wrapSpaceCursorPaginatedCollection(
+              makeRequest,
+              normalizeCursorPaginationResponse(data as CursorPaginatedCollectionProp<SpaceProps>),
+            )
+          : wrapSpaceCollection(makeRequest, data as CollectionProp<SpaceProps>),
+      )
     },
 
     /**

--- a/lib/entities/space.ts
+++ b/lib/entities/space.ts
@@ -1,7 +1,7 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { BasicMetaSysProps, DefaultElements, MakeRequest } from '../common-types'
-import { wrapCollection } from '../common-utils'
+import { wrapCollection, wrapCursorPaginatedCollection } from '../common-utils'
 import type { ContentfulSpaceAPI } from '../create-space-api'
 import createSpaceApi from '../create-space-api'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -40,3 +40,4 @@ export function wrapSpace(makeRequest: MakeRequest, data: SpaceProps): Space {
  * @internal
  */
 export const wrapSpaceCollection = wrapCollection(wrapSpace)
+export const wrapSpaceCursorPaginatedCollection = wrapCursorPaginatedCollection(wrapSpace)

--- a/lib/plain/entities/space.ts
+++ b/lib/plain/entities/space.ts
@@ -37,11 +37,11 @@ export type SpacePlainClientAPI = {
    * ```
    */
   getMany(
-    params: OptionalDefaults<{
-      query?: QueryParams['query'] | BasicCursorPaginationOptions
-      organizationId?: string
-    }>,
-  ): Promise<CollectionProp<SpaceProps> | CursorPaginatedCollectionProp<SpaceProps>>
+    params: OptionalDefaults<{ query?: QueryParams['query']; organizationId?: string }>,
+  ): Promise<CollectionProp<SpaceProps>>
+  getMany(
+    params: OptionalDefaults<{ query: BasicCursorPaginationOptions; organizationId?: string }>,
+  ): Promise<CursorPaginatedCollectionProp<SpaceProps>>
   /**
    * Fetches all the spaces in the given organization
    * @param params the organization ID and query parameters

--- a/lib/plain/entities/space.ts
+++ b/lib/plain/entities/space.ts
@@ -37,9 +37,10 @@ export type SpacePlainClientAPI = {
    * ```
    */
   getMany(
-    params: OptionalDefaults<
-      (QueryParams | BasicCursorPaginationOptions) & { organizationId?: string }
-    >,
+    params: OptionalDefaults<{
+      query?: QueryParams['query'] | BasicCursorPaginationOptions
+      organizationId?: string
+    }>,
   ): Promise<CollectionProp<SpaceProps> | CursorPaginatedCollectionProp<SpaceProps>>
   /**
    * Fetches all the spaces in the given organization

--- a/lib/plain/entities/space.ts
+++ b/lib/plain/entities/space.ts
@@ -3,6 +3,8 @@ import type {
   GetSpaceParams,
   QueryParams,
   CollectionProp,
+  CursorPaginatedCollectionProp,
+  BasicCursorPaginationOptions,
   GetOrganizationParams,
 } from '../../common-types'
 import type { OptionalDefaults } from '../wrappers/wrap'
@@ -34,7 +36,11 @@ export type SpacePlainClientAPI = {
    * });
    * ```
    */
-  getMany(params: OptionalDefaults<QueryParams>): Promise<CollectionProp<SpaceProps>>
+  getMany(
+    params: OptionalDefaults<
+      (QueryParams | BasicCursorPaginationOptions) & { organizationId?: string }
+    >,
+  ): Promise<CollectionProp<SpaceProps> | CursorPaginatedCollectionProp<SpaceProps>>
   /**
    * Fetches all the spaces in the given organization
    * @param params the organization ID and query parameters

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -184,7 +184,7 @@ export const createPlainClient = (
     },
     space: {
       get: wrap(wrapParams, 'Space', 'get'),
-      getMany: wrap(wrapParams, 'Space', 'getMany'),
+      getMany: wrap(wrapParams, 'Space', 'getMany') as PlainClientAPI['space']['getMany'],
       getManyForOrganization: wrap(wrapParams, 'Space', 'getManyForOrganization'),
       update: wrap(wrapParams, 'Space', 'update'),
       delete: wrap(wrapParams, 'Space', 'delete'),

--- a/test/unit/create-contentful-api.test.ts
+++ b/test/unit/create-contentful-api.test.ts
@@ -64,6 +64,53 @@ describe('createClientApi', () => {
         api.createSpace({ name: 'test space', productId: 'test-product' }, 'test-org'),
       ).rejects.toEqual(error)
     })
+
+    test('getSpaces calls getMany with query', async () => {
+      const { api, makeRequest } = setup(
+        Promise.resolve({ sys: { type: 'Array' }, total: 0, skip: 0, limit: 100, items: [] }),
+      )
+      await api.getSpaces({ limit: 10 })
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ entityType: 'Space', action: 'getMany' }),
+      )
+    })
+
+    test('getSpaces with cursor:true passes cursor in query', async () => {
+      const { api, makeRequest } = setup(
+        Promise.resolve({ sys: { type: 'Array' }, total: 0, skip: 0, limit: 100, items: [] }),
+      )
+      await api.getSpaces({ cursor: true, limit: 10 })
+      const [call] = makeRequest.mock.calls
+      expect(call[0].action).toBe('getMany')
+      expect(call[0].params.query).toMatchObject({ cursor: true, limit: 10 })
+    })
+
+    test('getSpaces with cursor:true and pageNext passes pageNext in query', async () => {
+      const { api, makeRequest } = setup(
+        Promise.resolve({ sys: { type: 'Array' }, total: 0, skip: 0, limit: 100, items: [] }),
+      )
+      await api.getSpaces({ cursor: true, pageNext: 'next-token' })
+      const [call] = makeRequest.mock.calls
+      expect(call[0].params.query).toMatchObject({ cursor: true, pageNext: 'next-token' })
+    })
+
+    test('getSpaces with organizationId passes it in params', async () => {
+      const { api, makeRequest } = setup(
+        Promise.resolve({ sys: { type: 'Array' }, total: 0, skip: 0, limit: 100, items: [] }),
+      )
+      await api.getSpaces({}, 'test-org')
+      const [call] = makeRequest.mock.calls
+      expect(call[0].params.organizationId).toBe('test-org')
+    })
+
+    test('getSpaces without organizationId omits it from params', async () => {
+      const { api, makeRequest } = setup(
+        Promise.resolve({ sys: { type: 'Array' }, total: 0, skip: 0, limit: 100, items: [] }),
+      )
+      await api.getSpaces()
+      const [call] = makeRequest.mock.calls
+      expect(call[0].params.organizationId).toBeUndefined()
+    })
   })
 })
 

--- a/test/unit/create-contentful-api.test.ts
+++ b/test/unit/create-contentful-api.test.ts
@@ -76,7 +76,7 @@ describe('createClientApi', () => {
       )
     })
 
-    test('getSpaces with cursor:true passes cursor in query', async () => {
+    test('getSpaces with cursor:true normalizes query params (cursor flag not forwarded)', async () => {
       const { api, makeRequest } = setup(Promise.resolve(cursorCollectionResponse))
       await api.getSpaces({ cursor: true, limit: 10 })
       const [call] = makeRequest.mock.calls

--- a/test/unit/create-contentful-api.test.ts
+++ b/test/unit/create-contentful-api.test.ts
@@ -65,10 +65,11 @@ describe('createClientApi', () => {
       ).rejects.toEqual(error)
     })
 
-    test('getSpaces calls getMany with query', async () => {
-      const { api, makeRequest } = setup(
-        Promise.resolve({ sys: { type: 'Array' }, total: 0, skip: 0, limit: 100, items: [] }),
-      )
+    const collectionResponse = { sys: { type: 'Array' }, total: 0, skip: 0, limit: 100, items: [] }
+    const cursorCollectionResponse = { sys: { type: 'Array' }, limit: 100, items: [], pages: {} }
+
+    test('getSpaces calls getMany', async () => {
+      const { api, makeRequest } = setup(Promise.resolve(collectionResponse))
       await api.getSpaces({ limit: 10 })
       expect(makeRequest).toHaveBeenCalledWith(
         expect.objectContaining({ entityType: 'Space', action: 'getMany' }),
@@ -76,9 +77,7 @@ describe('createClientApi', () => {
     })
 
     test('getSpaces with cursor:true passes cursor in query', async () => {
-      const { api, makeRequest } = setup(
-        Promise.resolve({ sys: { type: 'Array' }, total: 0, skip: 0, limit: 100, items: [] }),
-      )
+      const { api, makeRequest } = setup(Promise.resolve(cursorCollectionResponse))
       await api.getSpaces({ cursor: true, limit: 10 })
       const [call] = makeRequest.mock.calls
       expect(call[0].action).toBe('getMany')
@@ -86,27 +85,37 @@ describe('createClientApi', () => {
     })
 
     test('getSpaces with cursor:true and pageNext passes pageNext in query', async () => {
-      const { api, makeRequest } = setup(
-        Promise.resolve({ sys: { type: 'Array' }, total: 0, skip: 0, limit: 100, items: [] }),
-      )
+      const { api, makeRequest } = setup(Promise.resolve(cursorCollectionResponse))
       await api.getSpaces({ cursor: true, pageNext: 'next-token' })
       const [call] = makeRequest.mock.calls
       expect(call[0].params.query).toMatchObject({ cursor: true, pageNext: 'next-token' })
     })
 
-    test('getSpaces with organizationId passes it in params', async () => {
-      const { api, makeRequest } = setup(
-        Promise.resolve({ sys: { type: 'Array' }, total: 0, skip: 0, limit: 100, items: [] }),
+    test('getSpaces with cursor:true returns cursor paginated collection', async () => {
+      const { api } = setup(
+        Promise.resolve({ ...cursorCollectionResponse, pages: { next: 'pageNext=abc' } }),
       )
+      const result = await api.getSpaces({ cursor: true })
+      expect(result).toHaveProperty('pages')
+      expect(result).not.toHaveProperty('total')
+    })
+
+    test('getSpaces without cursor returns regular collection', async () => {
+      const { api } = setup(Promise.resolve(collectionResponse))
+      const result = await api.getSpaces()
+      expect(result).toHaveProperty('total')
+      expect(result).not.toHaveProperty('pages')
+    })
+
+    test('getSpaces with organizationId passes it in params', async () => {
+      const { api, makeRequest } = setup(Promise.resolve(collectionResponse))
       await api.getSpaces({}, 'test-org')
       const [call] = makeRequest.mock.calls
       expect(call[0].params.organizationId).toBe('test-org')
     })
 
     test('getSpaces without organizationId omits it from params', async () => {
-      const { api, makeRequest } = setup(
-        Promise.resolve({ sys: { type: 'Array' }, total: 0, skip: 0, limit: 100, items: [] }),
-      )
+      const { api, makeRequest } = setup(Promise.resolve(collectionResponse))
       await api.getSpaces()
       const [call] = makeRequest.mock.calls
       expect(call[0].params.organizationId).toBeUndefined()


### PR DESCRIPTION
https://contentful.atlassian.net/browse/HEJO-8559

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR enhances the getSpaces API in the Contentful Management SDK by adding support for organization-based filtering and cursor-based pagination. The changes allow users to retrieve spaces filtered by a specific organization and use efficient cursor pagination for handling large collections of spaces. All modifications maintain backward compatibility with existing code.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces organizationId parameter to getSpaces API, enabling filtered space retrieval by organization via X-Contentful-Organization header in lib/adapters/REST/endpoints/space.ts.</li>

<li>Adds cursor-based pagination support to getSpaces, allowing BasicCursorPaginationOptions for efficient large collection handling in lib/common-types.ts and lib/create-contentful-api.ts.</li>

<li>Updates entity wrapping functions in lib/entities/space.ts to support cursor-paginated collections and adjusts plain client types in lib/plain/entities/space.ts.</li>

<li>Modifies client API in lib/create-contentful-api.ts to conditionally wrap responses based on cursor flag, integrating new pagination utilities.</li>

</ul>
</details>

</div>