### PR TITLE
fix: wrap bulkAction plain client params with OptionalDefaults []

### DIFF
--- a/lib/plain/plain-client-types.ts
+++ b/lib/plain/plain-client-types.ts
@@ -257,30 +257,34 @@ export type PlainClientAPI = {
     ): Promise<CursorPaginatedCollectionProp<EnvironmentTemplateInstallationProps>>
   }
   bulkAction: {
-    get<T extends BulkActionPayload = any>(params: GetBulkActionParams): Promise<BulkActionProps<T>>
+    get<T extends BulkActionPayload = any>(
+      params: OptionalDefaults<GetBulkActionParams>,
+    ): Promise<BulkActionProps<T>>
     publish(
-      params: GetSpaceEnvironmentParams,
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
       payload: BulkActionPublishPayload,
     ): Promise<BulkActionProps<BulkActionPublishPayload>>
     unpublish(
-      params: GetSpaceEnvironmentParams,
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
       payload: BulkActionUnpublishPayload,
     ): Promise<BulkActionProps<BulkActionUnpublishPayload>>
     validate(
-      params: GetSpaceEnvironmentParams,
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
       payload: BulkActionValidatePayload,
     ): Promise<BulkActionProps<BulkActionValidatePayload>>
-    getV2(params: GetBulkActionParams): Promise<BulkActionProps<BulkActionV2Payload>>
+    getV2(
+      params: OptionalDefaults<GetBulkActionParams>,
+    ): Promise<BulkActionProps<BulkActionV2Payload>>
     publishV2(
-      params: GetSpaceEnvironmentParams,
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
       payload: PublishBulkActionV2Payload<'add'>,
     ): Promise<BulkActionProps<PublishBulkActionV2Payload<'add'>>>
     unpublishV2(
-      params: GetSpaceEnvironmentParams,
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
       payload: PublishBulkActionV2Payload<'remove'> | UnpublishBulkActionV2Payload,
     ): Promise<BulkActionProps<PublishBulkActionV2Payload<'remove'> | UnpublishBulkActionV2Payload>>
     validateV2(
-      params: GetSpaceEnvironmentParams,
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
       payload: ValidateBulkActionV2Payload<'add'> | ValidateBulkActionV2Payload<'remove'>,
     ): Promise<
       BulkActionProps<ValidateBulkActionV2Payload<'add'> | ValidateBulkActionV2Payload<'remove'>>

--- a/lib/plain/plain-client-types.ts
+++ b/lib/plain/plain-client-types.ts
@@ -261,30 +261,34 @@ export type PlainClientAPI = {
     ): Promise<CursorPaginatedCollectionProp<EnvironmentTemplateInstallationProps>>
   }
   bulkAction: {
-    get<T extends BulkActionPayload = any>(params: GetBulkActionParams): Promise<BulkActionProps<T>>
+    get<T extends BulkActionPayload = any>(
+      params: OptionalDefaults<GetBulkActionParams>,
+    ): Promise<BulkActionProps<T>>
     publish(
-      params: GetSpaceEnvironmentParams,
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
       payload: BulkActionPublishPayload,
     ): Promise<BulkActionProps<BulkActionPublishPayload>>
     unpublish(
-      params: GetSpaceEnvironmentParams,
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
       payload: BulkActionUnpublishPayload,
     ): Promise<BulkActionProps<BulkActionUnpublishPayload>>
     validate(
-      params: GetSpaceEnvironmentParams,
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
       payload: BulkActionValidatePayload,
     ): Promise<BulkActionProps<BulkActionValidatePayload>>
-    getV2(params: GetBulkActionParams): Promise<BulkActionProps<BulkActionV2Payload>>
+    getV2(
+      params: OptionalDefaults<GetBulkActionParams>,
+    ): Promise<BulkActionProps<BulkActionV2Payload>>
     publishV2(
-      params: GetSpaceEnvironmentParams,
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
       payload: PublishBulkActionV2Payload<'add'>,
     ): Promise<BulkActionProps<PublishBulkActionV2Payload<'add'>>>
     unpublishV2(
-      params: GetSpaceEnvironmentParams,
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
       payload: PublishBulkActionV2Payload<'remove'> | UnpublishBulkActionV2Payload,
     ): Promise<BulkActionProps<PublishBulkActionV2Payload<'remove'> | UnpublishBulkActionV2Payload>>
     validateV2(
-      params: GetSpaceEnvironmentParams,
+      params: OptionalDefaults<GetSpaceEnvironmentParams>,
       payload: ValidateBulkActionV2Payload<'add'> | ValidateBulkActionV2Payload<'remove'>,
     ): Promise<
       BulkActionProps<ValidateBulkActionV2Payload<'add'> | ValidateBulkActionV2Payload<'remove'>>


### PR DESCRIPTION
## Summary
- BulkAction methods in the plain client (https://github.com/contentful/contentful-management.js/pull/2528) required explicit `spaceId` and `environmentId` params even when defaults were configured on the client instance
- All other entities (entry, asset, contentType, release, etc.) correctly used the `OptionalDefaults` type wrapper — bulkAction was the only one missing it
- This is a type-level fix only; the runtime `wrap()` function already merges defaults correctly

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All unit tests pass (785/785)
- [x] All type tests pass (8/8)
- [ ] Verify consumers can now omit `spaceId`/`environmentId` from bulkAction calls when defaults are set on the plain client

Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes a type inconsistency in the plain client by making bulkAction parameters compatible with configured client-level defaults. It updates both standard and V2 bulk action APIs without changing runtime behavior or request processing.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates all standard bulkAction signatures in plain-client-types.ts to use OptionalDefaults, including get, publish, unpublish, and validate.</li>

<li>Updates the V2 bulkAction signatures in plain-client-types.ts with the same wrapper while preserving their existing payload unions, generic payload handling, and return types.</li>

</ul>
</details>

</div>