### PR TITLE
fix: align DesignPropertyValue with upstream schema refactor [DX-990]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -80,18 +80,23 @@ export type DesignTokenValue = {
 }
 
 // For designProperties[].defaultValue (definition level)
-// Upstream: DesignPropertyValueSchema (schema line 86-91)
+// Upstream: DesignPropertyValueSchema — canonical value only (no pointer, no dimensioned)
 export type DesignPropertyDefinitionValue = ManualDesignValue | DesignTokenValue
 
-// For componentTree node designProperties (tree-node level)
-// Upstream: ComponentTreeDesignPropertyValueSchema (schema line 101-104)
-export type DesignPropertyValue =
-  | ManualDesignValue
-  | DesignTokenValue
-  | DesignPropertyPointerValue
-  | Record<string, ManualDesignValue | DesignTokenValue | DesignPropertyPointerValue>
+// Canonical design property value — ManualDesignValue or DesignToken only
+// Upstream: DesignPropertyValueSchema (schema line 86-91)
+export type DesignPropertyValue = ManualDesignValue | DesignTokenValue
 
+// Dimensioned record — maps breakpoint keys to canonical values
+// Upstream: DimensionedDesignPropertyValueSchema — Record<string, DesignPropertyValueSchema>
 export type DimensionedDesignPropertyValue = Record<string, DesignPropertyValue>
+
+// Tree-node-level union — pointer and dimensioned are siblings of the canonical value
+// Upstream: ComponentTreeDesignPropertyValueSchema (schema line 101-104)
+export type ComponentTreeDesignPropertyValue =
+  | DesignPropertyValue
+  | DesignPropertyPointerValue
+  | DimensionedDesignPropertyValue
 
 // Tree node types for component tree
 export type ComponentNode = {
@@ -100,7 +105,7 @@ export type ComponentNode = {
   nodeType: 'Component'
   componentTypeId: string
   contentProperties: Record<string, ContentPropertyPointerValue | unknown> | string
-  designProperties: Record<string, DesignPropertyValue>
+  designProperties: Record<string, ComponentTreeDesignPropertyValue>
   slots: Record<string, TreeNode[]>
   contentBindings?: string
 }

--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -79,20 +79,12 @@ export type DesignTokenValue = {
   value: string
 }
 
-// For designProperties[].defaultValue (definition level)
-// Upstream: DesignPropertyValueSchema — canonical value only (no pointer, no dimensioned)
 export type DesignPropertyDefinitionValue = ManualDesignValue | DesignTokenValue
 
-// Canonical design property value — ManualDesignValue or DesignToken only
-// Upstream: DesignPropertyValueSchema (schema line 86-91)
 export type DesignPropertyValue = ManualDesignValue | DesignTokenValue
 
-// Dimensioned record — maps breakpoint keys to canonical values
-// Upstream: DimensionedDesignPropertyValueSchema — Record<string, DesignPropertyValueSchema>
 export type DimensionedDesignPropertyValue = Record<string, DesignPropertyValue>
 
-// Tree-node-level union — pointer and dimensioned are siblings of the canonical value
-// Upstream: ComponentTreeDesignPropertyValueSchema (schema line 101-104)
 export type ComponentTreeDesignPropertyValue =
   | DesignPropertyValue
   | DesignPropertyPointerValue


### PR DESCRIPTION
[DX-990](https://contentful.atlassian.net/browse/DX-990)

## Summary
- `DesignPropertyValue` is now the canonical base type (`ManualDesignValue | DesignTokenValue` only), matching upstream `DesignPropertyValueSchema` post INTEG-3511 (2026-03-26)
- New `ComponentTreeDesignPropertyValue` union introduced as the tree-node-level type — `DesignPropertyPointerValue` and `DimensionedDesignPropertyValue` are siblings of the canonical value, not nested inside it
- `ComponentNode.designProperties` updated to `Record<string, ComponentTreeDesignPropertyValue>`

## Test plan
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] Unit tests pass: `npm run test:unit`
- [ ] Confirm assigning `{ breakpoint: pointer }` to `DesignPropertyValue` produces a type error
- [ ] Confirm `ComponentTreeDesignPropertyValue` accepts pointer, dimensioned record, and canonical value as siblings

Generated with [Claude Code](https://claude.com/claude-code)

[DX-990]: https://contentful.atlassian.net/browse/DX-990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ