### PR TITLE
fix: correct FragmentProps.metadata type to ExperienceMetadataProps [DX-1004]

### DIFF
--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -2,8 +2,8 @@ import type { Except } from 'type-fest'
 import type {
   CursorPaginationParams,
   ExoCursorPaginatedCollectionProp,
-  ExoMetadataProps,
   ExoQueryFilters,
+  ExperienceMetadataProps,
   Link,
 } from '../common-types'
 import type {
@@ -51,7 +51,7 @@ export type FragmentProps = {
   designProperties: Record<string, DimensionedDesignPropertyValue>
   dimensionKeyMap: ExperienceDimensionKeyMap
   contentBindings?: ExperienceContentBindings
-  metadata?: ExoMetadataProps
+  metadata?: ExperienceMetadataProps
   slots?: Record<string, Array<TreeNode | FragmentNode | InlineFragmentNode>>
 }
 


### PR DESCRIPTION
[DX-1004](https://contentful.atlassian.net/browse/DX-1004)

## Summary
- Fix `FragmentProps.metadata` type from `ExoMetadataProps` → `ExperienceMetadataProps` to match upstream schema (Fragment inherits from Experience, which uses the extended metadata type with `name?`)

> **Note:** `DataAssemblyCollection` was already introduced in [#3020](https://github.com/contentful/contentful-management.js/pull/3020) via DX-1016 — removed from this PR's scope after rebase.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Verify `FragmentProps.metadata` now accepts `name` field

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1004]: https://contentful.atlassian.net/browse/DX-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ