### PR TITLE
feat: introduce ExoCursorPaginatedCollectionProp for ExO endpoints [DX-1016]

### DIFF
--- a/lib/adapters/REST/endpoints/component-type.ts
+++ b/lib/adapters/REST/endpoints/component-type.ts
@@ -3,7 +3,7 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
 import type {
-  CursorPaginatedCollectionProp,
+  ExoCursorPaginatedCollectionProp,
   GetComponentTypeParams,
   GetSpaceEnvironmentParams,
 } from '../../../common-types'
@@ -24,7 +24,7 @@ export const getMany: RestEndpoint<'ComponentType', 'getMany'> = (
   params: GetSpaceEnvironmentParams & { query: ComponentTypeQueryOptions },
   headers?: RawAxiosRequestHeaders,
 ) => {
-  return raw.get<CursorPaginatedCollectionProp<ComponentTypeProps>>(http, getBaseUrl(params), {
+  return raw.get<ExoCursorPaginatedCollectionProp<ComponentTypeProps>>(http, getBaseUrl(params), {
     params: params.query,
     headers,
   })

--- a/lib/adapters/REST/endpoints/component-type.ts
+++ b/lib/adapters/REST/endpoints/component-type.ts
@@ -3,15 +3,15 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
 import type {
-  ExoCursorPaginatedCollectionProp,
   GetComponentTypeParams,
   GetSpaceEnvironmentParams,
 } from '../../../common-types'
-import type {
-  ComponentTypeProps,
-  ComponentTypeQueryOptions,
-  CreateComponentTypeProps,
-  UpdateComponentTypeProps,
+import {
+  ComponentTypeCollection,
+  type ComponentTypeProps,
+  type ComponentTypeQueryOptions,
+  type CreateComponentTypeProps,
+  type UpdateComponentTypeProps,
 } from '../../../entities/component-type'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
@@ -24,7 +24,7 @@ export const getMany: RestEndpoint<'ComponentType', 'getMany'> = (
   params: GetSpaceEnvironmentParams & { query: ComponentTypeQueryOptions },
   headers?: RawAxiosRequestHeaders,
 ) => {
-  return raw.get<ExoCursorPaginatedCollectionProp<ComponentTypeProps>>(http, getBaseUrl(params), {
+  return raw.get<ComponentTypeCollection>(http, getBaseUrl(params), {
     params: params.query,
     headers,
   })

--- a/lib/adapters/REST/endpoints/component-type.ts
+++ b/lib/adapters/REST/endpoints/component-type.ts
@@ -3,7 +3,7 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
 import type { GetComponentTypeParams, GetSpaceEnvironmentParams } from '../../../common-types'
-import type{
+import type {
   ComponentTypeCollection,
   ComponentTypeProps,
   ComponentTypeQueryOptions,

--- a/lib/adapters/REST/endpoints/component-type.ts
+++ b/lib/adapters/REST/endpoints/component-type.ts
@@ -2,10 +2,7 @@ import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
-import type {
-  GetComponentTypeParams,
-  GetSpaceEnvironmentParams,
-} from '../../../common-types'
+import type { GetComponentTypeParams, GetSpaceEnvironmentParams } from '../../../common-types'
 import {
   ComponentTypeCollection,
   type ComponentTypeProps,

--- a/lib/adapters/REST/endpoints/component-type.ts
+++ b/lib/adapters/REST/endpoints/component-type.ts
@@ -3,12 +3,12 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
 import type { GetComponentTypeParams, GetSpaceEnvironmentParams } from '../../../common-types'
-import {
+import type{
   ComponentTypeCollection,
-  type ComponentTypeProps,
-  type ComponentTypeQueryOptions,
-  type CreateComponentTypeProps,
-  type UpdateComponentTypeProps,
+  ComponentTypeProps,
+  ComponentTypeQueryOptions,
+  CreateComponentTypeProps,
+  UpdateComponentTypeProps,
 } from '../../../entities/component-type'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'

--- a/lib/adapters/REST/endpoints/data-assembly.ts
+++ b/lib/adapters/REST/endpoints/data-assembly.ts
@@ -2,12 +2,12 @@ import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type {
-  CursorPaginatedCollectionProp,
   GetDataAssemblyParams,
   GetSpaceEnvironmentParams,
 } from '../../../common-types'
 import type {
   CreateDataAssemblyProps,
+  DataAssemblyCollection,
   DataAssemblyProps,
   DataAssemblyQueryOptions,
   UpdateDataAssemblyProps,
@@ -26,7 +26,7 @@ export const getMany: RestEndpoint<'DataAssembly', 'getMany'> = (
   params: GetSpaceEnvironmentParams & { query: DataAssemblyQueryOptions },
   headers?: RawAxiosRequestHeaders,
 ) => {
-  return raw.get<CursorPaginatedCollectionProp<DataAssemblyProps>>(http, getBaseUrl(params), {
+  return raw.get<DataAssemblyCollection>(http, getBaseUrl(params), {
     params: params.query,
     headers,
   })
@@ -102,7 +102,7 @@ export const getManyPublished: RestEndpoint<'DataAssembly', 'getManyPublished'> 
   params: GetSpaceEnvironmentParams & { query: DataAssemblyQueryOptions },
   headers?: RawAxiosRequestHeaders,
 ) => {
-  return raw.get<CursorPaginatedCollectionProp<DataAssemblyProps>>(http, getPublicUrl(params), {
+  return raw.get<DataAssemblyCollection>(http, getPublicUrl(params), {
     params: params.query,
     headers,
   })

--- a/lib/adapters/REST/endpoints/data-assembly.ts
+++ b/lib/adapters/REST/endpoints/data-assembly.ts
@@ -1,10 +1,7 @@
 import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type {
-  GetDataAssemblyParams,
-  GetSpaceEnvironmentParams,
-} from '../../../common-types'
+import type { GetDataAssemblyParams, GetSpaceEnvironmentParams } from '../../../common-types'
 import type {
   CreateDataAssemblyProps,
   DataAssemblyCollection,

--- a/lib/adapters/REST/endpoints/experience.ts
+++ b/lib/adapters/REST/endpoints/experience.ts
@@ -3,7 +3,7 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
 import type {
-  CursorPaginatedCollectionProp,
+  ExoCursorPaginatedCollectionProp,
   GetSpaceEnvironmentParams,
   GetExperienceParams,
 } from '../../../common-types'
@@ -25,7 +25,7 @@ export const getMany: RestEndpoint<'Experience', 'getMany'> = (
   params: GetSpaceEnvironmentParams & { query: ExperienceQueryOptions },
   headers?: RawAxiosRequestHeaders,
 ) => {
-  return raw.get<CursorPaginatedCollectionProp<ExperienceProps>>(http, getBaseUrl(params), {
+  return raw.get<ExoCursorPaginatedCollectionProp<ExperienceProps>>(http, getBaseUrl(params), {
     params: params.query,
     headers,
   })

--- a/lib/adapters/REST/endpoints/experience.ts
+++ b/lib/adapters/REST/endpoints/experience.ts
@@ -2,10 +2,7 @@ import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
-import type {
-  GetSpaceEnvironmentParams,
-  GetExperienceParams,
-} from '../../../common-types'
+import type { GetSpaceEnvironmentParams, GetExperienceParams } from '../../../common-types'
 import type {
   CreateExperienceProps,
   UpdateExperienceProps,

--- a/lib/adapters/REST/endpoints/experience.ts
+++ b/lib/adapters/REST/endpoints/experience.ts
@@ -3,7 +3,6 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
 import type {
-  ExoCursorPaginatedCollectionProp,
   GetSpaceEnvironmentParams,
   GetExperienceParams,
 } from '../../../common-types'
@@ -13,6 +12,7 @@ import type {
   ExperienceLocalePublishPayload,
   ExperienceProps,
   ExperienceQueryOptions,
+  ExperienceCollection,
 } from '../../../entities/experience'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
@@ -25,7 +25,7 @@ export const getMany: RestEndpoint<'Experience', 'getMany'> = (
   params: GetSpaceEnvironmentParams & { query: ExperienceQueryOptions },
   headers?: RawAxiosRequestHeaders,
 ) => {
-  return raw.get<ExoCursorPaginatedCollectionProp<ExperienceProps>>(http, getBaseUrl(params), {
+  return raw.get<ExperienceCollection>(http, getBaseUrl(params), {
     params: params.query,
     headers,
   })

--- a/lib/adapters/REST/endpoints/fragment.ts
+++ b/lib/adapters/REST/endpoints/fragment.ts
@@ -3,7 +3,7 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
 import type {
-  CursorPaginatedCollectionProp,
+  ExoCursorPaginatedCollectionProp,
   GetFragmentParams,
   GetSpaceEnvironmentParams,
 } from '../../../common-types'
@@ -24,7 +24,7 @@ export const getMany: RestEndpoint<'Fragment', 'getMany'> = (
   params: GetSpaceEnvironmentParams & { query: FragmentQueryOptions },
   headers?: RawAxiosRequestHeaders,
 ) => {
-  return raw.get<CursorPaginatedCollectionProp<FragmentProps>>(http, getBaseUrl(params), {
+  return raw.get<ExoCursorPaginatedCollectionProp<FragmentProps>>(http, getBaseUrl(params), {
     params: params.query,
     headers,
   })

--- a/lib/adapters/REST/endpoints/fragment.ts
+++ b/lib/adapters/REST/endpoints/fragment.ts
@@ -3,7 +3,6 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
 import type {
-  ExoCursorPaginatedCollectionProp,
   GetFragmentParams,
   GetSpaceEnvironmentParams,
 } from '../../../common-types'
@@ -12,6 +11,7 @@ import type {
   FragmentProps,
   FragmentQueryOptions,
   UpdateFragmentProps,
+  FragmentCollection,
 } from '../../../entities/fragment'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
@@ -24,7 +24,7 @@ export const getMany: RestEndpoint<'Fragment', 'getMany'> = (
   params: GetSpaceEnvironmentParams & { query: FragmentQueryOptions },
   headers?: RawAxiosRequestHeaders,
 ) => {
-  return raw.get<ExoCursorPaginatedCollectionProp<FragmentProps>>(http, getBaseUrl(params), {
+  return raw.get<FragmentCollection>(http, getBaseUrl(params), {
     params: params.query,
     headers,
   })

--- a/lib/adapters/REST/endpoints/fragment.ts
+++ b/lib/adapters/REST/endpoints/fragment.ts
@@ -2,10 +2,7 @@ import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
-import type {
-  GetFragmentParams,
-  GetSpaceEnvironmentParams,
-} from '../../../common-types'
+import type { GetFragmentParams, GetSpaceEnvironmentParams } from '../../../common-types'
 import type {
   CreateFragmentProps,
   FragmentProps,

--- a/lib/adapters/REST/endpoints/template.ts
+++ b/lib/adapters/REST/endpoints/template.ts
@@ -2,16 +2,13 @@ import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
-import type {
-  GetSpaceEnvironmentParams,
-  GetTemplateParams,
-} from '../../../common-types'
+import type { GetSpaceEnvironmentParams, GetTemplateParams } from '../../../common-types'
 import type {
   CreateTemplateProps,
   TemplateProps,
   TemplateQueryOptions,
   UpdateTemplateProps,
-  TemplateCollection
+  TemplateCollection,
 } from '../../../entities/template'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'

--- a/lib/adapters/REST/endpoints/template.ts
+++ b/lib/adapters/REST/endpoints/template.ts
@@ -3,7 +3,7 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
 import type {
-  CursorPaginatedCollectionProp,
+  ExoCursorPaginatedCollectionProp,
   GetSpaceEnvironmentParams,
   GetTemplateParams,
 } from '../../../common-types'
@@ -24,7 +24,7 @@ export const getMany: RestEndpoint<'Template', 'getMany'> = (
   params: GetSpaceEnvironmentParams & { query: TemplateQueryOptions },
   headers?: RawAxiosRequestHeaders,
 ) => {
-  return raw.get<CursorPaginatedCollectionProp<TemplateProps>>(http, getBaseUrl(params), {
+  return raw.get<ExoCursorPaginatedCollectionProp<TemplateProps>>(http, getBaseUrl(params), {
     params: params.query,
     headers,
   })

--- a/lib/adapters/REST/endpoints/template.ts
+++ b/lib/adapters/REST/endpoints/template.ts
@@ -3,7 +3,6 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
 import type {
-  ExoCursorPaginatedCollectionProp,
   GetSpaceEnvironmentParams,
   GetTemplateParams,
 } from '../../../common-types'
@@ -12,6 +11,7 @@ import type {
   TemplateProps,
   TemplateQueryOptions,
   UpdateTemplateProps,
+  TemplateCollection
 } from '../../../entities/template'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
@@ -24,7 +24,7 @@ export const getMany: RestEndpoint<'Template', 'getMany'> = (
   params: GetSpaceEnvironmentParams & { query: TemplateQueryOptions },
   headers?: RawAxiosRequestHeaders,
 ) => {
-  return raw.get<ExoCursorPaginatedCollectionProp<TemplateProps>>(http, getBaseUrl(params), {
+  return raw.get<TemplateCollection>(http, getBaseUrl(params), {
     params: params.query,
     headers,
   })

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -423,6 +423,15 @@ export interface CursorPaginatedCollectionProp<TObj>
   }
 }
 
+export interface ExoCursorPaginatedCollectionProp<TObj>
+  extends CursorPaginatedCollectionProp<TObj> {
+  total?: number
+  pages: {
+    next?: string
+    prev?: string
+  }
+}
+
 export interface Collection<T, TPlain>
   extends CollectionProp<T>,
     DefaultElements<CollectionProp<TPlain>> {}

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -168,6 +168,7 @@ import type {
   DataAssemblyProps,
   DataAssemblyQueryOptions,
   UpdateDataAssemblyProps,
+  DataAssemblyCollection,
 } from './entities/data-assembly'
 import type {
   CreateEnvironmentTemplateProps,
@@ -1683,7 +1684,7 @@ export type MRActions = {
   ComponentType: {
     getMany: {
       params: GetSpaceEnvironmentParams & { query: ComponentTypeQueryOptions }
-      return: CursorPaginatedCollectionProp<ComponentTypeProps>
+      return: ExoCursorPaginatedCollectionProp<ComponentTypeProps>
     }
     get: {
       params: GetComponentTypeParams
@@ -1829,11 +1830,11 @@ export type MRActions = {
   DataAssembly: {
     getMany: {
       params: GetSpaceEnvironmentParams & { query: DataAssemblyQueryOptions }
-      return: CursorPaginatedCollectionProp<DataAssemblyProps>
+      return: DataAssemblyCollection
     }
     getManyPublished: {
       params: GetSpaceEnvironmentParams & { query: DataAssemblyQueryOptions }
-      return: CursorPaginatedCollectionProp<DataAssemblyProps>
+      return: DataAssemblyCollection
     }
     getPublished: {
       params: GetDataAssemblyParams
@@ -2669,7 +2670,7 @@ export type MRActions = {
   Fragment: {
     getMany: {
       params: GetSpaceEnvironmentParams & { query: FragmentQueryOptions }
-      return: CursorPaginatedCollectionProp<FragmentProps>
+      return: ExoCursorPaginatedCollectionProp<FragmentProps>
     }
     get: {
       params: GetFragmentParams
@@ -2701,7 +2702,7 @@ export type MRActions = {
   Template: {
     getMany: {
       params: GetSpaceEnvironmentParams & { query: TemplateQueryOptions }
-      return: CursorPaginatedCollectionProp<TemplateProps>
+      return: ExoCursorPaginatedCollectionProp<TemplateProps>
     }
     get: {
       params: GetTemplateParams
@@ -2776,7 +2777,7 @@ export type MRActions = {
   Experience: {
     getMany: {
       params: GetSpaceEnvironmentParams & { query: ExperienceQueryOptions }
-      return: CursorPaginatedCollectionProp<ExperienceProps>
+      return: ExoCursorPaginatedCollectionProp<ExperienceProps>
     }
     get: {
       params: GetExperienceParams

--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -1,7 +1,7 @@
 import type { Except } from 'type-fest'
 import type {
-  CursorPaginatedCollectionProp,
   CursorPaginationParams,
+  ExoCursorPaginatedCollectionProp,
   ExoMetadataProps,
   Link,
 } from '../common-types'
@@ -186,4 +186,4 @@ export type CreateComponentTypeProps = Except<ComponentTypeProps, 'sys'>
 
 export type UpdateComponentTypeProps = ComponentTypeProps
 
-export type ComponentTypeCollection = CursorPaginatedCollectionProp<ComponentTypeProps>
+export type ComponentTypeCollection = ExoCursorPaginatedCollectionProp<ComponentTypeProps>

--- a/lib/entities/data-assembly.ts
+++ b/lib/entities/data-assembly.ts
@@ -1,4 +1,9 @@
-import type { CursorPaginationParams, Link, MetadataProps } from '../common-types'
+import type {
+  CursorPaginationParams,
+  ExoCursorPaginatedCollectionProp,
+  Link,
+  MetadataProps,
+} from '../common-types'
 import { User } from './user'
 
 export type DataAssemblyDataTypeField = {
@@ -97,4 +102,10 @@ export type UpdateDataAssemblyProps = DataAssemblyCommonProps & {
 // Query options for getMany - cursor-based pagination with mutual exclusivity
 export type DataAssemblyQueryOptions = CursorPaginationParams & {
   'sys.id[in]'?: string
+}
+
+export type DataAssemblyCollection = ExoCursorPaginatedCollectionProp<DataAssemblyProps> & {
+  errors?: {
+    notFoundIds: string[]
+  }
 }

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -1,6 +1,6 @@
 import type {
-  CursorPaginatedCollectionProp,
   CursorPaginationParams,
+  ExoCursorPaginatedCollectionProp,
   ExperienceMetadataProps,
   Link,
 } from '../common-types'
@@ -94,4 +94,4 @@ export type InlineFragmentNode = {
   slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>
 }
 
-export type ExperienceCollection = CursorPaginatedCollectionProp<ExperienceProps>
+export type ExperienceCollection = ExoCursorPaginatedCollectionProp<ExperienceProps>

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -1,7 +1,7 @@
 import type { Except } from 'type-fest'
 import type {
-  CursorPaginatedCollectionProp,
   CursorPaginationParams,
+  ExoCursorPaginatedCollectionProp,
   ExoMetadataProps,
   Link,
 } from '../common-types'
@@ -72,4 +72,4 @@ export type FragmentQueryOptions = CursorPaginationParams & {
   [key: string]: unknown
 }
 
-export type FragmentCollection = CursorPaginatedCollectionProp<FragmentProps>
+export type FragmentCollection = ExoCursorPaginatedCollectionProp<FragmentProps>

--- a/lib/entities/template.ts
+++ b/lib/entities/template.ts
@@ -1,7 +1,7 @@
 import type { Except } from 'type-fest'
 import type {
-  CursorPaginatedCollectionProp,
   CursorPaginationParams,
+  ExoCursorPaginatedCollectionProp,
   ExoMetadataProps,
   Link,
 } from '../common-types'
@@ -68,4 +68,4 @@ export type TemplateQueryOptions = CursorPaginationParams & {
   [key: string]: unknown
 }
 
-export type TemplateCollection = CursorPaginatedCollectionProp<TemplateProps>
+export type TemplateCollection = ExoCursorPaginatedCollectionProp<TemplateProps>

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -360,3 +360,5 @@ export type {
 export type { ComponentTypeCollection } from './entities/component-type'
 export type { TemplateCollection } from './entities/template'
 export type { ExperienceCollection } from './entities/experience'
+export type { FragmentCollection } from './entities/fragment'
+export type { DataAssemblyCollection } from './entities/data-assembly'

--- a/lib/plain/entities/component-type.ts
+++ b/lib/plain/entities/component-type.ts
@@ -1,7 +1,7 @@
 import type {
   GetSpaceEnvironmentParams,
   GetComponentTypeParams,
-  CursorPaginatedCollectionProp,
+  ExoCursorPaginatedCollectionProp,
 } from '../../common-types'
 import type {
   ComponentTypeQueryOptions,
@@ -34,7 +34,7 @@ export type ComponentTypePlainClientAPI = {
    */
   getMany(
     params: OptionalDefaults<GetSpaceEnvironmentParams & { query: ComponentTypeQueryOptions }>,
-  ): Promise<CursorPaginatedCollectionProp<ComponentTypeProps>>
+  ): Promise<ExoCursorPaginatedCollectionProp<ComponentTypeProps>>
 
   /**
    * Fetches a single component type by ID

--- a/lib/plain/entities/data-assembly.ts
+++ b/lib/plain/entities/data-assembly.ts
@@ -1,8 +1,5 @@
 import type { RawAxiosRequestHeaders } from 'axios'
-import type {
-  GetDataAssemblyParams,
-  GetSpaceEnvironmentParams,
-} from '../../common-types'
+import type { GetDataAssemblyParams, GetSpaceEnvironmentParams } from '../../common-types'
 import type {
   CreateDataAssemblyProps,
   DataAssemblyProps,

--- a/lib/plain/entities/data-assembly.ts
+++ b/lib/plain/entities/data-assembly.ts
@@ -1,6 +1,5 @@
 import type { RawAxiosRequestHeaders } from 'axios'
 import type {
-  CursorPaginatedCollectionProp,
   GetDataAssemblyParams,
   GetSpaceEnvironmentParams,
 } from '../../common-types'
@@ -9,6 +8,7 @@ import type {
   DataAssemblyProps,
   DataAssemblyQueryOptions,
   UpdateDataAssemblyProps,
+  DataAssemblyCollection,
 } from '../../entities/data-assembly'
 import type { OptionalDefaults } from '../wrappers/wrap'
 
@@ -32,7 +32,7 @@ export type DataAssemblyPlainClientAPI = {
    */
   getMany(
     params: OptionalDefaults<GetSpaceEnvironmentParams & { query: DataAssemblyQueryOptions }>,
-  ): Promise<CursorPaginatedCollectionProp<DataAssemblyProps>>
+  ): Promise<DataAssemblyCollection>
 
   /**
    * Fetches a single data assembly by ID
@@ -183,7 +183,7 @@ export type DataAssemblyPlainClientAPI = {
    */
   getManyPublished(
     params: OptionalDefaults<GetSpaceEnvironmentParams & { query: DataAssemblyQueryOptions }>,
-  ): Promise<CursorPaginatedCollectionProp<DataAssemblyProps>>
+  ): Promise<DataAssemblyCollection>
 
   /**
    * Fetches a single published data assembly by ID

--- a/lib/plain/entities/experience.ts
+++ b/lib/plain/entities/experience.ts
@@ -1,5 +1,5 @@
 import type {
-  CursorPaginatedCollectionProp,
+  ExoCursorPaginatedCollectionProp,
   GetSpaceEnvironmentParams,
   GetExperienceParams,
 } from '../../common-types'
@@ -32,7 +32,7 @@ export type ExperiencePlainClientAPI = {
    */
   getMany(
     params: OptionalDefaults<GetSpaceEnvironmentParams & { query: ExperienceQueryOptions }>,
-  ): Promise<CursorPaginatedCollectionProp<ExperienceProps>>
+  ): Promise<ExoCursorPaginatedCollectionProp<ExperienceProps>>
 
   /**
    * Fetches a single experience by ID

--- a/lib/plain/entities/fragment.ts
+++ b/lib/plain/entities/fragment.ts
@@ -1,5 +1,5 @@
 import type {
-  CursorPaginatedCollectionProp,
+  ExoCursorPaginatedCollectionProp,
   GetFragmentParams,
   GetSpaceEnvironmentParams,
 } from '../../common-types'
@@ -31,7 +31,7 @@ export type FragmentPlainClientAPI = {
    */
   getMany(
     params: OptionalDefaults<GetSpaceEnvironmentParams & { query: FragmentQueryOptions }>,
-  ): Promise<CursorPaginatedCollectionProp<FragmentProps>>
+  ): Promise<ExoCursorPaginatedCollectionProp<FragmentProps>>
 
   /**
    * Fetches a single fragment by ID

--- a/lib/plain/entities/template.ts
+++ b/lib/plain/entities/template.ts
@@ -1,5 +1,5 @@
 import type {
-  CursorPaginatedCollectionProp,
+  ExoCursorPaginatedCollectionProp,
   GetSpaceEnvironmentParams,
   GetTemplateParams,
 } from '../../common-types'
@@ -31,7 +31,7 @@ export type TemplatePlainClientAPI = {
    */
   getMany(
     params: OptionalDefaults<GetSpaceEnvironmentParams & { query: TemplateQueryOptions }>,
-  ): Promise<CursorPaginatedCollectionProp<TemplateProps>>
+  ): Promise<ExoCursorPaginatedCollectionProp<TemplateProps>>
 
   /**
    * Fetches a single template by ID


### PR DESCRIPTION
[DX-1016](https://contentful.atlassian.net/browse/DX-1016)

## Summary
- Introduces `ExoCursorPaginatedCollectionProp<T>` in `lib/common-types.ts` — a dedicated subtype of `CursorPaginatedCollectionProp<T>` that makes `pages` required and adds `total?: number`, reflecting the actual ExO API contract
- Updates all ExO entity collection aliases (`ExperienceCollection`, `FragmentCollection`, `TemplateCollection`, `ComponentTypeCollection`) and adds new `DataAssemblyCollection` (with `errors?: { notFoundIds: string[] }` intersection) to use the new type across entity files, plain client interfaces, REST endpoint type parameters, and `MakeRequestOptions` return types
- Leaves the shared `CursorPaginatedCollectionProp` and all non-ExO endpoints (Concept, ConceptScheme, Resource, Entry, Asset, etc.) completely unchanged; exports `FragmentCollection` and `DataAssemblyCollection` from `export-types.ts`

## Test plan
- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] `npx vitest run` passes
- [ ] Confirm `ExoCursorPaginatedCollectionProp`, `DataAssemblyCollection`, `FragmentCollection` are available as public exports
- [ ] Confirm non-ExO `getMany` return types are unchanged (e.g. Concept, Entry, Asset still use `CursorPaginatedCollectionProp`)

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1016]: https://contentful.atlassian.net/browse/DX-1016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ