### PR TITLE
feat: Add support to include license data to space entity [HEJO-8659]

### DIFF
--- a/lib/adapters/REST/endpoints/space.ts
+++ b/lib/adapters/REST/endpoints/space.ts
@@ -3,6 +3,7 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
 import type {
+  BasicCursorPaginationOptions,
   CollectionProp,
   GetOrganizationParams,
   GetSpaceParams,
@@ -17,7 +18,7 @@ export const get: RestEndpoint<'Space', 'get'> = (http: AxiosInstance, params: G
 
 export const getMany: RestEndpoint<'Space', 'getMany'> = (
   http: AxiosInstance,
-  params: QueryParams & { organizationId?: string },
+  params: (QueryParams | BasicCursorPaginationOptions) & { organizationId?: string },
 ) =>
   raw.get<CollectionProp<SpaceProps>>(http, `/spaces`, {
     params: params.query,

--- a/lib/adapters/REST/endpoints/space.ts
+++ b/lib/adapters/REST/endpoints/space.ts
@@ -23,7 +23,7 @@ export const get: RestEndpoint<'Space', 'get'> = (
 
 export const getMany: RestEndpoint<'Space', 'getMany'> = (
   http: AxiosInstance,
-  params: (QueryParams | BasicCursorPaginationOptions) & {
+  params: QueryParams & {
     organizationId?: string
     include?: 'sys.license'
   },

--- a/lib/adapters/REST/endpoints/space.ts
+++ b/lib/adapters/REST/endpoints/space.ts
@@ -3,7 +3,6 @@ import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type { SetOptional } from 'type-fest'
 import type {
-  BasicCursorPaginationOptions,
   CollectionProp,
   GetOrganizationParams,
   GetSpaceParams,

--- a/lib/adapters/REST/endpoints/space.ts
+++ b/lib/adapters/REST/endpoints/space.ts
@@ -13,15 +13,23 @@ import type { SpaceProps, UnarchiveProps } from '../../../entities/space'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
 
-export const get: RestEndpoint<'Space', 'get'> = (http: AxiosInstance, params: GetSpaceParams) =>
-  raw.get<SpaceProps>(http, `/spaces/${params.spaceId}`)
+export const get: RestEndpoint<'Space', 'get'> = (
+  http: AxiosInstance,
+  params: GetSpaceParams & { include?: 'sys.license' },
+) =>
+  raw.get<SpaceProps>(http, `/spaces/${params.spaceId}`, {
+    params: params.include ? { include: params.include } : undefined,
+  })
 
 export const getMany: RestEndpoint<'Space', 'getMany'> = (
   http: AxiosInstance,
-  params: (QueryParams | BasicCursorPaginationOptions) & { organizationId?: string },
+  params: (QueryParams | BasicCursorPaginationOptions) & {
+    organizationId?: string
+    include?: 'sys.license'
+  },
 ) =>
   raw.get<CollectionProp<SpaceProps>>(http, `/spaces`, {
-    params: params.query,
+    params: { ...params.query, ...(params.include ? { include: params.include } : {}) },
     headers: params.organizationId
       ? { 'X-Contentful-Organization': params.organizationId }
       : undefined,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -99,7 +99,7 @@ import type {
 import type { CreateRoleProps, RoleProps } from './entities/role'
 import type { ScheduledActionProps } from './entities/scheduled-action'
 import type { SnapshotProps } from './entities/snapshot'
-import type { SpaceProps, UnarchiveProps } from './entities/space'
+import type { SpaceProps, SpaceIncludes, SpaceIncludeParam, UnarchiveProps } from './entities/space'
 import type { SpaceAddOnProps, UpdateSpaceAddOnAllocationProps } from './entities/space-add-on'
 import type { SpaceMemberProps } from './entities/space-member'
 import type { CreateSpaceMembershipProps, SpaceMembershipProps } from './entities/space-membership'
@@ -2354,10 +2354,15 @@ export type MRActions = {
     }
   }
   Space: {
-    get: { params: GetSpaceParams; return: SpaceProps }
+    get: {
+      params: GetSpaceParams & SpaceIncludeParam
+      return: SpaceProps & { includes?: SpaceIncludes }
+    }
     getMany: {
-      params: QueryParams & { organizationId?: string }
-      return: CollectionProp<SpaceProps> | CursorPaginatedCollectionProp<SpaceProps>
+      params: QueryParams & { organizationId?: string } & SpaceIncludeParam
+      return: (CollectionProp<SpaceProps> | CursorPaginatedCollectionProp<SpaceProps>) & {
+        includes?: SpaceIncludes
+      }
     }
     getManyForOrganization: {
       params: GetOrganizationParams & QueryParams

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -45,7 +45,7 @@ import { wrapOAuthApplication, wrapOAuthApplicationCollection } from './entities
 
 import type { Organization, OrganizationProps } from './entities/organization'
 import type { CreatePersonalAccessTokenProps } from './entities/personal-access-token'
-import type { Space, SpaceProps } from './entities/space'
+import type { Space, SpaceIncludeParam, SpaceProps } from './entities/space'
 import type { AppDefinition } from './entities/app-definition'
 import type { UsageQuery } from './entities/usage'
 import type { UserProps } from './entities/user'
@@ -179,17 +179,23 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * ```
      */
     getSpaces: function getSpaces(
-      query: (QueryOptions | BasicCursorPaginationOptions) & { cursor?: boolean } = {},
+      query: (QueryOptions | BasicCursorPaginationOptions) & {
+        cursor?: boolean
+      } & SpaceIncludeParam = {},
       organizationId?: string,
     ): Promise<Collection<Space, SpaceProps> | CursorPaginatedCollection<Space, SpaceProps>> {
-      const { cursor, ...rest } = query
+      const { cursor, include, ...rest } = query
       const normalizedQuery = cursor
         ? normalizeCursorPaginationParameters(rest as BasicCursorPaginationOptions)
         : rest
       return makeRequest({
         entityType: 'Space',
         action: 'getMany',
-        params: { query: createRequestConfig({ query: normalizedQuery }).params, organizationId },
+        params: {
+          query: createRequestConfig({ query: normalizedQuery }).params,
+          organizationId,
+          include,
+        },
       }).then((data) =>
         // makeRequest returns the union type; cursor determines which branch is present at runtime so the casts are required
         cursor
@@ -226,11 +232,14 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * .catch(console.error)
      * ```
      */
-    getSpace: function getSpace(spaceId: string): Promise<Space> {
+    getSpace: function getSpace(
+      spaceId: string,
+      { include }: SpaceIncludeParam = {},
+    ): Promise<Space> {
       return makeRequest({
         entityType: 'Space',
         action: 'get',
-        params: { spaceId },
+        params: { spaceId, include },
       }).then((data) => wrapSpace(makeRequest, data))
     },
 

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -207,11 +207,11 @@ export default function createClientApi(makeRequest: MakeRequest) {
       )
     } as {
       (
-        query?: QueryOptions & { cursor?: false },
+        query?: QueryOptions & { cursor?: false } & SpaceIncludeParam,
         organizationId?: string,
       ): Promise<Collection<Space, SpaceProps>>
       (
-        query: BasicCursorPaginationOptions & { cursor: true },
+        query: BasicCursorPaginationOptions & { cursor: true } & SpaceIncludeParam,
         organizationId?: string,
       ): Promise<CursorPaginatedCollection<Space, SpaceProps>>
     },

--- a/lib/entities/space.ts
+++ b/lib/entities/space.ts
@@ -6,10 +6,31 @@ import type { ContentfulSpaceAPI } from '../create-space-api'
 import createSpaceApi from '../create-space-api'
 import enhanceWithMethods from '../enhance-with-methods'
 
+export type SpaceLicenseProps = {
+  sys: {
+    type: 'SpaceLicense'
+    id: string
+  }
+  isTrial: boolean
+  expiresAt: string
+  productId: string
+  productName: string
+}
+
 export type SpaceProps = {
-  sys: BasicMetaSysProps & { organization: { sys: { id: string } }; archivedAt?: string }
+  sys: BasicMetaSysProps & {
+    organization: { sys: { id: string } }
+    archivedAt?: string
+    license?: { sys: { type: 'Link'; linkType: 'SpaceLicense'; id: string } }
+  }
   name: string
 }
+
+export type SpaceIncludes = {
+  SpaceLicense?: SpaceLicenseProps[]
+}
+
+export type SpaceIncludeParam = { include?: 'sys.license' }
 
 export type UnarchiveProps = {
   productId: string

--- a/lib/plain/entities/space.ts
+++ b/lib/plain/entities/space.ts
@@ -8,7 +8,7 @@ import type {
   GetOrganizationParams,
 } from '../../common-types'
 import type { OptionalDefaults } from '../wrappers/wrap'
-import type { SpaceProps } from '../../entities/space'
+import type { SpaceIncludeParam, SpaceIncludes, SpaceProps } from '../../entities/space'
 
 export type SpacePlainClientAPI = {
   /**
@@ -22,7 +22,9 @@ export type SpacePlainClientAPI = {
    * });
    * ```
    */
-  get(params: OptionalDefaults<GetSpaceParams>): Promise<SpaceProps>
+  get(
+    params: OptionalDefaults<GetSpaceParams & SpaceIncludeParam>,
+  ): Promise<SpaceProps & { includes?: SpaceIncludes }>
   /**
    * Fetches all the spaces that the logged in user has access to
    * @param params (optional) filter and pagination query parameters
@@ -37,8 +39,16 @@ export type SpacePlainClientAPI = {
    * ```
    */
   getMany(
-    params: OptionalDefaults<{ query?: QueryParams['query']; organizationId?: string }>,
-  ): Promise<CollectionProp<SpaceProps>>
+    params: OptionalDefaults<
+      { query?: QueryParams['query']; organizationId?: string } & SpaceIncludeParam
+    >,
+  ): Promise<
+    CollectionProp<
+      SpaceProps & {
+        includes?: SpaceIncludes
+      }
+    >
+  >
   getMany(
     params: OptionalDefaults<{ query: BasicCursorPaginationOptions; organizationId?: string }>,
   ): Promise<CursorPaginatedCollectionProp<SpaceProps>>

--- a/lib/plain/entities/space.ts
+++ b/lib/plain/entities/space.ts
@@ -42,16 +42,12 @@ export type SpacePlainClientAPI = {
     params: OptionalDefaults<
       { query?: QueryParams['query']; organizationId?: string } & SpaceIncludeParam
     >,
-  ): Promise<
-    CollectionProp<
-      SpaceProps & {
-        includes?: SpaceIncludes
-      }
-    >
-  >
+  ): Promise<CollectionProp<SpaceProps> & { includes?: SpaceIncludes }>
   getMany(
-    params: OptionalDefaults<{ query: BasicCursorPaginationOptions; organizationId?: string }>,
-  ): Promise<CursorPaginatedCollectionProp<SpaceProps>>
+    params: OptionalDefaults<
+      { query: BasicCursorPaginationOptions; organizationId?: string } & SpaceIncludeParam
+    >,
+  ): Promise<CursorPaginatedCollectionProp<SpaceProps> & { includes?: SpaceIncludes }>
   /**
    * Fetches all the spaces in the given organization
    * @param params the organization ID and query parameters

--- a/test/unit/adapters/REST/endpoints/space.test.ts
+++ b/test/unit/adapters/REST/endpoints/space.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect } from 'vitest'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+
+const spaceMockResponse = {
+  sys: { type: 'Space', id: 'space-id' },
+  name: 'Test Space',
+}
+
+const collectionMockResponse = {
+  sys: { type: 'Array' },
+  total: 1,
+  skip: 0,
+  limit: 100,
+  items: [spaceMockResponse],
+}
+
+describe('Rest Space', { concurrent: true }, () => {
+  describe('get', () => {
+    test('fetches correct URL with no query params when include is not set', async () => {
+      const { httpMock, adapterMock } = setupRestAdapter(
+        Promise.resolve({ data: spaceMockResponse }),
+      )
+
+      await adapterMock.makeRequest({
+        entityType: 'Space',
+        action: 'get',
+        userAgent: 'mocked',
+        params: { spaceId: 'space-id' },
+      })
+
+      expect(httpMock.get.mock.calls[0][0]).to.eql('/spaces/space-id')
+      expect(httpMock.get.mock.calls[0][1]?.params).toBeUndefined()
+    })
+
+    test('forwards include as HTTP query param', async () => {
+      const { httpMock, adapterMock } = setupRestAdapter(
+        Promise.resolve({ data: spaceMockResponse }),
+      )
+
+      await adapterMock.makeRequest({
+        entityType: 'Space',
+        action: 'get',
+        userAgent: 'mocked',
+        params: { spaceId: 'space-id', include: 'sys.license' },
+      })
+
+      expect(httpMock.get.mock.calls[0][0]).to.eql('/spaces/space-id')
+      expect(httpMock.get.mock.calls[0][1].params).to.eql({ include: 'sys.license' })
+    })
+  })
+
+  describe('getMany', () => {
+    test('fetches correct URL', async () => {
+      const { httpMock, adapterMock } = setupRestAdapter(
+        Promise.resolve({ data: collectionMockResponse }),
+      )
+
+      await adapterMock.makeRequest({
+        entityType: 'Space',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {},
+      })
+
+      expect(httpMock.get.mock.calls[0][0]).to.eql('/spaces')
+    })
+
+    test('merges include into HTTP params alongside query options', async () => {
+      const { httpMock, adapterMock } = setupRestAdapter(
+        Promise.resolve({ data: collectionMockResponse }),
+      )
+
+      await adapterMock.makeRequest({
+        entityType: 'Space',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: { query: { limit: 10 }, include: 'sys.license' },
+      })
+
+      expect(httpMock.get.mock.calls[0][1].params).to.eql({ limit: 10, include: 'sys.license' })
+    })
+
+    test('sets X-Contentful-Organization header from organizationId', async () => {
+      const { httpMock, adapterMock } = setupRestAdapter(
+        Promise.resolve({ data: collectionMockResponse }),
+      )
+
+      await adapterMock.makeRequest({
+        entityType: 'Space',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: { organizationId: 'org-id', include: 'sys.license' },
+      })
+
+      expect(httpMock.get.mock.calls[0][1].params).to.eql({ include: 'sys.license' })
+      expect(httpMock.get.mock.calls[0][1].headers?.['X-Contentful-Organization']).to.eql('org-id')
+    })
+  })
+})

--- a/test/unit/create-contentful-api.test.ts
+++ b/test/unit/create-contentful-api.test.ts
@@ -120,6 +120,28 @@ describe('createClientApi', () => {
       const [call] = makeRequest.mock.calls
       expect(call[0].params.organizationId).toBeUndefined()
     })
+
+    test('getSpaces with include passes it as a top-level param', async () => {
+      const { api, makeRequest } = setup(Promise.resolve(collectionResponse))
+      await api.getSpaces({ include: 'sys.license' })
+      const [call] = makeRequest.mock.calls
+      expect(call[0].params.include).toBe('sys.license')
+      expect(call[0].params.query?.include).toBeUndefined()
+    })
+
+    test('getSpace with include passes it in params', async () => {
+      const { api, makeRequest } = setup(Promise.resolve({}))
+      await api.getSpace('test-space', { include: 'sys.license' })
+      const [call] = makeRequest.mock.calls
+      expect(call[0].params.include).toBe('sys.license')
+    })
+
+    test('getSpace without include omits it from params', async () => {
+      const { api, makeRequest } = setup(Promise.resolve({}))
+      await api.getSpace('test-space')
+      const [call] = makeRequest.mock.calls
+      expect(call[0].params.include).toBeUndefined()
+    })
   })
 })
 


### PR DESCRIPTION
https://contentful.atlassian.net/browse/HEJO-8659

## Summary                                                                                                                                                                                                                   
 
  - include support for getSpaces and getSpace: Added an optional include parameter accepting 'sys.license'. When set, the response includes sys.license on each space and a top-level includes.SpaceLicense array 
  with license details (isTrial, expiresAt, productId, productName).                                                                                                                                               
  - New types: SpaceLicenseProps, SpaceIncludes, and SpaceIncludeParam added to entities/space.ts. SpaceIncludeParam uses a template literal union so comma-separated values (e.g. 'sys.license, sys.usage') are   
  type-safe and extensible.    

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds support for including license data in space entities through an optional 'include' parameter in getSpaces and getSpace methods. When 'sys.license' is specified, the response includes license information on each space and a top-level includes.SpaceLicense array with details like trial status, expiration, and product info. New TypeScript types ensure type safety and extensibility for future includes, with modifications across REST endpoints, client API functions, and comprehensive unit tests.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces new TypeScript types (SpaceLicenseProps, SpaceIncludes, SpaceIncludeParam) in space.ts for license data support</li>

<li>Updates SpaceProps type in space.ts to include optional license link reference</li>

<li>Modifies get and getMany REST endpoints in endpoints/space.ts to accept and forward include parameter</li>

<li>Enhances getSpace and getSpaces functions in create-contentful-api.ts to destructure and pass include parameter</li>

<li>Adds unit tests in space.test.ts and create-contentful-api.test.ts for include functionality</li>

</ul>
</details>

</div>