### PR TITLE
feat: add missing source? field to ComponentTypeProps [DX-1069]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -5,6 +5,7 @@ import type {
   ExoMetadataProps,
   ExoQueryFilters,
   Link,
+  ResourceLink,
 } from '../common-types'
 
 // Query options for getMany - cursor-based pagination with typed filter fields
@@ -181,6 +182,7 @@ export type ComponentTypeProps = {
   slots?: ComponentTypeSlotDefinition[]
   metadata?: ExoMetadataProps
   dataAssemblies?: DataAssemblyLink[]
+  source?: ResourceLink<'Contentful:DesignSystemSource'>
 }
 
 export type CreateComponentTypeProps = Except<ComponentTypeProps, 'sys'>


### PR DESCRIPTION
[DX-1069](https://contentful.atlassian.net/browse/DX-1069)

## Summary
- Adds `source?: ResourceLink<'Contentful:DesignSystemSource'>` to `ComponentTypeProps`, matching the optional management-only field defined in the upstream `ComponentTypeSchema` in `experiences-api-schemas`
- `CreateComponentTypeProps` inherits the field for free via its `Except<ComponentTypeProps, 'sys'>` derivation — no separate override needed
- Without this field, callers creating or updating a ComponentType with a design system source had no way to express it in the typed payload — it would be silently dropped with no TS warning

## Test plan
- [ ] Verify `source?` is assignable on `ComponentTypeProps` with type `ResourceLink<'Contentful:DesignSystemSource'>`
- [ ] Verify `source?` is assignable on `CreateComponentTypeProps` without a separate declaration
- [ ] Verify `source` is optional — omitting it from a `ComponentTypeProps` object compiles without error
- [ ] Verify TS rejects a `source` typed as anything other than `ResourceLink<'Contentful:DesignSystemSource'>`

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1069]: https://contentful.atlassian.net/browse/DX-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ