### PR TITLE
feat: type ExO query filter parameters for Template, Experience, and Fragment [DX-935]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -388,6 +388,58 @@ export interface ExoMetadataProps {
   name?: string
 }
 
+/**
+ * Shared query filter fields for ExO list endpoints (ComponentType, Experience, Fragment, Template).
+ * Mirrors the four shared filter schemas in experiences-management-api-contract:
+ * SysFiltersSchema + TagFiltersSchema + TaxonomyConceptsFiltersSchema + TextFiltersSchema
+ */
+export interface ExoQueryFilters {
+  // SysFiltersSchema
+  'sys.id'?: string
+  'sys.id[in]'?: string
+  'sys.id[nin]'?: string
+  'sys.createdBy.sys.id'?: string
+  'sys.createdBy.sys.id[in]'?: string
+  'sys.createdBy.sys.id[nin]'?: string
+  'sys.updatedBy.sys.id'?: string
+  'sys.updatedBy.sys.id[in]'?: string
+  'sys.updatedBy.sys.id[nin]'?: string
+  'sys.publishedBy.sys.id'?: string
+  'sys.publishedBy.sys.id[in]'?: string
+  'sys.publishedBy.sys.id[nin]'?: string
+  'sys.createdAt[gt]'?: string
+  'sys.createdAt[gte]'?: string
+  'sys.createdAt[lt]'?: string
+  'sys.createdAt[lte]'?: string
+  'sys.updatedAt[gt]'?: string
+  'sys.updatedAt[gte]'?: string
+  'sys.updatedAt[lt]'?: string
+  'sys.updatedAt[lte]'?: string
+  'sys.publishedAt[gt]'?: string
+  'sys.publishedAt[gte]'?: string
+  'sys.publishedAt[lt]'?: string
+  'sys.publishedAt[lte]'?: string
+  'sys.firstPublishedAt[gt]'?: string
+  'sys.firstPublishedAt[gte]'?: string
+  'sys.firstPublishedAt[lt]'?: string
+  'sys.firstPublishedAt[lte]'?: string
+  'sys.version'?: number
+  'sys.publishedVersion'?: number
+  'sys.archivedAt[exists]'?: boolean
+  // TagFiltersSchema
+  'metadata.tags.sys.id[in]'?: string
+  'metadata.tags.sys.id[all]'?: string
+  'metadata.tags.sys.id[nin]'?: string
+  // TaxonomyConceptsFiltersSchema
+  'metadata.concepts.sys.id[in]'?: string
+  'metadata.concepts.sys.id[all]'?: string
+  'metadata.concepts.sys.id[nin]'?: string
+  'metadata.concepts.descendants[in]'?: string
+  // TextFiltersSchema
+  'name[match]'?: string
+  name?: string
+}
+
 export interface SysLink {
   sys: MetaLinkProps
 }

--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -3,13 +3,13 @@ import type {
   CursorPaginatedCollectionProp,
   CursorPaginationParams,
   ExoMetadataProps,
+  ExoQueryFilters,
   Link,
 } from '../common-types'
 
-// Query options for getMany - cursor-based pagination with mutual exclusivity & query filters
-export type ComponentTypeQueryOptions = CursorPaginationParams & {
+// Query options for getMany - cursor-based pagination with typed filter fields
+export type ComponentTypeQueryOptions = CursorPaginationParams & ExoQueryFilters & {
   order?: string
-  [key: string]: unknown
 }
 
 // Viewport definition

--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -8,9 +8,10 @@ import type {
 } from '../common-types'
 
 // Query options for getMany - cursor-based pagination with typed filter fields
-export type ComponentTypeQueryOptions = CursorPaginationParams & ExoQueryFilters & {
-  order?: string
-}
+export type ComponentTypeQueryOptions = CursorPaginationParams &
+  ExoQueryFilters & {
+    order?: string
+  }
 
 // Viewport definition
 export type ComponentTypeViewport = {

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -2,6 +2,7 @@ import type {
   CursorPaginatedCollectionProp,
   CursorPaginationParams,
   ExoMetadataProps,
+  ExoQueryFilters,
   Link,
 } from '../common-types'
 import type {
@@ -62,10 +63,9 @@ export type ExperienceProps = ExperienceCommonProps & {
   sys: ExperienceSys
 }
 
-// Query options for getMany - cursor-based pagination with mutual exclusivity
-export type ExperienceQueryOptions = CursorPaginationParams & {
+// Query options for getMany - cursor-based pagination with typed filter fields
+export type ExperienceQueryOptions = CursorPaginationParams & ExoQueryFilters & {
   order?: string
-  [key: string]: unknown
 }
 
 // Locale-based publish payload — add or remove specific locales.

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -64,9 +64,10 @@ export type ExperienceProps = ExperienceCommonProps & {
 }
 
 // Query options for getMany - cursor-based pagination with typed filter fields
-export type ExperienceQueryOptions = CursorPaginationParams & ExoQueryFilters & {
-  order?: string
-}
+export type ExperienceQueryOptions = CursorPaginationParams &
+  ExoQueryFilters & {
+    order?: string
+  }
 
 // Locale-based publish payload — add or remove specific locales.
 // Omit the payload entirely for a full publish (all locales).

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -3,6 +3,7 @@ import type {
   CursorPaginatedCollectionProp,
   CursorPaginationParams,
   ExoMetadataProps,
+  ExoQueryFilters,
   Link,
 } from '../common-types'
 import type {
@@ -67,9 +68,9 @@ export type UpdateFragmentProps = Omit<FragmentProps, 'sys'> & {
   componentTypeId: string
 }
 
-export type FragmentQueryOptions = CursorPaginationParams & {
-  order?: string
-  [key: string]: unknown
-}
+export type FragmentQueryOptions = CursorPaginationParams &
+  ExoQueryFilters & {
+    order?: string
+  }
 
 export type FragmentCollection = CursorPaginatedCollectionProp<FragmentProps>

--- a/lib/entities/template.ts
+++ b/lib/entities/template.ts
@@ -3,6 +3,7 @@ import type {
   CursorPaginatedCollectionProp,
   CursorPaginationParams,
   ExoMetadataProps,
+  ExoQueryFilters,
   Link,
 } from '../common-types'
 import type {
@@ -62,10 +63,9 @@ export type UpdateTemplateProps = Omit<TemplateProps, 'sys'> & {
   }
 }
 
-// Query options for getMany - cursor-based pagination with filter support
-export type TemplateQueryOptions = CursorPaginationParams & {
+// Query options for getMany - cursor-based pagination with typed filter fields
+export type TemplateQueryOptions = CursorPaginationParams & ExoQueryFilters & {
   order?: string
-  [key: string]: unknown
 }
 
 export type TemplateCollection = CursorPaginatedCollectionProp<TemplateProps>

--- a/lib/entities/template.ts
+++ b/lib/entities/template.ts
@@ -64,8 +64,9 @@ export type UpdateTemplateProps = Omit<TemplateProps, 'sys'> & {
 }
 
 // Query options for getMany - cursor-based pagination with typed filter fields
-export type TemplateQueryOptions = CursorPaginationParams & ExoQueryFilters & {
-  order?: string
-}
+export type TemplateQueryOptions = CursorPaginationParams &
+  ExoQueryFilters & {
+    order?: string
+  }
 
 export type TemplateCollection = CursorPaginatedCollectionProp<TemplateProps>


### PR DESCRIPTION
[DX-935](https://contentful.atlassian.net/browse/DX-935)

## Summary
- Introduced shared `ExoQueryFilters` interface in `lib/common-types.ts` mirroring the four upstream filter schemas (`SysFiltersSchema`, `TagFiltersSchema`, `TaxonomyConceptsFiltersSchema`, `TextFiltersSchema`) from `experiences-management-api-contract`
- Replaced `[key: string]: unknown` escape hatches on `ComponentTypeQueryOptions`, `ExperienceQueryOptions`, and `TemplateQueryOptions` with typed intersections of `CursorPaginationParams & ExoQueryFilters & { order? }`
- Fragment will use `ExoQueryFilters` the same way when its entity file is created

## Test plan
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] Unit tests pass: `npm run test:unit`
- [ ] Confirm passing an unknown filter key to any of the three query option types produces a compile error
- [ ] Confirm all 40 upstream filter fields (`sys.*`, `metadata.tags.*`, `metadata.concepts.*`, `name`, `name[match]`) are accepted without error

Generated with [Claude Code](https://claude.com/claude-code)

[DX-935]: https://contentful.atlassian.net/browse/DX-935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ