### PR TITLE
feat: add total? to CursorPaginatedCollectionProp to align with upstream ExO schema [DX-1000]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -404,6 +404,7 @@ export interface CollectionProp<TObj> {
 
 export interface CursorPaginatedCollectionProp<TObj>
   extends Omit<CollectionProp<TObj>, 'total' | 'skip'> {
+  total?: number
   pages?: {
     next?: string
     prev?: string


### PR DESCRIPTION
[DX-1000](https://contentful.atlassian.net/browse/DX-1000)

## Summary
- Add `total?: number` to `CursorPaginatedCollectionProp<T>` to match the optional `total` field present in the upstream cursor-paginated collection envelope (`makePaginatedResponseSchema` + `ComponentTypeCollectionSchema` in `experiences-api-schemas`)
- All ExO entity collections (`ComponentTypeCollection`, `TemplateCollection`, `ExperienceCollection`, `DataAssemblyCollection`) inherit this fix via the generic type — no per-entity changes needed

## Why `pages` optionality was not changed

The ticket also specifies making `pages` required (upstream defines it as always-present). This was investigated but deferred — making `pages` required exposes **pre-existing type mismatches** in non-ExO implementations where `CursorPaginatedCollectionProp` is declared as the return type but the actual implementation returns a plain `CollectionProp` (no `pages` field). Affected call sites (all predating `feat/exo`):

- `lib/create-environment-api.ts` lines 558, 845, 913, 1137, 1205, 2249 — ContentTypes, Entries, Assets, Releases
- `lib/plain/plain-client.ts` lines 439, 464 — Releases, ScheduledActions

Fixing those requires either correcting the return types or updating the implementations to include `pages` — a broader refactor outside the scope of this ticket. Tracked separately.

## Test plan
- [ ] `tsc --noEmit` passes with no errors
- [ ] `CursorPaginatedCollectionProp<T>` now includes `total?: number`
- [ ] All ExO collection types inherit `total?` without per-entity changes

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1000]: https://contentful.atlassian.net/browse/DX-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ