### PR TITLE
feat: expand ComponentTypeDesignProperty to full discriminated union [DX-1068]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -30,7 +30,7 @@ export type ComponentTypeContentProperty = {
   defaultValue?: unknown
 }
 
-// Design property validation option
+// Validation entry for legacy design property validations.in
 export type ComponentTypeDesignPropertyValidation =
   | {
       type: 'ManualDesignValue'
@@ -43,18 +43,71 @@ export type ComponentTypeDesignPropertyValidation =
       name?: string
     }
 
-// Design property definition
-export type ComponentTypeDesignProperty = {
+// Regexp validation shape for String design properties
+export type StringDesignPropertyRegexpValidation = {
+  regexp: {
+    pattern: string
+  }
+}
+
+// Allowed resource entry for token-backed design properties
+export type DesignTokenAllowedResource = {
+  type: 'DesignToken'
+  value: string
+  name?: string
+}
+
+// DTCG token type literals
+export type DTCGDesignPropertyType =
+  | 'DTCG.Color'
+  | 'DTCG.Dimension'
+  | 'DTCG.FontFamily'
+  | 'DTCG.FontWeight'
+  | 'DTCG.Duration'
+  | 'DTCG.CubicBezier'
+  | 'DTCG.Number'
+  | 'DTCG.StrokeStyle'
+  | 'DTCG.Border'
+  | 'DTCG.Transition'
+  | 'DTCG.Shadow'
+  | 'DTCG.Gradient'
+  | 'DTCG.Typography'
+
+type DesignPropertyCommonFields = {
   id: string
   name: string
-  type: 'Symbol' | 'Number' | 'Boolean'
   required: boolean
   description?: string
+}
+
+// Legacy design property — Symbol, Number, Boolean
+export type LegacyDesignProperty = DesignPropertyCommonFields & {
+  type: 'Symbol' | 'Number' | 'Boolean'
   defaultValue?: DesignPropertyDefinitionValue
   validations?: {
     in?: ComponentTypeDesignPropertyValidation[]
   }
 }
+
+// String design property — free-text with optional regexp validations
+export type StringDesignProperty = DesignPropertyCommonFields & {
+  type: 'String'
+  defaultValue?: { type: 'ManualDesignValue'; value: string }
+  validations?: StringDesignPropertyRegexpValidation[]
+}
+
+// Token-backed design property — DTCG types with optional allowedResources
+export type TokenBackedDesignProperty = DesignPropertyCommonFields & {
+  type: DTCGDesignPropertyType
+  defaultValue?: DesignTokenValue
+  allowedResources?: DesignTokenAllowedResource[]
+}
+
+// Discriminated union covering all three upstream arms
+export type ComponentTypeDesignProperty =
+  | LegacyDesignProperty
+  | StringDesignProperty
+  | TokenBackedDesignProperty
 
 // Dimension key map
 export type ComponentTypeDimensionKeyMap = {


### PR DESCRIPTION
[DX-1068](https://contentful.atlassian.net/browse/DX-1068)

## Summary
- Refactors `ComponentTypeDesignProperty` from a flat object (`Symbol | Number | Boolean` only) into a proper discriminated union with three arms matching the upstream `experiences-api-schemas` spec: `LegacyDesignProperty`, `StringDesignProperty`, and `TokenBackedDesignProperty`
- Adds `StringDesignProperty` with `type: 'String'` and optional regexp validations (`validations?: StringDesignPropertyRegexpValidation[]`), and `TokenBackedDesignProperty` with all 13 DTCG type values and optional `allowedResources`
- `TemplateProps.designProperties` picks up the updated union for free via its existing import — no separate fix needed

## Test plan
- [ ] Verify `ComponentTypeDesignProperty` accepts all 17 type values (Symbol, Number, Boolean, String, and 13 DTCG.* types) without TS errors
- [ ] Verify legacy `Symbol | Number | Boolean` usage still compiles without modification (no breaking change)
- [ ] Verify `StringDesignProperty` rejects `validations.in` (legacy shape) and accepts `validations` as `StringDesignPropertyRegexpValidation[]`
- [ ] Verify `TokenBackedDesignProperty` accepts `allowedResources` and rejects `validations`
- [ ] Verify `TemplateProps.designProperties` reflects the new union without a separate override

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1068]: https://contentful.atlassian.net/browse/DX-1068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ