### PR TITLE
fix: remove Fragment localeStatus and narrow slots union [DX-1014]

### DIFF
--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -10,7 +10,6 @@ import type {
   ComponentTypeViewport,
   DimensionedDesignPropertyValue,
   FragmentNode,
-  TreeNode,
 } from './component-type'
 import type {
   ExperienceContentBindings,
@@ -40,7 +39,6 @@ export type FragmentSys = {
   publishedCounter?: number
   firstPublishedAt?: string
   publishedBy?: Link<'User'> | Link<'AppDefinition'>
-  localeStatus?: Record<string, 'draft' | 'published' | 'changed'>
 }
 
 export type FragmentProps = {
@@ -52,7 +50,7 @@ export type FragmentProps = {
   dimensionKeyMap: ExperienceDimensionKeyMap
   contentBindings?: ExperienceContentBindings
   metadata?: ExperienceMetadataProps
-  slots?: Record<string, Array<TreeNode | FragmentNode | InlineFragmentNode>>
+  slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>
 }
 
 export type CreateFragmentProps = Except<FragmentProps, 'sys'> & {


### PR DESCRIPTION
[DX-1014](https://contentful.atlassian.net/browse/DX-1014)

## Summary
- Removes `localeStatus` from `FragmentSys` — upstream removed this field (SPA-4229, Apr 30) as part of making Fragment operations locale-unaware; the SDK was scaffolded against the prior state
- Narrows `FragmentProps.slots` from `Array<TreeNode | FragmentNode | InlineFragmentNode>` to `Array<FragmentNode | InlineFragmentNode>` — the wider union is a regression from the DX-927 squash-merge; upstream only allows fragment and inline-fragment nodes in fragment slots
- Removes the now-unused `TreeNode` import from `fragment.ts`

## Test plan
- [ ] `tsc --noEmit` passes on this branch (verified locally)
- [ ] No usages of `localeStatus` on Fragment or `ComponentNode`/`SlotNode` in Fragment slots exist in tests or adapters
- [ ] Confirm upstream `experiences-api-schemas/src/lib/fragment.ts` has no `localeStatus` on `FragmentSysCommon` and slots typed as `FragmentNode | InlineFragmentNode` only

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1014]: https://contentful.atlassian.net/browse/DX-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ