### PR TITLE
feat: add ReleaseExperience and ReleaseExperienceSys type family [DX-1001]

### DIFF
--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -96,3 +96,16 @@ export type InlineFragmentNode = {
 }
 
 export type ExperienceCollection = ExoCursorPaginatedCollectionProp<ExperienceProps>
+
+export type ReleaseExperienceSys = Omit<
+  ExperienceSys,
+  'variant' | 'variantType' | 'variantDimension'
+> & {
+  release: Link<'Release'>
+}
+
+export type ReleaseExperience = Omit<ExperienceProps, 'sys'> & {
+  sys: ReleaseExperienceSys
+}
+
+export type ReleaseExperienceCollection = ExoCursorPaginatedCollectionProp<ReleaseExperience>

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -354,6 +354,11 @@ export type {
 } from './entities/workflows-changelog-entry'
 export type { ComponentTypeCollection } from './entities/component-type'
 export type { TemplateCollection } from './entities/template'
-export type { ExperienceCollection } from './entities/experience'
+export type {
+  ExperienceCollection,
+  ReleaseExperience,
+  ReleaseExperienceCollection,
+  ReleaseExperienceSys,
+} from './entities/experience'
 export type { FragmentCollection } from './entities/fragment'
 export type { DataAssemblyCollection } from './entities/data-assembly'


### PR DESCRIPTION
[DX-1001](https://contentful.atlassian.net/browse/DX-1001)

## Summary
- Add `ReleaseExperienceSys` — `ExperienceSys` minus variant fields, plus `release: Link<'Release'>`
- Add `ReleaseExperience` — Experience with `ReleaseExperienceSys` instead of the standard sys
- Add `ReleaseExperienceCollection` — cursor-paginated collection wrapper
- All three types exported from the SDK's public type surface

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Verify all three types are importable from `contentful-management`
- [ ] Verify `ReleaseExperienceSys` excludes `variant`, `variantType`, `variantDimension` and includes `release`

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1001]: https://contentful.atlassian.net/browse/DX-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ