### PR TITLE
chore: ensure full v12 annotations on all ExO SDK methods [DX-910]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -976,6 +976,8 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Template', 'create', UA>): MRReturn<'Template', 'create'>
   (opts: MROpts<'Template', 'update', UA>): MRReturn<'Template', 'update'>
   (opts: MROpts<'Template', 'delete', UA>): MRReturn<'Template', 'delete'>
+  (opts: MROpts<'Template', 'publish', UA>): MRReturn<'Template', 'publish'>
+  (opts: MROpts<'Template', 'unpublish', UA>): MRReturn<'Template', 'unpublish'>
 
   (opts: MROpts<'UIConfig', 'get', UA>): MRReturn<'UIConfig', 'get'>
   (opts: MROpts<'UIConfig', 'update', UA>): MRReturn<'UIConfig', 'update'>

--- a/lib/plain/entities/fragment.ts
+++ b/lib/plain/entities/fragment.ts
@@ -78,7 +78,7 @@ export type FragmentPlainClientAPI = {
   ): Promise<FragmentProps>
 
   /**
-   * Updates a fragment
+   * Updates a fragment with PUT
    * @param params the space, environment, and fragment IDs
    * @param data the fragment data (including sys.version)
    * @returns the updated fragment

--- a/lib/plain/entities/template.ts
+++ b/lib/plain/entities/template.ts
@@ -78,7 +78,7 @@ export type TemplatePlainClientAPI = {
   ): Promise<TemplateProps>
 
   /**
-   * Updates a template (upsert)
+   * Updates a template with PUT
    * @param params the space, environment, and template IDs
    * @param data the template data (including sys.version)
    * @returns the updated template

--- a/lib/plain/entities/template.ts
+++ b/lib/plain/entities/template.ts
@@ -78,7 +78,7 @@ export type TemplatePlainClientAPI = {
   ): Promise<TemplateProps>
 
   /**
-   * Updates a template with PUT
+   * Updates a template with PUT (upsert)
    * @param params the space, environment, and template IDs
    * @param data the template data (including sys.version)
    * @returns the updated template


### PR DESCRIPTION
[DX-910](https://contentful.atlassian.net/browse/DX-910)

## Summary
- Fix Template and Fragment update method docs to use "with PUT" HTTP semantics convention
- Add missing `Template` `publish`/`unpublish` overloads to `MRInternal` type in `common-types.ts`
- Audit confirmed all 37 ExO methods across 5 entities have the full `@internal - Experimental endpoint, subject to breaking changes without notice` annotation, correct `@returns` tags, and `/** @internal */` on all `Get*Params` types

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Verify Template publish/unpublish `makeRequest` calls now have type checking
- [ ] Spot-check annotation consistency across Component Type, Data Assembly, Template, Fragment, and Experience methods

Generated with [Claude Code](https://claude.com/claude-code)

[DX-910]: https://contentful.atlassian.net/browse/DX-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ