### PR TITLE
chore: do not run integration tests twice on pull-requests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,12 @@ permissions:
 
 on:
   push:
-    branches: ['**']
+    branches:
+      - master
+      - beta
+      - canary
+      - dev
+      - '*.x'
   pull_request:
     branches: ['**']
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.
-->

## Summary

Right now on pull requests, the integration tests are running twice, because of the wildcard of push on all branches.

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR updates the GitHub Actions workflow to specify exact branches for push triggers, preventing integration tests from running twice on pull requests and optimizing CI resource usage.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Modifies the push trigger in .github/workflows/main.yaml to target only master, beta, canary, dev, and '*.x' branches, avoiding duplicate integration test executions on pull request events.</li>

</ul>
</details>

</div>