### PR TITLE
test: add integration tests for all ExO entities [DX-664]

### DIFF
--- a/test/integration/component-type-integration.test.ts
+++ b/test/integration/component-type-integration.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
+import { TestDefaults } from '../defaults'
+import type { ComponentTypeProps } from '../../lib/entities/component-type'
+
+describe('ComponentType Integration', () => {
+  const client = initPlainClient({
+    spaceId: TestDefaults.spaceId,
+    environmentId: TestDefaults.environmentId,
+  })
+
+  let componentType: ComponentTypeProps
+
+  beforeAll(async () => {
+    componentType = await client.componentType.create(
+      {},
+      {
+        name: 'Integration Test Component',
+        description: 'Created by integration test',
+        viewports: [
+          {
+            id: 'desktop',
+            query: '(min-width: 1024px)',
+            displayName: 'Desktop',
+            previewSize: '100%',
+          },
+        ],
+        contentProperties: [
+          {
+            id: 'title',
+            name: 'Title',
+            type: 'String',
+            required: false,
+          },
+        ],
+        designProperties: [
+          {
+            id: 'color',
+            name: 'Color',
+            type: 'Symbol',
+            required: false,
+          },
+        ],
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+  })
+
+  afterAll(async () => {
+    try {
+      const latest = await client.componentType.get({
+        componentTypeId: componentType.sys.id,
+      })
+      if (latest.sys.publishedVersion) {
+        await client.componentType.unpublish({
+          componentTypeId: latest.sys.id,
+          version: latest.sys.version,
+        })
+        const unpublished = await client.componentType.get({
+          componentTypeId: latest.sys.id,
+        })
+        await client.componentType.delete({
+          componentTypeId: unpublished.sys.id,
+        })
+      } else {
+        await client.componentType.delete({
+          componentTypeId: latest.sys.id,
+        })
+      }
+    } catch {
+      // already cleaned up
+    }
+
+    await timeoutToCalmRateLimiting()
+  })
+
+  it('creates a component type with correct sys fields', () => {
+    expect(componentType.sys.id).toBeDefined()
+    expect(componentType.sys.type).toBe('ComponentType')
+    expect(componentType.sys.version).toBeGreaterThanOrEqual(1)
+    expect(componentType.sys.createdAt).toBeDefined()
+    expect(componentType.sys.updatedAt).toBeDefined()
+    expect(componentType.sys.createdBy).toBeDefined()
+    expect(componentType.name).toBe('Integration Test Component')
+    expect(componentType.description).toBe('Created by integration test')
+  })
+
+  it('gets a component type by ID', async () => {
+    const fetched = await client.componentType.get({
+      componentTypeId: componentType.sys.id,
+    })
+
+    expect(fetched.sys.id).toBe(componentType.sys.id)
+    expect(fetched.sys.type).toBe('ComponentType')
+    expect(fetched.name).toBe('Integration Test Component')
+    expect(fetched.contentProperties).toHaveLength(1)
+    expect(fetched.designProperties).toHaveLength(1)
+  })
+
+  it('updates a component type', async () => {
+    const current = await client.componentType.get({
+      componentTypeId: componentType.sys.id,
+    })
+
+    const updated = await client.componentType.update(
+      { componentTypeId: current.sys.id },
+      {
+        ...current,
+        name: 'Updated Integration Test Component',
+      },
+    )
+
+    expect(updated.name).toBe('Updated Integration Test Component')
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+    componentType = updated
+  })
+
+  it('lists component types with cursor pagination', async () => {
+    const collection = await client.componentType.getMany({
+      query: { limit: 10 },
+    })
+
+    expect(collection.sys).toBeDefined()
+    expect(collection.pages).toBeDefined()
+    expect(collection.items).toBeDefined()
+    expect(Array.isArray(collection.items)).toBe(true)
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
+
+    const found = collection.items.find((item) => item.sys.id === componentType.sys.id)
+    expect(found).toBeDefined()
+  })
+
+  it('publishes a component type', async () => {
+    const current = await client.componentType.get({
+      componentTypeId: componentType.sys.id,
+    })
+
+    const published = await client.componentType.publish({
+      componentTypeId: current.sys.id,
+      version: current.sys.version,
+    })
+
+    expect(published.sys.publishedVersion).toBeDefined()
+    expect(published.sys.publishedAt).toBeDefined()
+    componentType = published
+  })
+
+  it('unpublishes a component type', async () => {
+    const current = await client.componentType.get({
+      componentTypeId: componentType.sys.id,
+    })
+
+    const unpublished = await client.componentType.unpublish({
+      componentTypeId: current.sys.id,
+      version: current.sys.version,
+    })
+
+    expect(unpublished.sys.publishedVersion).toBeUndefined()
+    componentType = unpublished
+  })
+})

--- a/test/integration/component-type-integration.test.ts
+++ b/test/integration/component-type-integration.test.ts
@@ -118,15 +118,12 @@ describe('ComponentType Integration', { sequential: true }, () => {
 
   it('rejects creation with missing required fields', async () => {
     await expect(
-      client.componentType.create(
-        {},
-        {
-          description: 'Should fail — missing name and viewports',
-          contentProperties: [],
-          designProperties: [],
-          dimensionKeyMap: { designProperties: {} },
-        } as any,
-      ),
+      client.componentType.create({}, {
+        description: 'Should fail — missing name and viewports',
+        contentProperties: [],
+        designProperties: [],
+        dimensionKeyMap: { designProperties: {} },
+      } as any),
     ).rejects.toThrow()
   })
 

--- a/test/integration/component-type-integration.test.ts
+++ b/test/integration/component-type-integration.test.ts
@@ -10,9 +10,28 @@ describe('ComponentType Integration', () => {
   })
 
   const createdIds: string[] = []
+  let componentTypeId: string
 
   beforeAll(async () => {
     await sweepStaleExoEntities(client)
+
+    const created = await client.componentType.create(
+      {},
+      {
+        name: `Integration Test Component ${testRunId}`,
+        description: 'Created by integration test',
+        viewports: [testViewport],
+        contentProperties: [
+          { id: 'title', name: 'Title', type: 'String', required: false },
+        ],
+        designProperties: [
+          { id: 'color', name: 'Color', type: 'Symbol', required: false },
+        ],
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+    componentTypeId = created.sys.id
+    createdIds.push(componentTypeId)
   })
 
   afterAll(async () => {
@@ -34,87 +53,85 @@ describe('ComponentType Integration', () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('full lifecycle: create → get → update → getMany → publish → unpublish → delete', async () => {
-    // --- Create ---
-    const created = await client.componentType.create(
-      {},
-      {
-        name: `Integration Test Component ${testRunId}`,
-        description: 'Created by integration test',
-        viewports: [testViewport],
-        contentProperties: [
-          { id: 'title', name: 'Title', type: 'String', required: false },
-        ],
-        designProperties: [
-          { id: 'color', name: 'Color', type: 'Symbol', required: false },
-        ],
-        dimensionKeyMap: { designProperties: {} },
-      },
-    )
-    createdIds.push(created.sys.id)
+  it('creates a component type with correct sys fields', async () => {
+    const ct = await client.componentType.get({ componentTypeId: componentTypeId })
 
-    expect(created.sys.id).toBeDefined()
-    expect(created.sys.type).toBe('ComponentType')
-    expect(created.sys.version).toBeGreaterThanOrEqual(1)
-    expect(created.sys.createdAt).toBeDefined()
-    expect(created.sys.updatedAt).toBeDefined()
-    expect(created.sys.createdBy).toBeDefined()
-    expect(created.name).toBe(`Integration Test Component ${testRunId}`)
+    expect(ct.sys.id).toBeDefined()
+    expect(ct.sys.type).toBe('ComponentType')
+    expect(ct.sys.version).toBeGreaterThanOrEqual(1)
+    expect(ct.sys.createdAt).toBeDefined()
+    expect(ct.sys.updatedAt).toBeDefined()
+    expect(ct.sys.createdBy).toBeDefined()
+    expect(ct.name).toBe(`Integration Test Component ${testRunId}`)
+    expect(ct.description).toBe('Created by integration test')
+  })
 
-    // --- Get ---
-    const fetched = await client.componentType.get({
-      componentTypeId: created.sys.id,
-    })
+  it('gets a component type by ID', async () => {
+    const fetched = await client.componentType.get({ componentTypeId: componentTypeId })
 
-    expect(fetched.sys.id).toBe(created.sys.id)
+    expect(fetched.sys.id).toBe(componentTypeId)
     expect(fetched.sys.type).toBe('ComponentType')
     expect(fetched.contentProperties).toHaveLength(1)
     expect(fetched.designProperties).toHaveLength(1)
+  })
 
-    // --- Update ---
+  it('updates a component type', async () => {
+    const current = await client.componentType.get({ componentTypeId: componentTypeId })
+
     const updated = await client.componentType.update(
-      { componentTypeId: fetched.sys.id },
-      { ...fetched, name: `Integration Test Component Updated ${testRunId}` },
+      { componentTypeId: componentTypeId },
+      { ...current, name: `Integration Test Component Updated ${testRunId}` },
     )
 
     expect(updated.name).toBe(`Integration Test Component Updated ${testRunId}`)
-    expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+  })
 
-    // --- GetMany (cursor pagination) ---
+  it('lists component types with cursor pagination', async () => {
     const collection = await client.componentType.getMany({ query: { limit: 10 } })
 
     expect(collection.sys).toBeDefined()
     expect(collection.pages).toBeDefined()
     expect(collection.items).toBeDefined()
     expect(Array.isArray(collection.items)).toBe(true)
-    const found = collection.items.find((item) => item.sys.id === created.sys.id)
-    expect(found).toBeDefined()
 
-    // --- Publish ---
+    const found = collection.items.find((item) => item.sys.id === componentTypeId)
+    expect(found).toBeDefined()
+  })
+
+  it('publishes a component type', async () => {
+    const current = await client.componentType.get({ componentTypeId: componentTypeId })
+
     const published = await client.componentType.publish({
-      componentTypeId: updated.sys.id,
-      version: updated.sys.version,
+      componentTypeId: componentTypeId,
+      version: current.sys.version,
     })
 
     expect(published.sys.publishedVersion).toBeDefined()
     expect(published.sys.publishedAt).toBeDefined()
+  })
 
-    // --- Unpublish ---
+  it('unpublishes a component type', async () => {
+    const current = await client.componentType.get({ componentTypeId: componentTypeId })
+
     const unpublished = await client.componentType.unpublish({
-      componentTypeId: published.sys.id,
-      version: published.sys.version,
+      componentTypeId: componentTypeId,
+      version: current.sys.version,
     })
 
     expect(unpublished.sys.publishedVersion).toBeUndefined()
+  })
 
-    // --- Delete ---
-    await client.componentType.delete({ componentTypeId: unpublished.sys.id })
+  it('deletes a component type', async () => {
+    const current = await client.componentType.get({ componentTypeId: componentTypeId })
+    expect(current.sys.publishedVersion).toBeUndefined()
+
+    await client.componentType.delete({ componentTypeId: componentTypeId })
 
     await expect(
-      client.componentType.get({ componentTypeId: unpublished.sys.id }),
+      client.componentType.get({ componentTypeId: componentTypeId }),
     ).rejects.toThrow()
 
-    // Remove from cleanup since we already deleted
-    createdIds.splice(createdIds.indexOf(created.sys.id), 1)
+    createdIds.splice(createdIds.indexOf(componentTypeId), 1)
   })
 })

--- a/test/integration/component-type-integration.test.ts
+++ b/test/integration/component-type-integration.test.ts
@@ -9,6 +9,7 @@ describe('ComponentType Integration', () => {
     environmentId: TestDefaults.environmentId,
   })
 
+  const createdComponentTypeIds: string[] = []
   let componentType: ComponentTypeProps
 
   beforeAll(async () => {
@@ -44,31 +45,25 @@ describe('ComponentType Integration', () => {
         dimensionKeyMap: { designProperties: {} },
       },
     )
+    createdComponentTypeIds.push(componentType.sys.id)
   })
 
   afterAll(async () => {
-    try {
-      const latest = await client.componentType.get({
-        componentTypeId: componentType.sys.id,
-      })
-      if (latest.sys.publishedVersion) {
-        await client.componentType.unpublish({
-          componentTypeId: latest.sys.id,
-          version: latest.sys.version,
-        })
-        const unpublished = await client.componentType.get({
-          componentTypeId: latest.sys.id,
-        })
-        await client.componentType.delete({
-          componentTypeId: unpublished.sys.id,
-        })
-      } else {
-        await client.componentType.delete({
-          componentTypeId: latest.sys.id,
-        })
+    for (const id of createdComponentTypeIds) {
+      try {
+        const latest = await client.componentType.get({ componentTypeId: id })
+        if (latest.sys.publishedVersion) {
+          const unpublished = await client.componentType.unpublish({
+            componentTypeId: id,
+            version: latest.sys.version,
+          })
+          await client.componentType.delete({ componentTypeId: id })
+        } else {
+          await client.componentType.delete({ componentTypeId: id })
+        }
+      } catch {
+        // entity already deleted or not found
       }
-    } catch {
-      // already cleaned up
     }
 
     await timeoutToCalmRateLimiting()

--- a/test/integration/component-type-integration.test.ts
+++ b/test/integration/component-type-integration.test.ts
@@ -3,7 +3,7 @@ import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
 import { testName, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
 
-describe('ComponentType Integration', () => {
+describe('ComponentType Integration', { sequential: true }, () => {
   const client = initPlainClient({
     spaceId: TestDefaults.spaceId,
     environmentId: TestDefaults.environmentId,
@@ -49,7 +49,7 @@ describe('ComponentType Integration', () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('creates a component type with correct sys fields', async () => {
+  it('has correct sys fields after creation', async () => {
     const ct = await client.componentType.get({ componentTypeId: componentTypeId })
 
     expect(ct.sys.id).toBeDefined()
@@ -86,10 +86,8 @@ describe('ComponentType Integration', () => {
   it('lists component types with cursor pagination', async () => {
     const collection = await client.componentType.getMany({ query: { limit: 10 } })
 
-    expect(collection.sys).toBeDefined()
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
     expect(collection.pages).toBeDefined()
-    expect(collection.items).toBeDefined()
-    expect(Array.isArray(collection.items)).toBe(true)
 
     const found = collection.items.find((item) => item.sys.id === componentTypeId)
     expect(found).toBeDefined()
@@ -118,6 +116,40 @@ describe('ComponentType Integration', () => {
     expect(unpublished.sys.publishedVersion).toBeUndefined()
   })
 
+  it('rejects creation with missing required fields', async () => {
+    await expect(
+      client.componentType.create(
+        {},
+        {
+          description: 'Should fail — missing name and viewports',
+          contentProperties: [],
+          designProperties: [],
+          dimensionKeyMap: { designProperties: {} },
+        } as any,
+      ),
+    ).rejects.toThrow()
+  })
+
+  it('rejects delete on a published entity', async () => {
+    const current = await client.componentType.get({ componentTypeId: componentTypeId })
+    if (!current.sys.publishedVersion) {
+      await client.componentType.publish({
+        componentTypeId: componentTypeId,
+        version: current.sys.version,
+      })
+    }
+
+    await expect(
+      client.componentType.delete({ componentTypeId: componentTypeId }),
+    ).rejects.toThrow()
+
+    const latest = await client.componentType.get({ componentTypeId: componentTypeId })
+    await client.componentType.unpublish({
+      componentTypeId: componentTypeId,
+      version: latest.sys.version,
+    })
+  })
+
   it('deletes a component type', async () => {
     const current = await client.componentType.get({ componentTypeId: componentTypeId })
     expect(current.sys.publishedVersion).toBeUndefined()
@@ -126,6 +158,7 @@ describe('ComponentType Integration', () => {
 
     await expect(client.componentType.get({ componentTypeId: componentTypeId })).rejects.toThrow()
 
-    createdIds.splice(createdIds.indexOf(componentTypeId), 1)
+    const idx = createdIds.indexOf(componentTypeId)
+    if (idx !== -1) createdIds.splice(idx, 1)
   })
 })

--- a/test/integration/component-type-integration.test.ts
+++ b/test/integration/component-type-integration.test.ts
@@ -39,7 +39,7 @@ describe('ComponentType Integration', () => {
     const created = await client.componentType.create(
       {},
       {
-        name: `${testRunId} Component`,
+        name: `Integration Test Component [${testRunId}]`,
         description: 'Created by integration test',
         viewports: [testViewport],
         contentProperties: [
@@ -59,7 +59,7 @@ describe('ComponentType Integration', () => {
     expect(created.sys.createdAt).toBeDefined()
     expect(created.sys.updatedAt).toBeDefined()
     expect(created.sys.createdBy).toBeDefined()
-    expect(created.name).toBe(`${testRunId} Component`)
+    expect(created.name).toBe(`Integration Test Component [${testRunId}]`)
 
     // --- Get ---
     const fetched = await client.componentType.get({
@@ -74,10 +74,10 @@ describe('ComponentType Integration', () => {
     // --- Update ---
     const updated = await client.componentType.update(
       { componentTypeId: fetched.sys.id },
-      { ...fetched, name: `${testRunId} Component Updated` },
+      { ...fetched, name: `Integration Test Component Updated [${testRunId}]` },
     )
 
-    expect(updated.name).toBe(`${testRunId} Component Updated`)
+    expect(updated.name).toBe(`Integration Test Component Updated [${testRunId}]`)
     expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
 
     // --- GetMany (cursor pagination) ---

--- a/test/integration/component-type-integration.test.ts
+++ b/test/integration/component-type-integration.test.ts
@@ -39,7 +39,7 @@ describe('ComponentType Integration', () => {
     const created = await client.componentType.create(
       {},
       {
-        name: `Integration Test Component [${testRunId}]`,
+        name: `Integration Test Component ${testRunId}`,
         description: 'Created by integration test',
         viewports: [testViewport],
         contentProperties: [
@@ -59,7 +59,7 @@ describe('ComponentType Integration', () => {
     expect(created.sys.createdAt).toBeDefined()
     expect(created.sys.updatedAt).toBeDefined()
     expect(created.sys.createdBy).toBeDefined()
-    expect(created.name).toBe(`Integration Test Component [${testRunId}]`)
+    expect(created.name).toBe(`Integration Test Component ${testRunId}`)
 
     // --- Get ---
     const fetched = await client.componentType.get({
@@ -74,10 +74,10 @@ describe('ComponentType Integration', () => {
     // --- Update ---
     const updated = await client.componentType.update(
       { componentTypeId: fetched.sys.id },
-      { ...fetched, name: `Integration Test Component Updated [${testRunId}]` },
+      { ...fetched, name: `Integration Test Component Updated ${testRunId}` },
     )
 
-    expect(updated.name).toBe(`Integration Test Component Updated [${testRunId}]`)
+    expect(updated.name).toBe(`Integration Test Component Updated ${testRunId}`)
     expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
 
     // --- GetMany (cursor pagination) ---

--- a/test/integration/component-type-integration.test.ts
+++ b/test/integration/component-type-integration.test.ts
@@ -21,12 +21,8 @@ describe('ComponentType Integration', () => {
         name: testName('Component'),
         description: 'Created by integration test',
         viewports: [testViewport],
-        contentProperties: [
-          { id: 'title', name: 'Title', type: 'String', required: false },
-        ],
-        designProperties: [
-          { id: 'color', name: 'Color', type: 'Symbol', required: false },
-        ],
+        contentProperties: [{ id: 'title', name: 'Title', type: 'String', required: false }],
+        designProperties: [{ id: 'color', name: 'Color', type: 'Symbol', required: false }],
         dimensionKeyMap: { designProperties: {} },
       },
     )
@@ -128,9 +124,7 @@ describe('ComponentType Integration', () => {
 
     await client.componentType.delete({ componentTypeId: componentTypeId })
 
-    await expect(
-      client.componentType.get({ componentTypeId: componentTypeId }),
-    ).rejects.toThrow()
+    await expect(client.componentType.get({ componentTypeId: componentTypeId })).rejects.toThrow()
 
     createdIds.splice(createdIds.indexOf(componentTypeId), 1)
   })

--- a/test/integration/component-type-integration.test.ts
+++ b/test/integration/component-type-integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
-import { testRunId, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
+import { testName, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
 
 describe('ComponentType Integration', () => {
   const client = initPlainClient({
@@ -18,7 +18,7 @@ describe('ComponentType Integration', () => {
     const created = await client.componentType.create(
       {},
       {
-        name: `Integration Test Component ${testRunId}`,
+        name: testName('Component'),
         description: 'Created by integration test',
         viewports: [testViewport],
         contentProperties: [
@@ -62,7 +62,7 @@ describe('ComponentType Integration', () => {
     expect(ct.sys.createdAt).toBeDefined()
     expect(ct.sys.updatedAt).toBeDefined()
     expect(ct.sys.createdBy).toBeDefined()
-    expect(ct.name).toBe(`Integration Test Component ${testRunId}`)
+    expect(ct.name).toBe(testName('Component'))
     expect(ct.description).toBe('Created by integration test')
   })
 
@@ -80,10 +80,10 @@ describe('ComponentType Integration', () => {
 
     const updated = await client.componentType.update(
       { componentTypeId: componentTypeId },
-      { ...current, name: `Integration Test Component Updated ${testRunId}` },
+      { ...current, name: testName('Component Updated') },
     )
 
-    expect(updated.name).toBe(`Integration Test Component Updated ${testRunId}`)
+    expect(updated.name).toBe(testName('Component Updated'))
     expect(updated.sys.version).toBeGreaterThan(current.sys.version)
   })
 

--- a/test/integration/component-type-integration.test.ts
+++ b/test/integration/component-type-integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
-import type { ComponentTypeProps } from '../../lib/entities/component-type'
+import { testRunId, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
 
 describe('ComponentType Integration', () => {
   const client = initPlainClient({
@@ -9,58 +9,23 @@ describe('ComponentType Integration', () => {
     environmentId: TestDefaults.environmentId,
   })
 
-  const createdComponentTypeIds: string[] = []
-  let componentType: ComponentTypeProps
+  const createdIds: string[] = []
 
   beforeAll(async () => {
-    componentType = await client.componentType.create(
-      {},
-      {
-        name: 'Integration Test Component',
-        description: 'Created by integration test',
-        viewports: [
-          {
-            id: 'desktop',
-            query: '(min-width: 1024px)',
-            displayName: 'Desktop',
-            previewSize: '100%',
-          },
-        ],
-        contentProperties: [
-          {
-            id: 'title',
-            name: 'Title',
-            type: 'String',
-            required: false,
-          },
-        ],
-        designProperties: [
-          {
-            id: 'color',
-            name: 'Color',
-            type: 'Symbol',
-            required: false,
-          },
-        ],
-        dimensionKeyMap: { designProperties: {} },
-      },
-    )
-    createdComponentTypeIds.push(componentType.sys.id)
+    await sweepStaleExoEntities(client)
   })
 
   afterAll(async () => {
-    for (const id of createdComponentTypeIds) {
+    for (const id of createdIds) {
       try {
         const latest = await client.componentType.get({ componentTypeId: id })
         if (latest.sys.publishedVersion) {
-          const unpublished = await client.componentType.unpublish({
+          await client.componentType.unpublish({
             componentTypeId: id,
             version: latest.sys.version,
           })
-          await client.componentType.delete({ componentTypeId: id })
-        } else {
-          await client.componentType.delete({ componentTypeId: id })
         }
+        await client.componentType.delete({ componentTypeId: id })
       } catch {
         // entity already deleted or not found
       }
@@ -69,88 +34,87 @@ describe('ComponentType Integration', () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('creates a component type with correct sys fields', () => {
-    expect(componentType.sys.id).toBeDefined()
-    expect(componentType.sys.type).toBe('ComponentType')
-    expect(componentType.sys.version).toBeGreaterThanOrEqual(1)
-    expect(componentType.sys.createdAt).toBeDefined()
-    expect(componentType.sys.updatedAt).toBeDefined()
-    expect(componentType.sys.createdBy).toBeDefined()
-    expect(componentType.name).toBe('Integration Test Component')
-    expect(componentType.description).toBe('Created by integration test')
-  })
-
-  it('gets a component type by ID', async () => {
-    const fetched = await client.componentType.get({
-      componentTypeId: componentType.sys.id,
-    })
-
-    expect(fetched.sys.id).toBe(componentType.sys.id)
-    expect(fetched.sys.type).toBe('ComponentType')
-    expect(fetched.name).toBe('Integration Test Component')
-    expect(fetched.contentProperties).toHaveLength(1)
-    expect(fetched.designProperties).toHaveLength(1)
-  })
-
-  it('updates a component type', async () => {
-    const current = await client.componentType.get({
-      componentTypeId: componentType.sys.id,
-    })
-
-    const updated = await client.componentType.update(
-      { componentTypeId: current.sys.id },
+  it('full lifecycle: create → get → update → getMany → publish → unpublish → delete', async () => {
+    // --- Create ---
+    const created = await client.componentType.create(
+      {},
       {
-        ...current,
-        name: 'Updated Integration Test Component',
+        name: `${testRunId} Component`,
+        description: 'Created by integration test',
+        viewports: [testViewport],
+        contentProperties: [
+          { id: 'title', name: 'Title', type: 'String', required: false },
+        ],
+        designProperties: [
+          { id: 'color', name: 'Color', type: 'Symbol', required: false },
+        ],
+        dimensionKeyMap: { designProperties: {} },
       },
     )
+    createdIds.push(created.sys.id)
 
-    expect(updated.name).toBe('Updated Integration Test Component')
-    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
-    componentType = updated
-  })
+    expect(created.sys.id).toBeDefined()
+    expect(created.sys.type).toBe('ComponentType')
+    expect(created.sys.version).toBeGreaterThanOrEqual(1)
+    expect(created.sys.createdAt).toBeDefined()
+    expect(created.sys.updatedAt).toBeDefined()
+    expect(created.sys.createdBy).toBeDefined()
+    expect(created.name).toBe(`${testRunId} Component`)
 
-  it('lists component types with cursor pagination', async () => {
-    const collection = await client.componentType.getMany({
-      query: { limit: 10 },
+    // --- Get ---
+    const fetched = await client.componentType.get({
+      componentTypeId: created.sys.id,
     })
+
+    expect(fetched.sys.id).toBe(created.sys.id)
+    expect(fetched.sys.type).toBe('ComponentType')
+    expect(fetched.contentProperties).toHaveLength(1)
+    expect(fetched.designProperties).toHaveLength(1)
+
+    // --- Update ---
+    const updated = await client.componentType.update(
+      { componentTypeId: fetched.sys.id },
+      { ...fetched, name: `${testRunId} Component Updated` },
+    )
+
+    expect(updated.name).toBe(`${testRunId} Component Updated`)
+    expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
+
+    // --- GetMany (cursor pagination) ---
+    const collection = await client.componentType.getMany({ query: { limit: 10 } })
 
     expect(collection.sys).toBeDefined()
     expect(collection.pages).toBeDefined()
     expect(collection.items).toBeDefined()
     expect(Array.isArray(collection.items)).toBe(true)
-    expect(collection.items.length).toBeGreaterThanOrEqual(1)
-
-    const found = collection.items.find((item) => item.sys.id === componentType.sys.id)
+    const found = collection.items.find((item) => item.sys.id === created.sys.id)
     expect(found).toBeDefined()
-  })
 
-  it('publishes a component type', async () => {
-    const current = await client.componentType.get({
-      componentTypeId: componentType.sys.id,
-    })
-
+    // --- Publish ---
     const published = await client.componentType.publish({
-      componentTypeId: current.sys.id,
-      version: current.sys.version,
+      componentTypeId: updated.sys.id,
+      version: updated.sys.version,
     })
 
     expect(published.sys.publishedVersion).toBeDefined()
     expect(published.sys.publishedAt).toBeDefined()
-    componentType = published
-  })
 
-  it('unpublishes a component type', async () => {
-    const current = await client.componentType.get({
-      componentTypeId: componentType.sys.id,
-    })
-
+    // --- Unpublish ---
     const unpublished = await client.componentType.unpublish({
-      componentTypeId: current.sys.id,
-      version: current.sys.version,
+      componentTypeId: published.sys.id,
+      version: published.sys.version,
     })
 
     expect(unpublished.sys.publishedVersion).toBeUndefined()
-    componentType = unpublished
+
+    // --- Delete ---
+    await client.componentType.delete({ componentTypeId: unpublished.sys.id })
+
+    await expect(
+      client.componentType.get({ componentTypeId: unpublished.sys.id }),
+    ).rejects.toThrow()
+
+    // Remove from cleanup since we already deleted
+    createdIds.splice(createdIds.indexOf(created.sys.id), 1)
   })
 })

--- a/test/integration/data-assembly-integration.test.ts
+++ b/test/integration/data-assembly-integration.test.ts
@@ -9,6 +9,7 @@ describe('DataAssembly Integration', () => {
     environmentId: TestDefaults.environmentId,
   })
 
+  const createdDataAssemblyIds: string[] = []
   let dataAssembly: DataAssemblyProps
 
   beforeAll(async () => {
@@ -41,31 +42,25 @@ describe('DataAssembly Integration', () => {
         },
       },
     )
+    createdDataAssemblyIds.push(dataAssembly.sys.id)
   })
 
   afterAll(async () => {
-    try {
-      const latest = await client.dataAssembly.get({
-        dataAssemblyId: dataAssembly.sys.id,
-      })
-      if (latest.sys.publishedVersion) {
-        await client.dataAssembly.unpublish({
-          dataAssemblyId: latest.sys.id,
-          version: latest.sys.version,
-        })
-        const unpublished = await client.dataAssembly.get({
-          dataAssemblyId: latest.sys.id,
-        })
-        await client.dataAssembly.delete({
-          dataAssemblyId: unpublished.sys.id,
-        })
-      } else {
-        await client.dataAssembly.delete({
-          dataAssemblyId: latest.sys.id,
-        })
+    for (const id of createdDataAssemblyIds) {
+      try {
+        const latest = await client.dataAssembly.get({ dataAssemblyId: id })
+        if (latest.sys.publishedVersion) {
+          await client.dataAssembly.unpublish({
+            dataAssemblyId: id,
+            version: latest.sys.version,
+          })
+          await client.dataAssembly.delete({ dataAssemblyId: id })
+        } else {
+          await client.dataAssembly.delete({ dataAssemblyId: id })
+        }
+      } catch {
+        // entity already deleted or not found
       }
-    } catch {
-      // already cleaned up
     }
 
     await timeoutToCalmRateLimiting()

--- a/test/integration/data-assembly-integration.test.ts
+++ b/test/integration/data-assembly-integration.test.ts
@@ -156,9 +156,7 @@ describe('DataAssembly Integration', { sequential: true }, () => {
       })
     }
 
-    await expect(
-      client.dataAssembly.delete({ dataAssemblyId: dataAssemblyId }),
-    ).rejects.toThrow()
+    await expect(client.dataAssembly.delete({ dataAssemblyId: dataAssemblyId })).rejects.toThrow()
 
     const latest = await client.dataAssembly.get({ dataAssemblyId: dataAssemblyId })
     await client.dataAssembly.unpublish({

--- a/test/integration/data-assembly-integration.test.ts
+++ b/test/integration/data-assembly-integration.test.ts
@@ -48,7 +48,7 @@ describe('DataAssembly Integration', () => {
           ],
         },
         metadata: { tags: [] },
-        name: `Integration Test DataAssembly [${testRunId}]`,
+        name: `Integration Test DataAssembly ${testRunId}`,
         description: 'Created by integration test',
         parameters: {},
         resolvers: {
@@ -70,7 +70,7 @@ describe('DataAssembly Integration', () => {
     expect(created.sys.createdAt).toBeDefined()
     expect(created.sys.createdBy).toBeDefined()
     expect(created.sys.dataType).toBeDefined()
-    expect(created.name).toBe(`Integration Test DataAssembly [${testRunId}]`)
+    expect(created.name).toBe(`Integration Test DataAssembly ${testRunId}`)
 
     // --- Get ---
     const fetched = await client.dataAssembly.get({ dataAssemblyId: created.sys.id })
@@ -91,11 +91,11 @@ describe('DataAssembly Integration', () => {
           version: fetched.sys.version,
           dataType: fetched.sys.dataType,
         },
-        name: `Integration Test DataAssembly Updated [${testRunId}]`,
+        name: `Integration Test DataAssembly Updated ${testRunId}`,
       },
     )
 
-    expect(updated.name).toBe(`Integration Test DataAssembly Updated [${testRunId}]`)
+    expect(updated.name).toBe(`Integration Test DataAssembly Updated ${testRunId}`)
     expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
 
     // --- GetMany (cursor pagination) ---
@@ -124,7 +124,7 @@ describe('DataAssembly Integration', () => {
 
     expect(fetchedPublished.sys.id).toBe(created.sys.id)
     expect(fetchedPublished.sys.type).toBe('DataAssembly')
-    expect(fetchedPublished.name).toBe(`Integration Test DataAssembly Updated [${testRunId}]`)
+    expect(fetchedPublished.name).toBe(`Integration Test DataAssembly Updated ${testRunId}`)
 
     // --- GetManyPublished ---
     const publishedCollection = await client.dataAssembly.getManyPublished({

--- a/test/integration/data-assembly-integration.test.ts
+++ b/test/integration/data-assembly-integration.test.ts
@@ -20,9 +20,7 @@ describe('DataAssembly Integration', () => {
       {
         sys: {
           type: 'DataAssembly',
-          dataType: [
-            { id: 'title', name: 'Title', type: 'String', required: false },
-          ],
+          dataType: [{ id: 'title', name: 'Title', type: 'String', required: false }],
         },
         metadata: { tags: [] },
         name: testName('DataAssembly'),
@@ -157,9 +155,7 @@ describe('DataAssembly Integration', () => {
 
     await client.dataAssembly.delete({ dataAssemblyId: dataAssemblyId })
 
-    await expect(
-      client.dataAssembly.get({ dataAssemblyId: dataAssemblyId }),
-    ).rejects.toThrow()
+    await expect(client.dataAssembly.get({ dataAssemblyId: dataAssemblyId })).rejects.toThrow()
 
     createdIds.splice(createdIds.indexOf(dataAssemblyId), 1)
   })

--- a/test/integration/data-assembly-integration.test.ts
+++ b/test/integration/data-assembly-integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
-import { testRunId, sweepStaleExoEntities } from './utils/exo.utils'
+import { testName, sweepStaleExoEntities } from './utils/exo.utils'
 
 describe('DataAssembly Integration', () => {
   const client = initPlainClient({
@@ -27,7 +27,7 @@ describe('DataAssembly Integration', () => {
           ],
         },
         metadata: { tags: [] },
-        name: `Integration Test DataAssembly ${testRunId}`,
+        name: testName('DataAssembly'),
         description: 'Created by integration test',
         parameters: {},
         resolvers: {
@@ -73,7 +73,7 @@ describe('DataAssembly Integration', () => {
     expect(da.sys.createdAt).toBeDefined()
     expect(da.sys.createdBy).toBeDefined()
     expect(da.sys.dataType).toBeDefined()
-    expect(da.name).toBe(`Integration Test DataAssembly ${testRunId}`)
+    expect(da.name).toBe(testName('DataAssembly'))
     expect(da.description).toBe('Created by integration test')
   })
 
@@ -99,11 +99,11 @@ describe('DataAssembly Integration', () => {
           version: current.sys.version,
           dataType: current.sys.dataType,
         },
-        name: `Integration Test DataAssembly Updated ${testRunId}`,
+        name: testName('DataAssembly Updated'),
       },
     )
 
-    expect(updated.name).toBe(`Integration Test DataAssembly Updated ${testRunId}`)
+    expect(updated.name).toBe(testName('DataAssembly Updated'))
     expect(updated.sys.version).toBeGreaterThan(current.sys.version)
   })
 

--- a/test/integration/data-assembly-integration.test.ts
+++ b/test/integration/data-assembly-integration.test.ts
@@ -10,32 +10,11 @@ describe('DataAssembly Integration', () => {
   })
 
   const createdIds: string[] = []
+  let dataAssemblyId: string
 
   beforeAll(async () => {
     await sweepStaleExoEntities(client)
-  })
 
-  afterAll(async () => {
-    for (const id of createdIds) {
-      try {
-        const latest = await client.dataAssembly.get({ dataAssemblyId: id })
-        if (latest.sys.publishedVersion) {
-          await client.dataAssembly.unpublish({
-            dataAssemblyId: id,
-            version: latest.sys.version,
-          })
-        }
-        await client.dataAssembly.delete({ dataAssemblyId: id })
-      } catch {
-        // entity already deleted or not found
-      }
-    }
-
-    await timeoutToCalmRateLimiting()
-  })
-
-  it('full lifecycle: create → get → update → getMany → publish → getPublished → getManyPublished → unpublish → delete', async () => {
-    // --- Create ---
     // DataAssembly requires sys.type and sys.dataType in the create payload
     // because the API uses these to define the assembly's return schema
     const created = await client.dataAssembly.create(
@@ -62,98 +41,135 @@ describe('DataAssembly Integration', () => {
         },
       },
     )
-    createdIds.push(created.sys.id)
+    dataAssemblyId = created.sys.id
+    createdIds.push(dataAssemblyId)
+  })
 
-    expect(created.sys.id).toBeDefined()
-    expect(created.sys.type).toBe('DataAssembly')
-    expect(created.sys.version).toBeGreaterThanOrEqual(1)
-    expect(created.sys.createdAt).toBeDefined()
-    expect(created.sys.createdBy).toBeDefined()
-    expect(created.sys.dataType).toBeDefined()
-    expect(created.name).toBe(`Integration Test DataAssembly ${testRunId}`)
+  afterAll(async () => {
+    for (const id of createdIds) {
+      try {
+        const latest = await client.dataAssembly.get({ dataAssemblyId: id })
+        if (latest.sys.publishedVersion) {
+          await client.dataAssembly.unpublish({
+            dataAssemblyId: id,
+            version: latest.sys.version,
+          })
+        }
+        await client.dataAssembly.delete({ dataAssemblyId: id })
+      } catch {
+        // entity already deleted or not found
+      }
+    }
 
-    // --- Get ---
-    const fetched = await client.dataAssembly.get({ dataAssemblyId: created.sys.id })
+    await timeoutToCalmRateLimiting()
+  })
 
-    expect(fetched.sys.id).toBe(created.sys.id)
+  it('creates a data assembly with correct sys fields', async () => {
+    const da = await client.dataAssembly.get({ dataAssemblyId: dataAssemblyId })
+
+    expect(da.sys.id).toBeDefined()
+    expect(da.sys.type).toBe('DataAssembly')
+    expect(da.sys.version).toBeGreaterThanOrEqual(1)
+    expect(da.sys.createdAt).toBeDefined()
+    expect(da.sys.createdBy).toBeDefined()
+    expect(da.sys.dataType).toBeDefined()
+    expect(da.name).toBe(`Integration Test DataAssembly ${testRunId}`)
+    expect(da.description).toBe('Created by integration test')
+  })
+
+  it('gets a data assembly by ID', async () => {
+    const fetched = await client.dataAssembly.get({ dataAssemblyId: dataAssemblyId })
+
+    expect(fetched.sys.id).toBe(dataAssemblyId)
     expect(fetched.sys.type).toBe('DataAssembly')
     expect(fetched.resolvers).toBeDefined()
     expect(fetched.return).toBeDefined()
+  })
 
-    // --- Update ---
+  it('updates a data assembly', async () => {
+    const current = await client.dataAssembly.get({ dataAssemblyId: dataAssemblyId })
+
     const updated = await client.dataAssembly.update(
-      { dataAssemblyId: fetched.sys.id },
+      { dataAssemblyId: dataAssemblyId },
       {
-        ...fetched,
+        ...current,
         sys: {
-          id: fetched.sys.id,
+          id: current.sys.id,
           type: 'DataAssembly' as const,
-          version: fetched.sys.version,
-          dataType: fetched.sys.dataType,
+          version: current.sys.version,
+          dataType: current.sys.dataType,
         },
         name: `Integration Test DataAssembly Updated ${testRunId}`,
       },
     )
 
     expect(updated.name).toBe(`Integration Test DataAssembly Updated ${testRunId}`)
-    expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+  })
 
-    // --- GetMany (cursor pagination) ---
+  it('lists data assemblies with cursor pagination', async () => {
     const collection = await client.dataAssembly.getMany({ query: { limit: 10 } })
 
     expect(collection.sys).toBeDefined()
     expect(collection.pages).toBeDefined()
     expect(collection.items).toBeDefined()
     expect(Array.isArray(collection.items)).toBe(true)
-    const found = collection.items.find((item) => item.sys.id === created.sys.id)
-    expect(found).toBeDefined()
 
-    // --- Publish ---
+    const found = collection.items.find((item) => item.sys.id === dataAssemblyId)
+    expect(found).toBeDefined()
+  })
+
+  it('publishes a data assembly', async () => {
+    const current = await client.dataAssembly.get({ dataAssemblyId: dataAssemblyId })
+
     const published = await client.dataAssembly.publish({
-      dataAssemblyId: updated.sys.id,
-      version: updated.sys.version,
+      dataAssemblyId: dataAssemblyId,
+      version: current.sys.version,
     })
 
     expect(published.sys.publishedVersion).toBeDefined()
     expect(published.sys.publishedAt).toBeDefined()
+  })
 
-    // --- GetPublished ---
-    const fetchedPublished = await client.dataAssembly.getPublished({
-      dataAssemblyId: created.sys.id,
-    })
+  it('gets a published data assembly by ID', async () => {
+    const fetched = await client.dataAssembly.getPublished({ dataAssemblyId: dataAssemblyId })
 
-    expect(fetchedPublished.sys.id).toBe(created.sys.id)
-    expect(fetchedPublished.sys.type).toBe('DataAssembly')
-    expect(fetchedPublished.name).toBe(`Integration Test DataAssembly Updated ${testRunId}`)
+    expect(fetched.sys.id).toBe(dataAssemblyId)
+    expect(fetched.sys.type).toBe('DataAssembly')
+  })
 
-    // --- GetManyPublished ---
-    const publishedCollection = await client.dataAssembly.getManyPublished({
-      query: { limit: 10 },
-    })
+  it('lists published data assemblies', async () => {
+    const collection = await client.dataAssembly.getManyPublished({ query: { limit: 10 } })
 
-    expect(publishedCollection.sys).toBeDefined()
-    expect(publishedCollection.pages).toBeDefined()
-    expect(publishedCollection.items).toBeDefined()
-    const foundPublished = publishedCollection.items.find(
-      (item) => item.sys.id === created.sys.id,
-    )
-    expect(foundPublished).toBeDefined()
+    expect(collection.sys).toBeDefined()
+    expect(collection.pages).toBeDefined()
+    expect(collection.items).toBeDefined()
 
-    // --- Unpublish ---
+    const found = collection.items.find((item) => item.sys.id === dataAssemblyId)
+    expect(found).toBeDefined()
+  })
+
+  it('unpublishes a data assembly', async () => {
+    const current = await client.dataAssembly.get({ dataAssemblyId: dataAssemblyId })
+
     const unpublished = await client.dataAssembly.unpublish({
-      dataAssemblyId: published.sys.id,
-      version: published.sys.version,
+      dataAssemblyId: dataAssemblyId,
+      version: current.sys.version,
     })
 
     expect(unpublished.sys.publishedVersion).toBeUndefined()
+  })
 
-    // --- Delete ---
-    await client.dataAssembly.delete({ dataAssemblyId: unpublished.sys.id })
+  it('deletes a data assembly', async () => {
+    const current = await client.dataAssembly.get({ dataAssemblyId: dataAssemblyId })
+    expect(current.sys.publishedVersion).toBeUndefined()
+
+    await client.dataAssembly.delete({ dataAssemblyId: dataAssemblyId })
 
     await expect(
-      client.dataAssembly.get({ dataAssemblyId: unpublished.sys.id }),
+      client.dataAssembly.get({ dataAssemblyId: dataAssemblyId }),
     ).rejects.toThrow()
 
-    createdIds.splice(createdIds.indexOf(created.sys.id), 1)
+    createdIds.splice(createdIds.indexOf(dataAssemblyId), 1)
   })
 })

--- a/test/integration/data-assembly-integration.test.ts
+++ b/test/integration/data-assembly-integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
-import type { DataAssemblyProps } from '../../lib/entities/data-assembly'
+import { testRunId, sweepStaleExoEntities } from './utils/exo.utils'
 
 describe('DataAssembly Integration', () => {
   const client = initPlainClient({
@@ -9,26 +9,46 @@ describe('DataAssembly Integration', () => {
     environmentId: TestDefaults.environmentId,
   })
 
-  const createdDataAssemblyIds: string[] = []
-  let dataAssembly: DataAssemblyProps
+  const createdIds: string[] = []
 
   beforeAll(async () => {
-    dataAssembly = await client.dataAssembly.create(
+    await sweepStaleExoEntities(client)
+  })
+
+  afterAll(async () => {
+    for (const id of createdIds) {
+      try {
+        const latest = await client.dataAssembly.get({ dataAssemblyId: id })
+        if (latest.sys.publishedVersion) {
+          await client.dataAssembly.unpublish({
+            dataAssemblyId: id,
+            version: latest.sys.version,
+          })
+        }
+        await client.dataAssembly.delete({ dataAssemblyId: id })
+      } catch {
+        // entity already deleted or not found
+      }
+    }
+
+    await timeoutToCalmRateLimiting()
+  })
+
+  it('full lifecycle: create → get → update → getMany → publish → getPublished → getManyPublished → unpublish → delete', async () => {
+    // --- Create ---
+    // DataAssembly requires sys.type and sys.dataType in the create payload
+    // because the API uses these to define the assembly's return schema
+    const created = await client.dataAssembly.create(
       {},
       {
         sys: {
           type: 'DataAssembly',
           dataType: [
-            {
-              id: 'title',
-              name: 'Title',
-              type: 'String',
-              required: false,
-            },
+            { id: 'title', name: 'Title', type: 'String', required: false },
           ],
         },
         metadata: { tags: [] },
-        name: 'Integration Test DataAssembly',
+        name: `${testRunId} DataAssembly`,
         description: 'Created by integration test',
         parameters: {},
         resolvers: {
@@ -42,142 +62,98 @@ describe('DataAssembly Integration', () => {
         },
       },
     )
-    createdDataAssemblyIds.push(dataAssembly.sys.id)
-  })
+    createdIds.push(created.sys.id)
 
-  afterAll(async () => {
-    for (const id of createdDataAssemblyIds) {
-      try {
-        const latest = await client.dataAssembly.get({ dataAssemblyId: id })
-        if (latest.sys.publishedVersion) {
-          await client.dataAssembly.unpublish({
-            dataAssemblyId: id,
-            version: latest.sys.version,
-          })
-          await client.dataAssembly.delete({ dataAssemblyId: id })
-        } else {
-          await client.dataAssembly.delete({ dataAssemblyId: id })
-        }
-      } catch {
-        // entity already deleted or not found
-      }
-    }
+    expect(created.sys.id).toBeDefined()
+    expect(created.sys.type).toBe('DataAssembly')
+    expect(created.sys.version).toBeGreaterThanOrEqual(1)
+    expect(created.sys.createdAt).toBeDefined()
+    expect(created.sys.createdBy).toBeDefined()
+    expect(created.sys.dataType).toBeDefined()
+    expect(created.name).toBe(`${testRunId} DataAssembly`)
 
-    await timeoutToCalmRateLimiting()
-  })
+    // --- Get ---
+    const fetched = await client.dataAssembly.get({ dataAssemblyId: created.sys.id })
 
-  it('creates a data assembly with correct sys fields', () => {
-    expect(dataAssembly.sys.id).toBeDefined()
-    expect(dataAssembly.sys.type).toBe('DataAssembly')
-    expect(dataAssembly.sys.version).toBeGreaterThanOrEqual(1)
-    expect(dataAssembly.sys.createdAt).toBeDefined()
-    expect(dataAssembly.sys.createdBy).toBeDefined()
-    expect(dataAssembly.sys.dataType).toBeDefined()
-    expect(dataAssembly.name).toBe('Integration Test DataAssembly')
-    expect(dataAssembly.description).toBe('Created by integration test')
-  })
-
-  it('gets a data assembly by ID', async () => {
-    const fetched = await client.dataAssembly.get({
-      dataAssemblyId: dataAssembly.sys.id,
-    })
-
-    expect(fetched.sys.id).toBe(dataAssembly.sys.id)
+    expect(fetched.sys.id).toBe(created.sys.id)
     expect(fetched.sys.type).toBe('DataAssembly')
-    expect(fetched.name).toBe('Integration Test DataAssembly')
     expect(fetched.resolvers).toBeDefined()
     expect(fetched.return).toBeDefined()
-  })
 
-  it('updates a data assembly', async () => {
-    const current = await client.dataAssembly.get({
-      dataAssemblyId: dataAssembly.sys.id,
-    })
-
+    // --- Update ---
     const updated = await client.dataAssembly.update(
-      { dataAssemblyId: current.sys.id },
+      { dataAssemblyId: fetched.sys.id },
       {
-        ...current,
+        ...fetched,
         sys: {
-          id: current.sys.id,
-          type: 'DataAssembly',
-          version: current.sys.version,
-          dataType: current.sys.dataType,
+          id: fetched.sys.id,
+          type: 'DataAssembly' as const,
+          version: fetched.sys.version,
+          dataType: fetched.sys.dataType,
         },
-        name: 'Updated Integration Test DataAssembly',
+        name: `${testRunId} DataAssembly Updated`,
       },
     )
 
-    expect(updated.name).toBe('Updated Integration Test DataAssembly')
-    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
-    dataAssembly = updated
-  })
+    expect(updated.name).toBe(`${testRunId} DataAssembly Updated`)
+    expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
 
-  it('lists data assemblies with cursor pagination', async () => {
-    const collection = await client.dataAssembly.getMany({
-      query: { limit: 10 },
-    })
+    // --- GetMany (cursor pagination) ---
+    const collection = await client.dataAssembly.getMany({ query: { limit: 10 } })
 
     expect(collection.sys).toBeDefined()
     expect(collection.pages).toBeDefined()
     expect(collection.items).toBeDefined()
     expect(Array.isArray(collection.items)).toBe(true)
-    expect(collection.items.length).toBeGreaterThanOrEqual(1)
-
-    const found = collection.items.find((item) => item.sys.id === dataAssembly.sys.id)
+    const found = collection.items.find((item) => item.sys.id === created.sys.id)
     expect(found).toBeDefined()
-  })
 
-  it('publishes a data assembly', async () => {
-    const current = await client.dataAssembly.get({
-      dataAssemblyId: dataAssembly.sys.id,
-    })
-
+    // --- Publish ---
     const published = await client.dataAssembly.publish({
-      dataAssemblyId: current.sys.id,
-      version: current.sys.version,
+      dataAssemblyId: updated.sys.id,
+      version: updated.sys.version,
     })
 
     expect(published.sys.publishedVersion).toBeDefined()
     expect(published.sys.publishedAt).toBeDefined()
-    dataAssembly = published
-  })
 
-  it('gets a published data assembly by ID', async () => {
-    const fetched = await client.dataAssembly.getPublished({
-      dataAssemblyId: dataAssembly.sys.id,
+    // --- GetPublished ---
+    const fetchedPublished = await client.dataAssembly.getPublished({
+      dataAssemblyId: created.sys.id,
     })
 
-    expect(fetched.sys.id).toBe(dataAssembly.sys.id)
-    expect(fetched.sys.type).toBe('DataAssembly')
-    expect(fetched.name).toBe('Updated Integration Test DataAssembly')
-  })
+    expect(fetchedPublished.sys.id).toBe(created.sys.id)
+    expect(fetchedPublished.sys.type).toBe('DataAssembly')
+    expect(fetchedPublished.name).toBe(`${testRunId} DataAssembly Updated`)
 
-  it('lists published data assemblies', async () => {
-    const collection = await client.dataAssembly.getManyPublished({
+    // --- GetManyPublished ---
+    const publishedCollection = await client.dataAssembly.getManyPublished({
       query: { limit: 10 },
     })
 
-    expect(collection.sys).toBeDefined()
-    expect(collection.pages).toBeDefined()
-    expect(collection.items).toBeDefined()
-    expect(Array.isArray(collection.items)).toBe(true)
+    expect(publishedCollection.sys).toBeDefined()
+    expect(publishedCollection.pages).toBeDefined()
+    expect(publishedCollection.items).toBeDefined()
+    const foundPublished = publishedCollection.items.find(
+      (item) => item.sys.id === created.sys.id,
+    )
+    expect(foundPublished).toBeDefined()
 
-    const found = collection.items.find((item) => item.sys.id === dataAssembly.sys.id)
-    expect(found).toBeDefined()
-  })
-
-  it('unpublishes a data assembly', async () => {
-    const current = await client.dataAssembly.get({
-      dataAssemblyId: dataAssembly.sys.id,
-    })
-
+    // --- Unpublish ---
     const unpublished = await client.dataAssembly.unpublish({
-      dataAssemblyId: current.sys.id,
-      version: current.sys.version,
+      dataAssemblyId: published.sys.id,
+      version: published.sys.version,
     })
 
     expect(unpublished.sys.publishedVersion).toBeUndefined()
-    dataAssembly = unpublished
+
+    // --- Delete ---
+    await client.dataAssembly.delete({ dataAssemblyId: unpublished.sys.id })
+
+    await expect(
+      client.dataAssembly.get({ dataAssemblyId: unpublished.sys.id }),
+    ).rejects.toThrow()
+
+    createdIds.splice(createdIds.indexOf(created.sys.id), 1)
   })
 })

--- a/test/integration/data-assembly-integration.test.ts
+++ b/test/integration/data-assembly-integration.test.ts
@@ -3,7 +3,7 @@ import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
 import { testName, sweepStaleExoEntities } from './utils/exo.utils'
 
-describe('DataAssembly Integration', () => {
+describe('DataAssembly Integration', { sequential: true }, () => {
   const client = initPlainClient({
     spaceId: TestDefaults.spaceId,
     environmentId: TestDefaults.environmentId,
@@ -53,7 +53,7 @@ describe('DataAssembly Integration', () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('creates a data assembly with correct sys fields', async () => {
+  it('has correct sys fields after creation', async () => {
     const da = await client.dataAssembly.get({ dataAssemblyId: dataAssemblyId })
 
     expect(da.sys.id).toBeDefined()
@@ -78,6 +78,7 @@ describe('DataAssembly Integration', () => {
   it('updates a data assembly', async () => {
     const current = await client.dataAssembly.get({ dataAssemblyId: dataAssemblyId })
 
+    // Update types require minimal sys — full entity sys is not assignable
     const updated = await client.dataAssembly.update(
       { dataAssemblyId: dataAssemblyId },
       {
@@ -99,10 +100,8 @@ describe('DataAssembly Integration', () => {
   it('lists data assemblies with cursor pagination', async () => {
     const collection = await client.dataAssembly.getMany({ query: { limit: 10 } })
 
-    expect(collection.sys).toBeDefined()
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
     expect(collection.pages).toBeDefined()
-    expect(collection.items).toBeDefined()
-    expect(Array.isArray(collection.items)).toBe(true)
 
     const found = collection.items.find((item) => item.sys.id === dataAssemblyId)
     expect(found).toBeDefined()
@@ -130,9 +129,8 @@ describe('DataAssembly Integration', () => {
   it('lists published data assemblies', async () => {
     const collection = await client.dataAssembly.getManyPublished({ query: { limit: 10 } })
 
-    expect(collection.sys).toBeDefined()
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
     expect(collection.pages).toBeDefined()
-    expect(collection.items).toBeDefined()
 
     const found = collection.items.find((item) => item.sys.id === dataAssemblyId)
     expect(found).toBeDefined()
@@ -149,6 +147,26 @@ describe('DataAssembly Integration', () => {
     expect(unpublished.sys.publishedVersion).toBeUndefined()
   })
 
+  it('rejects delete on a published entity', async () => {
+    const current = await client.dataAssembly.get({ dataAssemblyId: dataAssemblyId })
+    if (!current.sys.publishedVersion) {
+      await client.dataAssembly.publish({
+        dataAssemblyId: dataAssemblyId,
+        version: current.sys.version,
+      })
+    }
+
+    await expect(
+      client.dataAssembly.delete({ dataAssemblyId: dataAssemblyId }),
+    ).rejects.toThrow()
+
+    const latest = await client.dataAssembly.get({ dataAssemblyId: dataAssemblyId })
+    await client.dataAssembly.unpublish({
+      dataAssemblyId: dataAssemblyId,
+      version: latest.sys.version,
+    })
+  })
+
   it('deletes a data assembly', async () => {
     const current = await client.dataAssembly.get({ dataAssemblyId: dataAssemblyId })
     expect(current.sys.publishedVersion).toBeUndefined()
@@ -157,6 +175,7 @@ describe('DataAssembly Integration', () => {
 
     await expect(client.dataAssembly.get({ dataAssemblyId: dataAssemblyId })).rejects.toThrow()
 
-    createdIds.splice(createdIds.indexOf(dataAssemblyId), 1)
+    const idx = createdIds.indexOf(dataAssemblyId)
+    if (idx !== -1) createdIds.splice(idx, 1)
   })
 })

--- a/test/integration/data-assembly-integration.test.ts
+++ b/test/integration/data-assembly-integration.test.ts
@@ -15,8 +15,6 @@ describe('DataAssembly Integration', () => {
   beforeAll(async () => {
     await sweepStaleExoEntities(client)
 
-    // DataAssembly requires sys.type and sys.dataType in the create payload
-    // because the API uses these to define the assembly's return schema
     const created = await client.dataAssembly.create(
       {},
       {
@@ -30,15 +28,8 @@ describe('DataAssembly Integration', () => {
         name: testName('DataAssembly'),
         description: 'Created by integration test',
         parameters: {},
-        resolvers: {
-          entries: {
-            source: 'Contentful:GraphQL',
-            query: '{ entryCollection { items { sys { id } } } }',
-          },
-        },
-        return: {
-          title: '$resolvers.entries.data.entryCollection.items[0].sys.id',
-        },
+        resolvers: {},
+        return: {},
       },
     )
     dataAssemblyId = created.sys.id

--- a/test/integration/data-assembly-integration.test.ts
+++ b/test/integration/data-assembly-integration.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
+import { TestDefaults } from '../defaults'
+import type { DataAssemblyProps } from '../../lib/entities/data-assembly'
+
+describe('DataAssembly Integration', () => {
+  const client = initPlainClient({
+    spaceId: TestDefaults.spaceId,
+    environmentId: TestDefaults.environmentId,
+  })
+
+  let dataAssembly: DataAssemblyProps
+
+  beforeAll(async () => {
+    dataAssembly = await client.dataAssembly.create(
+      {},
+      {
+        sys: {
+          type: 'DataAssembly',
+          dataType: [
+            {
+              id: 'title',
+              name: 'Title',
+              type: 'String',
+              required: false,
+            },
+          ],
+        },
+        metadata: { tags: [] },
+        name: 'Integration Test DataAssembly',
+        description: 'Created by integration test',
+        parameters: {},
+        resolvers: {
+          entries: {
+            source: 'Contentful:GraphQL',
+            query: '{ entryCollection { items { sys { id } } } }',
+          },
+        },
+        return: {
+          title: '$resolvers.entries.data.entryCollection.items[0].sys.id',
+        },
+      },
+    )
+  })
+
+  afterAll(async () => {
+    try {
+      const latest = await client.dataAssembly.get({
+        dataAssemblyId: dataAssembly.sys.id,
+      })
+      if (latest.sys.publishedVersion) {
+        await client.dataAssembly.unpublish({
+          dataAssemblyId: latest.sys.id,
+          version: latest.sys.version,
+        })
+        const unpublished = await client.dataAssembly.get({
+          dataAssemblyId: latest.sys.id,
+        })
+        await client.dataAssembly.delete({
+          dataAssemblyId: unpublished.sys.id,
+        })
+      } else {
+        await client.dataAssembly.delete({
+          dataAssemblyId: latest.sys.id,
+        })
+      }
+    } catch {
+      // already cleaned up
+    }
+
+    await timeoutToCalmRateLimiting()
+  })
+
+  it('creates a data assembly with correct sys fields', () => {
+    expect(dataAssembly.sys.id).toBeDefined()
+    expect(dataAssembly.sys.type).toBe('DataAssembly')
+    expect(dataAssembly.sys.version).toBeGreaterThanOrEqual(1)
+    expect(dataAssembly.sys.createdAt).toBeDefined()
+    expect(dataAssembly.sys.createdBy).toBeDefined()
+    expect(dataAssembly.sys.dataType).toBeDefined()
+    expect(dataAssembly.name).toBe('Integration Test DataAssembly')
+    expect(dataAssembly.description).toBe('Created by integration test')
+  })
+
+  it('gets a data assembly by ID', async () => {
+    const fetched = await client.dataAssembly.get({
+      dataAssemblyId: dataAssembly.sys.id,
+    })
+
+    expect(fetched.sys.id).toBe(dataAssembly.sys.id)
+    expect(fetched.sys.type).toBe('DataAssembly')
+    expect(fetched.name).toBe('Integration Test DataAssembly')
+    expect(fetched.resolvers).toBeDefined()
+    expect(fetched.return).toBeDefined()
+  })
+
+  it('updates a data assembly', async () => {
+    const current = await client.dataAssembly.get({
+      dataAssemblyId: dataAssembly.sys.id,
+    })
+
+    const updated = await client.dataAssembly.update(
+      { dataAssemblyId: current.sys.id },
+      {
+        ...current,
+        sys: {
+          id: current.sys.id,
+          type: 'DataAssembly',
+          version: current.sys.version,
+          dataType: current.sys.dataType,
+        },
+        name: 'Updated Integration Test DataAssembly',
+      },
+    )
+
+    expect(updated.name).toBe('Updated Integration Test DataAssembly')
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+    dataAssembly = updated
+  })
+
+  it('lists data assemblies with cursor pagination', async () => {
+    const collection = await client.dataAssembly.getMany({
+      query: { limit: 10 },
+    })
+
+    expect(collection.sys).toBeDefined()
+    expect(collection.pages).toBeDefined()
+    expect(collection.items).toBeDefined()
+    expect(Array.isArray(collection.items)).toBe(true)
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
+
+    const found = collection.items.find((item) => item.sys.id === dataAssembly.sys.id)
+    expect(found).toBeDefined()
+  })
+
+  it('publishes a data assembly', async () => {
+    const current = await client.dataAssembly.get({
+      dataAssemblyId: dataAssembly.sys.id,
+    })
+
+    const published = await client.dataAssembly.publish({
+      dataAssemblyId: current.sys.id,
+      version: current.sys.version,
+    })
+
+    expect(published.sys.publishedVersion).toBeDefined()
+    expect(published.sys.publishedAt).toBeDefined()
+    dataAssembly = published
+  })
+
+  it('gets a published data assembly by ID', async () => {
+    const fetched = await client.dataAssembly.getPublished({
+      dataAssemblyId: dataAssembly.sys.id,
+    })
+
+    expect(fetched.sys.id).toBe(dataAssembly.sys.id)
+    expect(fetched.sys.type).toBe('DataAssembly')
+    expect(fetched.name).toBe('Updated Integration Test DataAssembly')
+  })
+
+  it('lists published data assemblies', async () => {
+    const collection = await client.dataAssembly.getManyPublished({
+      query: { limit: 10 },
+    })
+
+    expect(collection.sys).toBeDefined()
+    expect(collection.pages).toBeDefined()
+    expect(collection.items).toBeDefined()
+    expect(Array.isArray(collection.items)).toBe(true)
+
+    const found = collection.items.find((item) => item.sys.id === dataAssembly.sys.id)
+    expect(found).toBeDefined()
+  })
+
+  it('unpublishes a data assembly', async () => {
+    const current = await client.dataAssembly.get({
+      dataAssemblyId: dataAssembly.sys.id,
+    })
+
+    const unpublished = await client.dataAssembly.unpublish({
+      dataAssemblyId: current.sys.id,
+      version: current.sys.version,
+    })
+
+    expect(unpublished.sys.publishedVersion).toBeUndefined()
+    dataAssembly = unpublished
+  })
+})

--- a/test/integration/data-assembly-integration.test.ts
+++ b/test/integration/data-assembly-integration.test.ts
@@ -48,7 +48,7 @@ describe('DataAssembly Integration', () => {
           ],
         },
         metadata: { tags: [] },
-        name: `${testRunId} DataAssembly`,
+        name: `Integration Test DataAssembly [${testRunId}]`,
         description: 'Created by integration test',
         parameters: {},
         resolvers: {
@@ -70,7 +70,7 @@ describe('DataAssembly Integration', () => {
     expect(created.sys.createdAt).toBeDefined()
     expect(created.sys.createdBy).toBeDefined()
     expect(created.sys.dataType).toBeDefined()
-    expect(created.name).toBe(`${testRunId} DataAssembly`)
+    expect(created.name).toBe(`Integration Test DataAssembly [${testRunId}]`)
 
     // --- Get ---
     const fetched = await client.dataAssembly.get({ dataAssemblyId: created.sys.id })
@@ -91,11 +91,11 @@ describe('DataAssembly Integration', () => {
           version: fetched.sys.version,
           dataType: fetched.sys.dataType,
         },
-        name: `${testRunId} DataAssembly Updated`,
+        name: `Integration Test DataAssembly Updated [${testRunId}]`,
       },
     )
 
-    expect(updated.name).toBe(`${testRunId} DataAssembly Updated`)
+    expect(updated.name).toBe(`Integration Test DataAssembly Updated [${testRunId}]`)
     expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
 
     // --- GetMany (cursor pagination) ---
@@ -124,7 +124,7 @@ describe('DataAssembly Integration', () => {
 
     expect(fetchedPublished.sys.id).toBe(created.sys.id)
     expect(fetchedPublished.sys.type).toBe('DataAssembly')
-    expect(fetchedPublished.name).toBe(`${testRunId} DataAssembly Updated`)
+    expect(fetchedPublished.name).toBe(`Integration Test DataAssembly Updated [${testRunId}]`)
 
     // --- GetManyPublished ---
     const publishedCollection = await client.dataAssembly.getManyPublished({

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
-import { testRunId, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
+import { testName, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
 
 describe('Experience Integration', () => {
   const client = initPlainClient({
@@ -20,7 +20,7 @@ describe('Experience Integration', () => {
     const ct = await client.componentType.create(
       {},
       {
-        name: `Integration Test CT for Experience ${testRunId}`,
+        name: testName('CT for Experience'),
         description: 'Backing component type for experience integration test',
         viewports: [testViewport],
         contentProperties: [],
@@ -39,7 +39,7 @@ describe('Experience Integration', () => {
     const exp = await client.experience.create(
       {},
       {
-        name: `Integration Test Experience ${testRunId}`,
+        name: testName('Experience'),
         description: 'Created by integration test',
         componentTypeId: componentTypeId,
         viewports: [testViewport],
@@ -97,7 +97,7 @@ describe('Experience Integration', () => {
     expect(exp.sys.createdBy).toBeDefined()
     expect(exp.sys.componentType).toBeDefined()
     expect(exp.sys.componentType!.sys.id).toBe(componentTypeId)
-    expect(exp.name).toBe(`Integration Test Experience ${testRunId}`)
+    expect(exp.name).toBe(testName('Experience'))
   })
 
   it('gets an experience by ID', async () => {
@@ -112,10 +112,10 @@ describe('Experience Integration', () => {
 
     const updated = await client.experience.update(
       { experienceId: experienceId },
-      { ...current, name: `Integration Test Experience Updated ${testRunId}` },
+      { ...current, name: testName('Experience Updated') },
     )
 
-    expect(updated.name).toBe(`Integration Test Experience Updated ${testRunId}`)
+    expect(updated.name).toBe(testName('Experience Updated'))
     expect(updated.sys.version).toBeGreaterThan(current.sys.version)
   })
 

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -3,7 +3,7 @@ import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
 import { testName, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
 
-describe('Experience Integration', () => {
+describe('Experience Integration', { sequential: true }, () => {
   const client = initPlainClient({
     spaceId: TestDefaults.spaceId,
     environmentId: TestDefaults.environmentId,
@@ -87,7 +87,7 @@ describe('Experience Integration', () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('creates an experience with correct sys fields', async () => {
+  it('has correct sys fields after creation', async () => {
     const exp = await client.experience.get({ experienceId: experienceId })
 
     expect(exp.sys.id).toBeDefined()
@@ -123,10 +123,8 @@ describe('Experience Integration', () => {
   it('lists experiences with cursor pagination', async () => {
     const collection = await client.experience.getMany({ query: { limit: 10 } })
 
-    expect(collection.sys).toBeDefined()
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
     expect(collection.pages).toBeDefined()
-    expect(collection.items).toBeDefined()
-    expect(Array.isArray(collection.items)).toBe(true)
 
     const found = collection.items.find((item) => item.sys.id === experienceId)
     expect(found).toBeDefined()
@@ -166,6 +164,26 @@ describe('Experience Integration', () => {
     expect(unpublished.sys.publishedVersion).toBeUndefined()
   })
 
+  it('rejects delete on a published entity', async () => {
+    const current = await client.experience.get({ experienceId: experienceId })
+    if (!current.sys.publishedVersion) {
+      await client.experience.publish({
+        experienceId: experienceId,
+        version: current.sys.version,
+      })
+    }
+
+    await expect(
+      client.experience.delete({ experienceId: experienceId }),
+    ).rejects.toThrow()
+
+    const latest = await client.experience.get({ experienceId: experienceId })
+    await client.experience.unpublish({
+      experienceId: experienceId,
+      version: latest.sys.version,
+    })
+  })
+
   it('deletes an experience', async () => {
     const current = await client.experience.get({ experienceId: experienceId })
     expect(current.sys.publishedVersion).toBeUndefined()
@@ -174,6 +192,7 @@ describe('Experience Integration', () => {
 
     await expect(client.experience.get({ experienceId: experienceId })).rejects.toThrow()
 
-    createdExperienceIds.splice(createdExperienceIds.indexOf(experienceId), 1)
+    const idx = createdExperienceIds.indexOf(experienceId)
+    if (idx !== -1) createdExperienceIds.splice(idx, 1)
   })
 })

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -10,30 +10,31 @@ describe('Experience Integration', () => {
   })
 
   const createdExperienceIds: string[] = []
-  const createdComponentTypeIds: string[] = []
+  const createdTemplateIds: string[] = []
   let experienceId: string
-  let componentTypeId: string
+  let templateId: string
 
   beforeAll(async () => {
     await sweepStaleExoEntities(client)
 
-    const ct = await client.componentType.create(
+    // Experiences require a published Template
+    const tmpl = await client.template.create(
       {},
       {
-        name: testName('CT for Experience'),
-        description: 'Backing component type for experience integration test',
+        name: testName('Template for Experience'),
+        description: 'Backing template for experience integration test',
         viewports: [testViewport],
         contentProperties: [],
         designProperties: [],
         dimensionKeyMap: { designProperties: {} },
       },
     )
-    componentTypeId = ct.sys.id
-    createdComponentTypeIds.push(componentTypeId)
+    templateId = tmpl.sys.id
+    createdTemplateIds.push(templateId)
 
-    await client.componentType.publish({
-      componentTypeId: componentTypeId,
-      version: ct.sys.version,
+    await client.template.publish({
+      templateId: templateId,
+      version: tmpl.sys.version,
     })
 
     const exp = await client.experience.create(
@@ -41,7 +42,7 @@ describe('Experience Integration', () => {
       {
         name: testName('Experience'),
         description: 'Created by integration test',
-        componentTypeId: componentTypeId,
+        templateId: templateId,
         viewports: [testViewport],
         contentProperties: {},
         designProperties: {},
@@ -68,16 +69,16 @@ describe('Experience Integration', () => {
       }
     }
 
-    for (const id of createdComponentTypeIds) {
+    for (const id of createdTemplateIds) {
       try {
-        const latest = await client.componentType.get({ componentTypeId: id })
+        const latest = await client.template.get({ templateId: id })
         if (latest.sys.publishedVersion) {
-          await client.componentType.unpublish({
-            componentTypeId: id,
+          await client.template.unpublish({
+            templateId: id,
             version: latest.sys.version,
           })
         }
-        await client.componentType.delete({ componentTypeId: id })
+        await client.template.delete({ templateId: id })
       } catch {
         // entity already deleted or not found
       }
@@ -95,8 +96,8 @@ describe('Experience Integration', () => {
     expect(exp.sys.createdAt).toBeDefined()
     expect(exp.sys.updatedAt).toBeDefined()
     expect(exp.sys.createdBy).toBeDefined()
-    expect(exp.sys.componentType).toBeDefined()
-    expect(exp.sys.componentType!.sys.id).toBe(componentTypeId)
+    expect(exp.sys.template).toBeDefined()
+    expect(exp.sys.template!.sys.id).toBe(templateId)
     expect(exp.name).toBe(testName('Experience'))
   })
 

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -55,7 +55,7 @@ describe('Experience Integration', () => {
     let ct = await client.componentType.create(
       {},
       {
-        name: `Integration Test CT for Experience [${testRunId}]`,
+        name: `Integration Test CT for Experience ${testRunId}`,
         description: 'Backing component type for experience integration test',
         viewports: [testViewport],
         contentProperties: [],
@@ -74,7 +74,7 @@ describe('Experience Integration', () => {
     const created = await client.experience.create(
       {},
       {
-        name: `Integration Test Experience [${testRunId}]`,
+        name: `Integration Test Experience ${testRunId}`,
         description: 'Created by integration test',
         componentTypeId: ct.sys.id,
         viewports: [testViewport],
@@ -92,7 +92,7 @@ describe('Experience Integration', () => {
     expect(created.sys.createdBy).toBeDefined()
     expect(created.sys.componentType).toBeDefined()
     expect(created.sys.componentType!.sys.id).toBe(ct.sys.id)
-    expect(created.name).toBe(`Integration Test Experience [${testRunId}]`)
+    expect(created.name).toBe(`Integration Test Experience ${testRunId}`)
 
     // --- Get ---
     const fetched = await client.experience.get({ experienceId: created.sys.id })
@@ -103,10 +103,10 @@ describe('Experience Integration', () => {
     // --- Update ---
     const updated = await client.experience.update(
       { experienceId: fetched.sys.id },
-      { ...fetched, name: `Integration Test Experience Updated [${testRunId}]` },
+      { ...fetched, name: `Integration Test Experience Updated ${testRunId}` },
     )
 
-    expect(updated.name).toBe(`Integration Test Experience Updated [${testRunId}]`)
+    expect(updated.name).toBe(`Integration Test Experience Updated ${testRunId}`)
     expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
 
     // --- GetMany (cursor pagination) ---

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -10,11 +10,12 @@ describe('Experience Integration', () => {
     environmentId: TestDefaults.environmentId,
   })
 
+  const createdExperienceIds: string[] = []
+  const createdComponentTypeIds: string[] = []
   let componentType: ComponentTypeProps
   let experience: ExperienceProps
 
   beforeAll(async () => {
-    // Experiences require a published ComponentType
     componentType = await client.componentType.create(
       {},
       {
@@ -33,6 +34,7 @@ describe('Experience Integration', () => {
         dimensionKeyMap: { designProperties: {} },
       },
     )
+    createdComponentTypeIds.push(componentType.sys.id)
 
     componentType = await client.componentType.publish({
       componentTypeId: componentType.sys.id,
@@ -58,55 +60,43 @@ describe('Experience Integration', () => {
         dimensionKeyMap: { designProperties: {} },
       },
     )
+    createdExperienceIds.push(experience.sys.id)
   })
 
   afterAll(async () => {
-    try {
-      const latestExp = await client.experience.get({
-        experienceId: experience.sys.id,
-      })
-      if (latestExp.sys.publishedVersion) {
-        await client.experience.unpublish({
-          experienceId: latestExp.sys.id,
-          version: latestExp.sys.version,
-        })
-        const unpublishedExp = await client.experience.get({
-          experienceId: latestExp.sys.id,
-        })
-        await client.experience.delete({
-          experienceId: unpublishedExp.sys.id,
-        })
-      } else {
-        await client.experience.delete({
-          experienceId: latestExp.sys.id,
-        })
+    // Delete experiences first (they depend on component types)
+    for (const id of createdExperienceIds) {
+      try {
+        const latest = await client.experience.get({ experienceId: id })
+        if (latest.sys.publishedVersion) {
+          await client.experience.unpublish({
+            experienceId: id,
+            version: latest.sys.version,
+          })
+          await client.experience.delete({ experienceId: id })
+        } else {
+          await client.experience.delete({ experienceId: id })
+        }
+      } catch {
+        // entity already deleted or not found
       }
-    } catch {
-      // already cleaned up
     }
 
-    try {
-      const latestCt = await client.componentType.get({
-        componentTypeId: componentType.sys.id,
-      })
-      if (latestCt.sys.publishedVersion) {
-        await client.componentType.unpublish({
-          componentTypeId: latestCt.sys.id,
-          version: latestCt.sys.version,
-        })
-        const unpublishedCt = await client.componentType.get({
-          componentTypeId: latestCt.sys.id,
-        })
-        await client.componentType.delete({
-          componentTypeId: unpublishedCt.sys.id,
-        })
-      } else {
-        await client.componentType.delete({
-          componentTypeId: latestCt.sys.id,
-        })
+    for (const id of createdComponentTypeIds) {
+      try {
+        const latest = await client.componentType.get({ componentTypeId: id })
+        if (latest.sys.publishedVersion) {
+          await client.componentType.unpublish({
+            componentTypeId: id,
+            version: latest.sys.version,
+          })
+          await client.componentType.delete({ componentTypeId: id })
+        } else {
+          await client.componentType.delete({ componentTypeId: id })
+        }
+      } catch {
+        // entity already deleted or not found
       }
-    } catch {
-      // already cleaned up
     }
 
     await timeoutToCalmRateLimiting()

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -173,9 +173,7 @@ describe('Experience Integration', { sequential: true }, () => {
       })
     }
 
-    await expect(
-      client.experience.delete({ experienceId: experienceId }),
-    ).rejects.toThrow()
+    await expect(client.experience.delete({ experienceId: experienceId })).rejects.toThrow()
 
     const latest = await client.experience.get({ experienceId: experienceId })
     await client.experience.unpublish({

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -11,9 +11,45 @@ describe('Experience Integration', () => {
 
   const createdExperienceIds: string[] = []
   const createdComponentTypeIds: string[] = []
+  let experienceId: string
+  let componentTypeId: string
 
   beforeAll(async () => {
     await sweepStaleExoEntities(client)
+
+    const ct = await client.componentType.create(
+      {},
+      {
+        name: `Integration Test CT for Experience ${testRunId}`,
+        description: 'Backing component type for experience integration test',
+        viewports: [testViewport],
+        contentProperties: [],
+        designProperties: [],
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+    componentTypeId = ct.sys.id
+    createdComponentTypeIds.push(componentTypeId)
+
+    await client.componentType.publish({
+      componentTypeId: componentTypeId,
+      version: ct.sys.version,
+    })
+
+    const exp = await client.experience.create(
+      {},
+      {
+        name: `Integration Test Experience ${testRunId}`,
+        description: 'Created by integration test',
+        componentTypeId: componentTypeId,
+        viewports: [testViewport],
+        contentProperties: {},
+        designProperties: {},
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+    experienceId = exp.sys.id
+    createdExperienceIds.push(experienceId)
   })
 
   afterAll(async () => {
@@ -50,107 +86,95 @@ describe('Experience Integration', () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('full lifecycle: create → get → update → getMany → publish → locale publish → unpublish → delete', async () => {
-    // --- Setup: create and publish a backing ComponentType ---
-    let ct = await client.componentType.create(
-      {},
-      {
-        name: `Integration Test CT for Experience ${testRunId}`,
-        description: 'Backing component type for experience integration test',
-        viewports: [testViewport],
-        contentProperties: [],
-        designProperties: [],
-        dimensionKeyMap: { designProperties: {} },
-      },
-    )
-    createdComponentTypeIds.push(ct.sys.id)
+  it('creates an experience with correct sys fields', async () => {
+    const exp = await client.experience.get({ experienceId: experienceId })
 
-    ct = await client.componentType.publish({
-      componentTypeId: ct.sys.id,
-      version: ct.sys.version,
-    })
+    expect(exp.sys.id).toBeDefined()
+    expect(exp.sys.type).toBe('Experience')
+    expect(exp.sys.version).toBeGreaterThanOrEqual(1)
+    expect(exp.sys.createdAt).toBeDefined()
+    expect(exp.sys.updatedAt).toBeDefined()
+    expect(exp.sys.createdBy).toBeDefined()
+    expect(exp.sys.componentType).toBeDefined()
+    expect(exp.sys.componentType!.sys.id).toBe(componentTypeId)
+    expect(exp.name).toBe(`Integration Test Experience ${testRunId}`)
+  })
 
-    // --- Create ---
-    const created = await client.experience.create(
-      {},
-      {
-        name: `Integration Test Experience ${testRunId}`,
-        description: 'Created by integration test',
-        componentTypeId: ct.sys.id,
-        viewports: [testViewport],
-        contentProperties: {},
-        designProperties: {},
-        dimensionKeyMap: { designProperties: {} },
-      },
-    )
-    createdExperienceIds.push(created.sys.id)
+  it('gets an experience by ID', async () => {
+    const fetched = await client.experience.get({ experienceId: experienceId })
 
-    expect(created.sys.id).toBeDefined()
-    expect(created.sys.type).toBe('Experience')
-    expect(created.sys.version).toBeGreaterThanOrEqual(1)
-    expect(created.sys.createdAt).toBeDefined()
-    expect(created.sys.createdBy).toBeDefined()
-    expect(created.sys.componentType).toBeDefined()
-    expect(created.sys.componentType!.sys.id).toBe(ct.sys.id)
-    expect(created.name).toBe(`Integration Test Experience ${testRunId}`)
-
-    // --- Get ---
-    const fetched = await client.experience.get({ experienceId: created.sys.id })
-
-    expect(fetched.sys.id).toBe(created.sys.id)
+    expect(fetched.sys.id).toBe(experienceId)
     expect(fetched.sys.type).toBe('Experience')
+  })
 
-    // --- Update ---
+  it('updates an experience', async () => {
+    const current = await client.experience.get({ experienceId: experienceId })
+
     const updated = await client.experience.update(
-      { experienceId: fetched.sys.id },
-      { ...fetched, name: `Integration Test Experience Updated ${testRunId}` },
+      { experienceId: experienceId },
+      { ...current, name: `Integration Test Experience Updated ${testRunId}` },
     )
 
     expect(updated.name).toBe(`Integration Test Experience Updated ${testRunId}`)
-    expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+  })
 
-    // --- GetMany (cursor pagination) ---
+  it('lists experiences with cursor pagination', async () => {
     const collection = await client.experience.getMany({ query: { limit: 10 } })
 
     expect(collection.sys).toBeDefined()
     expect(collection.pages).toBeDefined()
     expect(collection.items).toBeDefined()
     expect(Array.isArray(collection.items)).toBe(true)
-    const found = collection.items.find((item) => item.sys.id === created.sys.id)
-    expect(found).toBeDefined()
 
-    // --- Publish (full — all locales) ---
+    const found = collection.items.find((item) => item.sys.id === experienceId)
+    expect(found).toBeDefined()
+  })
+
+  it('publishes an experience (full publish)', async () => {
+    const current = await client.experience.get({ experienceId: experienceId })
+
     const published = await client.experience.publish({
-      experienceId: updated.sys.id,
-      version: updated.sys.version,
+      experienceId: experienceId,
+      version: current.sys.version,
     })
 
     expect(published.sys.publishedVersion).toBeDefined()
     expect(published.sys.publishedAt).toBeDefined()
+  })
 
-    // --- Publish (locale-aware add) ---
-    const localePublished = await client.experience.publish(
-      { experienceId: published.sys.id, version: published.sys.version },
+  it('publishes an experience with locale-aware add', async () => {
+    const current = await client.experience.get({ experienceId: experienceId })
+
+    const published = await client.experience.publish(
+      { experienceId: experienceId, version: current.sys.version },
       { add: ['en-US'] },
     )
 
-    expect(localePublished.sys.publishedVersion).toBeDefined()
+    expect(published.sys.publishedVersion).toBeDefined()
+  })
 
-    // --- Unpublish ---
+  it('unpublishes an experience', async () => {
+    const current = await client.experience.get({ experienceId: experienceId })
+
     const unpublished = await client.experience.unpublish({
-      experienceId: localePublished.sys.id,
-      version: localePublished.sys.version,
+      experienceId: experienceId,
+      version: current.sys.version,
     })
 
     expect(unpublished.sys.publishedVersion).toBeUndefined()
+  })
 
-    // --- Delete ---
-    await client.experience.delete({ experienceId: unpublished.sys.id })
+  it('deletes an experience', async () => {
+    const current = await client.experience.get({ experienceId: experienceId })
+    expect(current.sys.publishedVersion).toBeUndefined()
+
+    await client.experience.delete({ experienceId: experienceId })
 
     await expect(
-      client.experience.get({ experienceId: unpublished.sys.id }),
+      client.experience.get({ experienceId: experienceId }),
     ).rejects.toThrow()
 
-    createdExperienceIds.splice(createdExperienceIds.indexOf(created.sys.id), 1)
+    createdExperienceIds.splice(createdExperienceIds.indexOf(experienceId), 1)
   })
 })

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
-import type { ComponentTypeProps } from '../../lib/entities/component-type'
-import type { ExperienceProps } from '../../lib/entities/experience'
+import { testRunId, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
 
 describe('Experience Integration', () => {
   const client = initPlainClient({
@@ -12,59 +11,12 @@ describe('Experience Integration', () => {
 
   const createdExperienceIds: string[] = []
   const createdComponentTypeIds: string[] = []
-  let componentType: ComponentTypeProps
-  let experience: ExperienceProps
 
   beforeAll(async () => {
-    componentType = await client.componentType.create(
-      {},
-      {
-        name: 'CT for Experience Test',
-        description: 'Backing component type for experience integration test',
-        viewports: [
-          {
-            id: 'desktop',
-            query: '(min-width: 1024px)',
-            displayName: 'Desktop',
-            previewSize: '100%',
-          },
-        ],
-        contentProperties: [],
-        designProperties: [],
-        dimensionKeyMap: { designProperties: {} },
-      },
-    )
-    createdComponentTypeIds.push(componentType.sys.id)
-
-    componentType = await client.componentType.publish({
-      componentTypeId: componentType.sys.id,
-      version: componentType.sys.version,
-    })
-
-    experience = await client.experience.create(
-      {},
-      {
-        name: 'Integration Test Experience',
-        description: 'Created by integration test',
-        componentTypeId: componentType.sys.id,
-        viewports: [
-          {
-            id: 'desktop',
-            query: '(min-width: 1024px)',
-            displayName: 'Desktop',
-            previewSize: '100%',
-          },
-        ],
-        contentProperties: {},
-        designProperties: {},
-        dimensionKeyMap: { designProperties: {} },
-      },
-    )
-    createdExperienceIds.push(experience.sys.id)
+    await sweepStaleExoEntities(client)
   })
 
   afterAll(async () => {
-    // Delete experiences first (they depend on component types)
     for (const id of createdExperienceIds) {
       try {
         const latest = await client.experience.get({ experienceId: id })
@@ -73,10 +25,8 @@ describe('Experience Integration', () => {
             experienceId: id,
             version: latest.sys.version,
           })
-          await client.experience.delete({ experienceId: id })
-        } else {
-          await client.experience.delete({ experienceId: id })
         }
+        await client.experience.delete({ experienceId: id })
       } catch {
         // entity already deleted or not found
       }
@@ -90,10 +40,8 @@ describe('Experience Integration', () => {
             componentTypeId: id,
             version: latest.sys.version,
           })
-          await client.componentType.delete({ componentTypeId: id })
-        } else {
-          await client.componentType.delete({ componentTypeId: id })
         }
+        await client.componentType.delete({ componentTypeId: id })
       } catch {
         // entity already deleted or not found
       }
@@ -102,104 +50,107 @@ describe('Experience Integration', () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('creates an experience with correct sys fields', () => {
-    expect(experience.sys.id).toBeDefined()
-    expect(experience.sys.type).toBe('Experience')
-    expect(experience.sys.version).toBeGreaterThanOrEqual(1)
-    expect(experience.sys.createdAt).toBeDefined()
-    expect(experience.sys.updatedAt).toBeDefined()
-    expect(experience.sys.createdBy).toBeDefined()
-    expect(experience.sys.componentType).toBeDefined()
-    expect(experience.sys.componentType!.sys.id).toBe(componentType.sys.id)
-    expect(experience.name).toBe('Integration Test Experience')
-  })
-
-  it('gets an experience by ID', async () => {
-    const fetched = await client.experience.get({
-      experienceId: experience.sys.id,
-    })
-
-    expect(fetched.sys.id).toBe(experience.sys.id)
-    expect(fetched.sys.type).toBe('Experience')
-    expect(fetched.name).toBe('Integration Test Experience')
-  })
-
-  it('updates an experience', async () => {
-    const current = await client.experience.get({
-      experienceId: experience.sys.id,
-    })
-
-    const updated = await client.experience.update(
-      { experienceId: current.sys.id },
+  it('full lifecycle: create → get → update → getMany → publish → locale publish → unpublish → delete', async () => {
+    // --- Setup: create and publish a backing ComponentType ---
+    let ct = await client.componentType.create(
+      {},
       {
-        ...current,
-        name: 'Updated Integration Test Experience',
+        name: `${testRunId} CT for Experience`,
+        description: 'Backing component type for experience integration test',
+        viewports: [testViewport],
+        contentProperties: [],
+        designProperties: [],
+        dimensionKeyMap: { designProperties: {} },
       },
     )
+    createdComponentTypeIds.push(ct.sys.id)
 
-    expect(updated.name).toBe('Updated Integration Test Experience')
-    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
-    experience = updated
-  })
-
-  it('lists experiences with cursor pagination', async () => {
-    const collection = await client.experience.getMany({
-      query: { limit: 10 },
+    ct = await client.componentType.publish({
+      componentTypeId: ct.sys.id,
+      version: ct.sys.version,
     })
+
+    // --- Create ---
+    const created = await client.experience.create(
+      {},
+      {
+        name: `${testRunId} Experience`,
+        description: 'Created by integration test',
+        componentTypeId: ct.sys.id,
+        viewports: [testViewport],
+        contentProperties: {},
+        designProperties: {},
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+    createdExperienceIds.push(created.sys.id)
+
+    expect(created.sys.id).toBeDefined()
+    expect(created.sys.type).toBe('Experience')
+    expect(created.sys.version).toBeGreaterThanOrEqual(1)
+    expect(created.sys.createdAt).toBeDefined()
+    expect(created.sys.createdBy).toBeDefined()
+    expect(created.sys.componentType).toBeDefined()
+    expect(created.sys.componentType!.sys.id).toBe(ct.sys.id)
+    expect(created.name).toBe(`${testRunId} Experience`)
+
+    // --- Get ---
+    const fetched = await client.experience.get({ experienceId: created.sys.id })
+
+    expect(fetched.sys.id).toBe(created.sys.id)
+    expect(fetched.sys.type).toBe('Experience')
+
+    // --- Update ---
+    const updated = await client.experience.update(
+      { experienceId: fetched.sys.id },
+      { ...fetched, name: `${testRunId} Experience Updated` },
+    )
+
+    expect(updated.name).toBe(`${testRunId} Experience Updated`)
+    expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
+
+    // --- GetMany (cursor pagination) ---
+    const collection = await client.experience.getMany({ query: { limit: 10 } })
 
     expect(collection.sys).toBeDefined()
     expect(collection.pages).toBeDefined()
     expect(collection.items).toBeDefined()
     expect(Array.isArray(collection.items)).toBe(true)
-    expect(collection.items.length).toBeGreaterThanOrEqual(1)
-
-    const found = collection.items.find((item) => item.sys.id === experience.sys.id)
+    const found = collection.items.find((item) => item.sys.id === created.sys.id)
     expect(found).toBeDefined()
-  })
 
-  it('publishes an experience (full publish)', async () => {
-    const current = await client.experience.get({
-      experienceId: experience.sys.id,
-    })
-
+    // --- Publish (full — all locales) ---
     const published = await client.experience.publish({
-      experienceId: current.sys.id,
-      version: current.sys.version,
+      experienceId: updated.sys.id,
+      version: updated.sys.version,
     })
 
     expect(published.sys.publishedVersion).toBeDefined()
     expect(published.sys.publishedAt).toBeDefined()
-    experience = published
-  })
 
-  it('publishes an experience with locale-aware add', async () => {
-    const current = await client.experience.get({
-      experienceId: experience.sys.id,
-    })
-
-    const published = await client.experience.publish(
-      {
-        experienceId: current.sys.id,
-        version: current.sys.version,
-      },
+    // --- Publish (locale-aware add) ---
+    const localePublished = await client.experience.publish(
+      { experienceId: published.sys.id, version: published.sys.version },
       { add: ['en-US'] },
     )
 
-    expect(published.sys.publishedVersion).toBeDefined()
-    experience = published
-  })
+    expect(localePublished.sys.publishedVersion).toBeDefined()
 
-  it('unpublishes an experience', async () => {
-    const current = await client.experience.get({
-      experienceId: experience.sys.id,
-    })
-
+    // --- Unpublish ---
     const unpublished = await client.experience.unpublish({
-      experienceId: current.sys.id,
-      version: current.sys.version,
+      experienceId: localePublished.sys.id,
+      version: localePublished.sys.version,
     })
 
     expect(unpublished.sys.publishedVersion).toBeUndefined()
-    experience = unpublished
+
+    // --- Delete ---
+    await client.experience.delete({ experienceId: unpublished.sys.id })
+
+    await expect(
+      client.experience.get({ experienceId: unpublished.sys.id }),
+    ).rejects.toThrow()
+
+    createdExperienceIds.splice(createdExperienceIds.indexOf(created.sys.id), 1)
   })
 })

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -55,7 +55,7 @@ describe('Experience Integration', () => {
     let ct = await client.componentType.create(
       {},
       {
-        name: `${testRunId} CT for Experience`,
+        name: `Integration Test CT for Experience [${testRunId}]`,
         description: 'Backing component type for experience integration test',
         viewports: [testViewport],
         contentProperties: [],
@@ -74,7 +74,7 @@ describe('Experience Integration', () => {
     const created = await client.experience.create(
       {},
       {
-        name: `${testRunId} Experience`,
+        name: `Integration Test Experience [${testRunId}]`,
         description: 'Created by integration test',
         componentTypeId: ct.sys.id,
         viewports: [testViewport],
@@ -92,7 +92,7 @@ describe('Experience Integration', () => {
     expect(created.sys.createdBy).toBeDefined()
     expect(created.sys.componentType).toBeDefined()
     expect(created.sys.componentType!.sys.id).toBe(ct.sys.id)
-    expect(created.name).toBe(`${testRunId} Experience`)
+    expect(created.name).toBe(`Integration Test Experience [${testRunId}]`)
 
     // --- Get ---
     const fetched = await client.experience.get({ experienceId: created.sys.id })
@@ -103,10 +103,10 @@ describe('Experience Integration', () => {
     // --- Update ---
     const updated = await client.experience.update(
       { experienceId: fetched.sys.id },
-      { ...fetched, name: `${testRunId} Experience Updated` },
+      { ...fetched, name: `Integration Test Experience Updated [${testRunId}]` },
     )
 
-    expect(updated.name).toBe(`${testRunId} Experience Updated`)
+    expect(updated.name).toBe(`Integration Test Experience Updated [${testRunId}]`)
     expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
 
     // --- GetMany (cursor pagination) ---

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -172,9 +172,7 @@ describe('Experience Integration', () => {
 
     await client.experience.delete({ experienceId: experienceId })
 
-    await expect(
-      client.experience.get({ experienceId: experienceId }),
-    ).rejects.toThrow()
+    await expect(client.experience.get({ experienceId: experienceId })).rejects.toThrow()
 
     createdExperienceIds.splice(createdExperienceIds.indexOf(experienceId), 1)
   })

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
+import { TestDefaults } from '../defaults'
+import type { ComponentTypeProps } from '../../lib/entities/component-type'
+import type { ExperienceProps } from '../../lib/entities/experience'
+
+describe('Experience Integration', () => {
+  const client = initPlainClient({
+    spaceId: TestDefaults.spaceId,
+    environmentId: TestDefaults.environmentId,
+  })
+
+  let componentType: ComponentTypeProps
+  let experience: ExperienceProps
+
+  beforeAll(async () => {
+    // Experiences require a published ComponentType
+    componentType = await client.componentType.create(
+      {},
+      {
+        name: 'CT for Experience Test',
+        description: 'Backing component type for experience integration test',
+        viewports: [
+          {
+            id: 'desktop',
+            query: '(min-width: 1024px)',
+            displayName: 'Desktop',
+            previewSize: '100%',
+          },
+        ],
+        contentProperties: [],
+        designProperties: [],
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+
+    componentType = await client.componentType.publish({
+      componentTypeId: componentType.sys.id,
+      version: componentType.sys.version,
+    })
+
+    experience = await client.experience.create(
+      {},
+      {
+        name: 'Integration Test Experience',
+        description: 'Created by integration test',
+        componentTypeId: componentType.sys.id,
+        viewports: [
+          {
+            id: 'desktop',
+            query: '(min-width: 1024px)',
+            displayName: 'Desktop',
+            previewSize: '100%',
+          },
+        ],
+        contentProperties: {},
+        designProperties: {},
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+  })
+
+  afterAll(async () => {
+    try {
+      const latestExp = await client.experience.get({
+        experienceId: experience.sys.id,
+      })
+      if (latestExp.sys.publishedVersion) {
+        await client.experience.unpublish({
+          experienceId: latestExp.sys.id,
+          version: latestExp.sys.version,
+        })
+        const unpublishedExp = await client.experience.get({
+          experienceId: latestExp.sys.id,
+        })
+        await client.experience.delete({
+          experienceId: unpublishedExp.sys.id,
+        })
+      } else {
+        await client.experience.delete({
+          experienceId: latestExp.sys.id,
+        })
+      }
+    } catch {
+      // already cleaned up
+    }
+
+    try {
+      const latestCt = await client.componentType.get({
+        componentTypeId: componentType.sys.id,
+      })
+      if (latestCt.sys.publishedVersion) {
+        await client.componentType.unpublish({
+          componentTypeId: latestCt.sys.id,
+          version: latestCt.sys.version,
+        })
+        const unpublishedCt = await client.componentType.get({
+          componentTypeId: latestCt.sys.id,
+        })
+        await client.componentType.delete({
+          componentTypeId: unpublishedCt.sys.id,
+        })
+      } else {
+        await client.componentType.delete({
+          componentTypeId: latestCt.sys.id,
+        })
+      }
+    } catch {
+      // already cleaned up
+    }
+
+    await timeoutToCalmRateLimiting()
+  })
+
+  it('creates an experience with correct sys fields', () => {
+    expect(experience.sys.id).toBeDefined()
+    expect(experience.sys.type).toBe('Experience')
+    expect(experience.sys.version).toBeGreaterThanOrEqual(1)
+    expect(experience.sys.createdAt).toBeDefined()
+    expect(experience.sys.updatedAt).toBeDefined()
+    expect(experience.sys.createdBy).toBeDefined()
+    expect(experience.sys.componentType).toBeDefined()
+    expect(experience.sys.componentType!.sys.id).toBe(componentType.sys.id)
+    expect(experience.name).toBe('Integration Test Experience')
+  })
+
+  it('gets an experience by ID', async () => {
+    const fetched = await client.experience.get({
+      experienceId: experience.sys.id,
+    })
+
+    expect(fetched.sys.id).toBe(experience.sys.id)
+    expect(fetched.sys.type).toBe('Experience')
+    expect(fetched.name).toBe('Integration Test Experience')
+  })
+
+  it('updates an experience', async () => {
+    const current = await client.experience.get({
+      experienceId: experience.sys.id,
+    })
+
+    const updated = await client.experience.update(
+      { experienceId: current.sys.id },
+      {
+        ...current,
+        name: 'Updated Integration Test Experience',
+      },
+    )
+
+    expect(updated.name).toBe('Updated Integration Test Experience')
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+    experience = updated
+  })
+
+  it('lists experiences with cursor pagination', async () => {
+    const collection = await client.experience.getMany({
+      query: { limit: 10 },
+    })
+
+    expect(collection.sys).toBeDefined()
+    expect(collection.pages).toBeDefined()
+    expect(collection.items).toBeDefined()
+    expect(Array.isArray(collection.items)).toBe(true)
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
+
+    const found = collection.items.find((item) => item.sys.id === experience.sys.id)
+    expect(found).toBeDefined()
+  })
+
+  it('publishes an experience (full publish)', async () => {
+    const current = await client.experience.get({
+      experienceId: experience.sys.id,
+    })
+
+    const published = await client.experience.publish({
+      experienceId: current.sys.id,
+      version: current.sys.version,
+    })
+
+    expect(published.sys.publishedVersion).toBeDefined()
+    expect(published.sys.publishedAt).toBeDefined()
+    experience = published
+  })
+
+  it('publishes an experience with locale-aware add', async () => {
+    const current = await client.experience.get({
+      experienceId: experience.sys.id,
+    })
+
+    const published = await client.experience.publish(
+      {
+        experienceId: current.sys.id,
+        version: current.sys.version,
+      },
+      { add: ['en-US'] },
+    )
+
+    expect(published.sys.publishedVersion).toBeDefined()
+    experience = published
+  })
+
+  it('unpublishes an experience', async () => {
+    const current = await client.experience.get({
+      experienceId: experience.sys.id,
+    })
+
+    const unpublished = await client.experience.unpublish({
+      experienceId: current.sys.id,
+      version: current.sys.version,
+    })
+
+    expect(unpublished.sys.publishedVersion).toBeUndefined()
+    experience = unpublished
+  })
+})

--- a/test/integration/fragment-integration.test.ts
+++ b/test/integration/fragment-integration.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
+import { TestDefaults } from '../defaults'
+import type { ComponentTypeProps } from '../../lib/entities/component-type'
+import type { FragmentProps } from '../../lib/entities/fragment'
+
+describe('Fragment Integration', () => {
+  const client = initPlainClient({
+    spaceId: TestDefaults.spaceId,
+    environmentId: TestDefaults.environmentId,
+  })
+
+  let componentType: ComponentTypeProps
+  let fragment: FragmentProps
+
+  beforeAll(async () => {
+    // Fragments require a published ComponentType
+    componentType = await client.componentType.create(
+      {},
+      {
+        name: 'CT for Fragment Test',
+        description: 'Backing component type for fragment integration test',
+        viewports: [
+          {
+            id: 'desktop',
+            query: '(min-width: 1024px)',
+            displayName: 'Desktop',
+            previewSize: '100%',
+          },
+        ],
+        contentProperties: [],
+        designProperties: [],
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+
+    componentType = await client.componentType.publish({
+      componentTypeId: componentType.sys.id,
+      version: componentType.sys.version,
+    })
+
+    fragment = await client.fragment.create(
+      {},
+      {
+        name: 'Integration Test Fragment',
+        description: 'Created by integration test',
+        componentTypeId: componentType.sys.id,
+        viewports: [
+          {
+            id: 'desktop',
+            query: '(min-width: 1024px)',
+            displayName: 'Desktop',
+            previewSize: '100%',
+          },
+        ],
+        designProperties: {},
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+  })
+
+  afterAll(async () => {
+    try {
+      const latestFrag = await client.fragment.get({
+        fragmentId: fragment.sys.id,
+      })
+      if (latestFrag.sys.publishedVersion) {
+        await client.fragment.unpublish({
+          fragmentId: latestFrag.sys.id,
+          version: latestFrag.sys.version,
+        })
+        const unpublishedFrag = await client.fragment.get({
+          fragmentId: latestFrag.sys.id,
+        })
+        await client.fragment.delete({
+          fragmentId: unpublishedFrag.sys.id,
+        })
+      } else {
+        await client.fragment.delete({
+          fragmentId: latestFrag.sys.id,
+        })
+      }
+    } catch {
+      // already cleaned up
+    }
+
+    try {
+      const latestCt = await client.componentType.get({
+        componentTypeId: componentType.sys.id,
+      })
+      if (latestCt.sys.publishedVersion) {
+        await client.componentType.unpublish({
+          componentTypeId: latestCt.sys.id,
+          version: latestCt.sys.version,
+        })
+        const unpublishedCt = await client.componentType.get({
+          componentTypeId: latestCt.sys.id,
+        })
+        await client.componentType.delete({
+          componentTypeId: unpublishedCt.sys.id,
+        })
+      } else {
+        await client.componentType.delete({
+          componentTypeId: latestCt.sys.id,
+        })
+      }
+    } catch {
+      // already cleaned up
+    }
+
+    await timeoutToCalmRateLimiting()
+  })
+
+  it('creates a fragment with correct sys fields', () => {
+    expect(fragment.sys.id).toBeDefined()
+    expect(fragment.sys.type).toBe('Fragment')
+    expect(fragment.sys.version).toBeGreaterThanOrEqual(1)
+    expect(fragment.sys.createdAt).toBeDefined()
+    expect(fragment.sys.updatedAt).toBeDefined()
+    expect(fragment.sys.createdBy).toBeDefined()
+    expect(fragment.sys.componentType).toBeDefined()
+    expect(fragment.sys.componentType.sys.id).toBe(componentType.sys.id)
+    expect(fragment.name).toBe('Integration Test Fragment')
+  })
+
+  it('gets a fragment by ID', async () => {
+    const fetched = await client.fragment.get({
+      fragmentId: fragment.sys.id,
+    })
+
+    expect(fetched.sys.id).toBe(fragment.sys.id)
+    expect(fetched.sys.type).toBe('Fragment')
+    expect(fetched.name).toBe('Integration Test Fragment')
+  })
+
+  it('updates a fragment', async () => {
+    const current = await client.fragment.get({
+      fragmentId: fragment.sys.id,
+    })
+
+    const updated = await client.fragment.update(
+      { fragmentId: current.sys.id },
+      {
+        ...current,
+        sys: { id: current.sys.id, type: 'Fragment', version: current.sys.version },
+        componentTypeId: componentType.sys.id,
+        name: 'Updated Integration Test Fragment',
+      },
+    )
+
+    expect(updated.name).toBe('Updated Integration Test Fragment')
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+    fragment = updated
+  })
+
+  it('lists fragments with cursor pagination', async () => {
+    const collection = await client.fragment.getMany({
+      query: { limit: 10 },
+    })
+
+    expect(collection.sys).toBeDefined()
+    expect(collection.pages).toBeDefined()
+    expect(collection.items).toBeDefined()
+    expect(Array.isArray(collection.items)).toBe(true)
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
+
+    const found = collection.items.find((item) => item.sys.id === fragment.sys.id)
+    expect(found).toBeDefined()
+  })
+
+  it('publishes a fragment', async () => {
+    const current = await client.fragment.get({
+      fragmentId: fragment.sys.id,
+    })
+
+    const published = await client.fragment.publish({
+      fragmentId: current.sys.id,
+      version: current.sys.version,
+    })
+
+    expect(published.sys.publishedVersion).toBeDefined()
+    expect(published.sys.publishedAt).toBeDefined()
+    fragment = published
+  })
+
+  it('unpublishes a fragment', async () => {
+    const current = await client.fragment.get({
+      fragmentId: fragment.sys.id,
+    })
+
+    const unpublished = await client.fragment.unpublish({
+      fragmentId: current.sys.id,
+      version: current.sys.version,
+    })
+
+    expect(unpublished.sys.publishedVersion).toBeUndefined()
+    fragment = unpublished
+  })
+})

--- a/test/integration/fragment-integration.test.ts
+++ b/test/integration/fragment-integration.test.ts
@@ -10,11 +10,12 @@ describe('Fragment Integration', () => {
     environmentId: TestDefaults.environmentId,
   })
 
+  const createdFragmentIds: string[] = []
+  const createdComponentTypeIds: string[] = []
   let componentType: ComponentTypeProps
   let fragment: FragmentProps
 
   beforeAll(async () => {
-    // Fragments require a published ComponentType
     componentType = await client.componentType.create(
       {},
       {
@@ -33,6 +34,7 @@ describe('Fragment Integration', () => {
         dimensionKeyMap: { designProperties: {} },
       },
     )
+    createdComponentTypeIds.push(componentType.sys.id)
 
     componentType = await client.componentType.publish({
       componentTypeId: componentType.sys.id,
@@ -57,55 +59,43 @@ describe('Fragment Integration', () => {
         dimensionKeyMap: { designProperties: {} },
       },
     )
+    createdFragmentIds.push(fragment.sys.id)
   })
 
   afterAll(async () => {
-    try {
-      const latestFrag = await client.fragment.get({
-        fragmentId: fragment.sys.id,
-      })
-      if (latestFrag.sys.publishedVersion) {
-        await client.fragment.unpublish({
-          fragmentId: latestFrag.sys.id,
-          version: latestFrag.sys.version,
-        })
-        const unpublishedFrag = await client.fragment.get({
-          fragmentId: latestFrag.sys.id,
-        })
-        await client.fragment.delete({
-          fragmentId: unpublishedFrag.sys.id,
-        })
-      } else {
-        await client.fragment.delete({
-          fragmentId: latestFrag.sys.id,
-        })
+    // Delete fragments first (they depend on component types)
+    for (const id of createdFragmentIds) {
+      try {
+        const latest = await client.fragment.get({ fragmentId: id })
+        if (latest.sys.publishedVersion) {
+          await client.fragment.unpublish({
+            fragmentId: id,
+            version: latest.sys.version,
+          })
+          await client.fragment.delete({ fragmentId: id })
+        } else {
+          await client.fragment.delete({ fragmentId: id })
+        }
+      } catch {
+        // entity already deleted or not found
       }
-    } catch {
-      // already cleaned up
     }
 
-    try {
-      const latestCt = await client.componentType.get({
-        componentTypeId: componentType.sys.id,
-      })
-      if (latestCt.sys.publishedVersion) {
-        await client.componentType.unpublish({
-          componentTypeId: latestCt.sys.id,
-          version: latestCt.sys.version,
-        })
-        const unpublishedCt = await client.componentType.get({
-          componentTypeId: latestCt.sys.id,
-        })
-        await client.componentType.delete({
-          componentTypeId: unpublishedCt.sys.id,
-        })
-      } else {
-        await client.componentType.delete({
-          componentTypeId: latestCt.sys.id,
-        })
+    for (const id of createdComponentTypeIds) {
+      try {
+        const latest = await client.componentType.get({ componentTypeId: id })
+        if (latest.sys.publishedVersion) {
+          await client.componentType.unpublish({
+            componentTypeId: id,
+            version: latest.sys.version,
+          })
+          await client.componentType.delete({ componentTypeId: id })
+        } else {
+          await client.componentType.delete({ componentTypeId: id })
+        }
+      } catch {
+        // entity already deleted or not found
       }
-    } catch {
-      // already cleaned up
     }
 
     await timeoutToCalmRateLimiting()

--- a/test/integration/fragment-integration.test.ts
+++ b/test/integration/fragment-integration.test.ts
@@ -11,9 +11,44 @@ describe('Fragment Integration', () => {
 
   const createdFragmentIds: string[] = []
   const createdComponentTypeIds: string[] = []
+  let fragmentId: string
+  let componentTypeId: string
 
   beforeAll(async () => {
     await sweepStaleExoEntities(client)
+
+    const ct = await client.componentType.create(
+      {},
+      {
+        name: `Integration Test CT for Fragment ${testRunId}`,
+        description: 'Backing component type for fragment integration test',
+        viewports: [testViewport],
+        contentProperties: [],
+        designProperties: [],
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+    componentTypeId = ct.sys.id
+    createdComponentTypeIds.push(componentTypeId)
+
+    await client.componentType.publish({
+      componentTypeId: componentTypeId,
+      version: ct.sys.version,
+    })
+
+    const frag = await client.fragment.create(
+      {},
+      {
+        name: `Integration Test Fragment ${testRunId}`,
+        description: 'Created by integration test',
+        componentTypeId: componentTypeId,
+        viewports: [testViewport],
+        designProperties: {},
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+    fragmentId = frag.sys.id
+    createdFragmentIds.push(fragmentId)
   })
 
   afterAll(async () => {
@@ -50,103 +85,89 @@ describe('Fragment Integration', () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('full lifecycle: create → get → update → getMany → publish → unpublish → delete', async () => {
-    // --- Setup: create and publish a backing ComponentType ---
-    let ct = await client.componentType.create(
-      {},
-      {
-        name: `Integration Test CT for Fragment ${testRunId}`,
-        description: 'Backing component type for fragment integration test',
-        viewports: [testViewport],
-        contentProperties: [],
-        designProperties: [],
-        dimensionKeyMap: { designProperties: {} },
-      },
-    )
-    createdComponentTypeIds.push(ct.sys.id)
+  it('creates a fragment with correct sys fields', async () => {
+    const frag = await client.fragment.get({ fragmentId: fragmentId })
 
-    ct = await client.componentType.publish({
-      componentTypeId: ct.sys.id,
-      version: ct.sys.version,
-    })
+    expect(frag.sys.id).toBeDefined()
+    expect(frag.sys.type).toBe('Fragment')
+    expect(frag.sys.version).toBeGreaterThanOrEqual(1)
+    expect(frag.sys.createdAt).toBeDefined()
+    expect(frag.sys.updatedAt).toBeDefined()
+    expect(frag.sys.createdBy).toBeDefined()
+    expect(frag.sys.componentType).toBeDefined()
+    expect(frag.sys.componentType.sys.id).toBe(componentTypeId)
+    expect(frag.name).toBe(`Integration Test Fragment ${testRunId}`)
+  })
 
-    // --- Create ---
-    const created = await client.fragment.create(
-      {},
-      {
-        name: `Integration Test Fragment ${testRunId}`,
-        description: 'Created by integration test',
-        componentTypeId: ct.sys.id,
-        viewports: [testViewport],
-        designProperties: {},
-        dimensionKeyMap: { designProperties: {} },
-      },
-    )
-    createdFragmentIds.push(created.sys.id)
+  it('gets a fragment by ID', async () => {
+    const fetched = await client.fragment.get({ fragmentId: fragmentId })
 
-    expect(created.sys.id).toBeDefined()
-    expect(created.sys.type).toBe('Fragment')
-    expect(created.sys.version).toBeGreaterThanOrEqual(1)
-    expect(created.sys.createdAt).toBeDefined()
-    expect(created.sys.createdBy).toBeDefined()
-    expect(created.sys.componentType).toBeDefined()
-    expect(created.sys.componentType.sys.id).toBe(ct.sys.id)
-    expect(created.name).toBe(`Integration Test Fragment ${testRunId}`)
-
-    // --- Get ---
-    const fetched = await client.fragment.get({ fragmentId: created.sys.id })
-
-    expect(fetched.sys.id).toBe(created.sys.id)
+    expect(fetched.sys.id).toBe(fragmentId)
     expect(fetched.sys.type).toBe('Fragment')
+  })
 
-    // --- Update ---
+  it('updates a fragment', async () => {
+    const current = await client.fragment.get({ fragmentId: fragmentId })
+
     const updated = await client.fragment.update(
-      { fragmentId: fetched.sys.id },
+      { fragmentId: fragmentId },
       {
-        ...fetched,
-        sys: { id: fetched.sys.id, type: 'Fragment' as const, version: fetched.sys.version },
-        componentTypeId: ct.sys.id,
+        ...current,
+        sys: { id: current.sys.id, type: 'Fragment' as const, version: current.sys.version },
+        componentTypeId: componentTypeId,
         name: `Integration Test Fragment Updated ${testRunId}`,
       },
     )
 
     expect(updated.name).toBe(`Integration Test Fragment Updated ${testRunId}`)
-    expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+  })
 
-    // --- GetMany (cursor pagination) ---
+  it('lists fragments with cursor pagination', async () => {
     const collection = await client.fragment.getMany({ query: { limit: 10 } })
 
     expect(collection.sys).toBeDefined()
     expect(collection.pages).toBeDefined()
     expect(collection.items).toBeDefined()
     expect(Array.isArray(collection.items)).toBe(true)
-    const found = collection.items.find((item) => item.sys.id === created.sys.id)
-    expect(found).toBeDefined()
 
-    // --- Publish ---
+    const found = collection.items.find((item) => item.sys.id === fragmentId)
+    expect(found).toBeDefined()
+  })
+
+  it('publishes a fragment', async () => {
+    const current = await client.fragment.get({ fragmentId: fragmentId })
+
     const published = await client.fragment.publish({
-      fragmentId: updated.sys.id,
-      version: updated.sys.version,
+      fragmentId: fragmentId,
+      version: current.sys.version,
     })
 
     expect(published.sys.publishedVersion).toBeDefined()
     expect(published.sys.publishedAt).toBeDefined()
+  })
 
-    // --- Unpublish ---
+  it('unpublishes a fragment', async () => {
+    const current = await client.fragment.get({ fragmentId: fragmentId })
+
     const unpublished = await client.fragment.unpublish({
-      fragmentId: published.sys.id,
-      version: published.sys.version,
+      fragmentId: fragmentId,
+      version: current.sys.version,
     })
 
     expect(unpublished.sys.publishedVersion).toBeUndefined()
+  })
 
-    // --- Delete ---
-    await client.fragment.delete({ fragmentId: unpublished.sys.id })
+  it('deletes a fragment', async () => {
+    const current = await client.fragment.get({ fragmentId: fragmentId })
+    expect(current.sys.publishedVersion).toBeUndefined()
+
+    await client.fragment.delete({ fragmentId: fragmentId })
 
     await expect(
-      client.fragment.get({ fragmentId: unpublished.sys.id }),
+      client.fragment.get({ fragmentId: fragmentId }),
     ).rejects.toThrow()
 
-    createdFragmentIds.splice(createdFragmentIds.indexOf(created.sys.id), 1)
+    createdFragmentIds.splice(createdFragmentIds.indexOf(fragmentId), 1)
   })
 })

--- a/test/integration/fragment-integration.test.ts
+++ b/test/integration/fragment-integration.test.ts
@@ -3,7 +3,7 @@ import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
 import { testName, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
 
-describe('Fragment Integration', () => {
+describe('Fragment Integration', { sequential: true }, () => {
   const client = initPlainClient({
     spaceId: TestDefaults.spaceId,
     environmentId: TestDefaults.environmentId,
@@ -85,7 +85,7 @@ describe('Fragment Integration', () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('creates a fragment with correct sys fields', async () => {
+  it('has correct sys fields after creation', async () => {
     const frag = await client.fragment.get({ fragmentId: fragmentId })
 
     expect(frag.sys.id).toBeDefined()
@@ -109,6 +109,7 @@ describe('Fragment Integration', () => {
   it('updates a fragment', async () => {
     const current = await client.fragment.get({ fragmentId: fragmentId })
 
+    // Update types require minimal sys — full entity sys is not assignable
     const updated = await client.fragment.update(
       { fragmentId: fragmentId },
       {
@@ -126,10 +127,8 @@ describe('Fragment Integration', () => {
   it('lists fragments with cursor pagination', async () => {
     const collection = await client.fragment.getMany({ query: { limit: 10 } })
 
-    expect(collection.sys).toBeDefined()
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
     expect(collection.pages).toBeDefined()
-    expect(collection.items).toBeDefined()
-    expect(Array.isArray(collection.items)).toBe(true)
 
     const found = collection.items.find((item) => item.sys.id === fragmentId)
     expect(found).toBeDefined()
@@ -158,6 +157,24 @@ describe('Fragment Integration', () => {
     expect(unpublished.sys.publishedVersion).toBeUndefined()
   })
 
+  it('rejects delete on a published entity', async () => {
+    const current = await client.fragment.get({ fragmentId: fragmentId })
+    if (!current.sys.publishedVersion) {
+      await client.fragment.publish({
+        fragmentId: fragmentId,
+        version: current.sys.version,
+      })
+    }
+
+    await expect(client.fragment.delete({ fragmentId: fragmentId })).rejects.toThrow()
+
+    const latest = await client.fragment.get({ fragmentId: fragmentId })
+    await client.fragment.unpublish({
+      fragmentId: fragmentId,
+      version: latest.sys.version,
+    })
+  })
+
   it('deletes a fragment', async () => {
     const current = await client.fragment.get({ fragmentId: fragmentId })
     expect(current.sys.publishedVersion).toBeUndefined()
@@ -166,6 +183,7 @@ describe('Fragment Integration', () => {
 
     await expect(client.fragment.get({ fragmentId: fragmentId })).rejects.toThrow()
 
-    createdFragmentIds.splice(createdFragmentIds.indexOf(fragmentId), 1)
+    const idx = createdFragmentIds.indexOf(fragmentId)
+    if (idx !== -1) createdFragmentIds.splice(idx, 1)
   })
 })

--- a/test/integration/fragment-integration.test.ts
+++ b/test/integration/fragment-integration.test.ts
@@ -55,7 +55,7 @@ describe('Fragment Integration', () => {
     let ct = await client.componentType.create(
       {},
       {
-        name: `${testRunId} CT for Fragment`,
+        name: `Integration Test CT for Fragment [${testRunId}]`,
         description: 'Backing component type for fragment integration test',
         viewports: [testViewport],
         contentProperties: [],
@@ -74,7 +74,7 @@ describe('Fragment Integration', () => {
     const created = await client.fragment.create(
       {},
       {
-        name: `${testRunId} Fragment`,
+        name: `Integration Test Fragment [${testRunId}]`,
         description: 'Created by integration test',
         componentTypeId: ct.sys.id,
         viewports: [testViewport],
@@ -91,7 +91,7 @@ describe('Fragment Integration', () => {
     expect(created.sys.createdBy).toBeDefined()
     expect(created.sys.componentType).toBeDefined()
     expect(created.sys.componentType.sys.id).toBe(ct.sys.id)
-    expect(created.name).toBe(`${testRunId} Fragment`)
+    expect(created.name).toBe(`Integration Test Fragment [${testRunId}]`)
 
     // --- Get ---
     const fetched = await client.fragment.get({ fragmentId: created.sys.id })
@@ -106,11 +106,11 @@ describe('Fragment Integration', () => {
         ...fetched,
         sys: { id: fetched.sys.id, type: 'Fragment' as const, version: fetched.sys.version },
         componentTypeId: ct.sys.id,
-        name: `${testRunId} Fragment Updated`,
+        name: `Integration Test Fragment Updated [${testRunId}]`,
       },
     )
 
-    expect(updated.name).toBe(`${testRunId} Fragment Updated`)
+    expect(updated.name).toBe(`Integration Test Fragment Updated [${testRunId}]`)
     expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
 
     // --- GetMany (cursor pagination) ---

--- a/test/integration/fragment-integration.test.ts
+++ b/test/integration/fragment-integration.test.ts
@@ -55,7 +55,7 @@ describe('Fragment Integration', () => {
     let ct = await client.componentType.create(
       {},
       {
-        name: `Integration Test CT for Fragment [${testRunId}]`,
+        name: `Integration Test CT for Fragment ${testRunId}`,
         description: 'Backing component type for fragment integration test',
         viewports: [testViewport],
         contentProperties: [],
@@ -74,7 +74,7 @@ describe('Fragment Integration', () => {
     const created = await client.fragment.create(
       {},
       {
-        name: `Integration Test Fragment [${testRunId}]`,
+        name: `Integration Test Fragment ${testRunId}`,
         description: 'Created by integration test',
         componentTypeId: ct.sys.id,
         viewports: [testViewport],
@@ -91,7 +91,7 @@ describe('Fragment Integration', () => {
     expect(created.sys.createdBy).toBeDefined()
     expect(created.sys.componentType).toBeDefined()
     expect(created.sys.componentType.sys.id).toBe(ct.sys.id)
-    expect(created.name).toBe(`Integration Test Fragment [${testRunId}]`)
+    expect(created.name).toBe(`Integration Test Fragment ${testRunId}`)
 
     // --- Get ---
     const fetched = await client.fragment.get({ fragmentId: created.sys.id })
@@ -106,11 +106,11 @@ describe('Fragment Integration', () => {
         ...fetched,
         sys: { id: fetched.sys.id, type: 'Fragment' as const, version: fetched.sys.version },
         componentTypeId: ct.sys.id,
-        name: `Integration Test Fragment Updated [${testRunId}]`,
+        name: `Integration Test Fragment Updated ${testRunId}`,
       },
     )
 
-    expect(updated.name).toBe(`Integration Test Fragment Updated [${testRunId}]`)
+    expect(updated.name).toBe(`Integration Test Fragment Updated ${testRunId}`)
     expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
 
     // --- GetMany (cursor pagination) ---

--- a/test/integration/fragment-integration.test.ts
+++ b/test/integration/fragment-integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
-import { testRunId, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
+import { testName, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
 
 describe('Fragment Integration', () => {
   const client = initPlainClient({
@@ -20,7 +20,7 @@ describe('Fragment Integration', () => {
     const ct = await client.componentType.create(
       {},
       {
-        name: `Integration Test CT for Fragment ${testRunId}`,
+        name: testName('CT for Fragment'),
         description: 'Backing component type for fragment integration test',
         viewports: [testViewport],
         contentProperties: [],
@@ -39,7 +39,7 @@ describe('Fragment Integration', () => {
     const frag = await client.fragment.create(
       {},
       {
-        name: `Integration Test Fragment ${testRunId}`,
+        name: testName('Fragment'),
         description: 'Created by integration test',
         componentTypeId: componentTypeId,
         viewports: [testViewport],
@@ -96,7 +96,7 @@ describe('Fragment Integration', () => {
     expect(frag.sys.createdBy).toBeDefined()
     expect(frag.sys.componentType).toBeDefined()
     expect(frag.sys.componentType.sys.id).toBe(componentTypeId)
-    expect(frag.name).toBe(`Integration Test Fragment ${testRunId}`)
+    expect(frag.name).toBe(testName('Fragment'))
   })
 
   it('gets a fragment by ID', async () => {
@@ -115,11 +115,11 @@ describe('Fragment Integration', () => {
         ...current,
         sys: { id: current.sys.id, type: 'Fragment' as const, version: current.sys.version },
         componentTypeId: componentTypeId,
-        name: `Integration Test Fragment Updated ${testRunId}`,
+        name: testName('Fragment Updated'),
       },
     )
 
-    expect(updated.name).toBe(`Integration Test Fragment Updated ${testRunId}`)
+    expect(updated.name).toBe(testName('Fragment Updated'))
     expect(updated.sys.version).toBeGreaterThan(current.sys.version)
   })
 

--- a/test/integration/fragment-integration.test.ts
+++ b/test/integration/fragment-integration.test.ts
@@ -164,9 +164,7 @@ describe('Fragment Integration', () => {
 
     await client.fragment.delete({ fragmentId: fragmentId })
 
-    await expect(
-      client.fragment.get({ fragmentId: fragmentId }),
-    ).rejects.toThrow()
+    await expect(client.fragment.get({ fragmentId: fragmentId })).rejects.toThrow()
 
     createdFragmentIds.splice(createdFragmentIds.indexOf(fragmentId), 1)
   })

--- a/test/integration/fragment-integration.test.ts
+++ b/test/integration/fragment-integration.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
-import type { ComponentTypeProps } from '../../lib/entities/component-type'
-import type { FragmentProps } from '../../lib/entities/fragment'
+import { testRunId, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
 
 describe('Fragment Integration', () => {
   const client = initPlainClient({
@@ -12,58 +11,12 @@ describe('Fragment Integration', () => {
 
   const createdFragmentIds: string[] = []
   const createdComponentTypeIds: string[] = []
-  let componentType: ComponentTypeProps
-  let fragment: FragmentProps
 
   beforeAll(async () => {
-    componentType = await client.componentType.create(
-      {},
-      {
-        name: 'CT for Fragment Test',
-        description: 'Backing component type for fragment integration test',
-        viewports: [
-          {
-            id: 'desktop',
-            query: '(min-width: 1024px)',
-            displayName: 'Desktop',
-            previewSize: '100%',
-          },
-        ],
-        contentProperties: [],
-        designProperties: [],
-        dimensionKeyMap: { designProperties: {} },
-      },
-    )
-    createdComponentTypeIds.push(componentType.sys.id)
-
-    componentType = await client.componentType.publish({
-      componentTypeId: componentType.sys.id,
-      version: componentType.sys.version,
-    })
-
-    fragment = await client.fragment.create(
-      {},
-      {
-        name: 'Integration Test Fragment',
-        description: 'Created by integration test',
-        componentTypeId: componentType.sys.id,
-        viewports: [
-          {
-            id: 'desktop',
-            query: '(min-width: 1024px)',
-            displayName: 'Desktop',
-            previewSize: '100%',
-          },
-        ],
-        designProperties: {},
-        dimensionKeyMap: { designProperties: {} },
-      },
-    )
-    createdFragmentIds.push(fragment.sys.id)
+    await sweepStaleExoEntities(client)
   })
 
   afterAll(async () => {
-    // Delete fragments first (they depend on component types)
     for (const id of createdFragmentIds) {
       try {
         const latest = await client.fragment.get({ fragmentId: id })
@@ -72,10 +25,8 @@ describe('Fragment Integration', () => {
             fragmentId: id,
             version: latest.sys.version,
           })
-          await client.fragment.delete({ fragmentId: id })
-        } else {
-          await client.fragment.delete({ fragmentId: id })
         }
+        await client.fragment.delete({ fragmentId: id })
       } catch {
         // entity already deleted or not found
       }
@@ -89,10 +40,8 @@ describe('Fragment Integration', () => {
             componentTypeId: id,
             version: latest.sys.version,
           })
-          await client.componentType.delete({ componentTypeId: id })
-        } else {
-          await client.componentType.delete({ componentTypeId: id })
         }
+        await client.componentType.delete({ componentTypeId: id })
       } catch {
         // entity already deleted or not found
       }
@@ -101,89 +50,103 @@ describe('Fragment Integration', () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('creates a fragment with correct sys fields', () => {
-    expect(fragment.sys.id).toBeDefined()
-    expect(fragment.sys.type).toBe('Fragment')
-    expect(fragment.sys.version).toBeGreaterThanOrEqual(1)
-    expect(fragment.sys.createdAt).toBeDefined()
-    expect(fragment.sys.updatedAt).toBeDefined()
-    expect(fragment.sys.createdBy).toBeDefined()
-    expect(fragment.sys.componentType).toBeDefined()
-    expect(fragment.sys.componentType.sys.id).toBe(componentType.sys.id)
-    expect(fragment.name).toBe('Integration Test Fragment')
-  })
-
-  it('gets a fragment by ID', async () => {
-    const fetched = await client.fragment.get({
-      fragmentId: fragment.sys.id,
-    })
-
-    expect(fetched.sys.id).toBe(fragment.sys.id)
-    expect(fetched.sys.type).toBe('Fragment')
-    expect(fetched.name).toBe('Integration Test Fragment')
-  })
-
-  it('updates a fragment', async () => {
-    const current = await client.fragment.get({
-      fragmentId: fragment.sys.id,
-    })
-
-    const updated = await client.fragment.update(
-      { fragmentId: current.sys.id },
+  it('full lifecycle: create → get → update → getMany → publish → unpublish → delete', async () => {
+    // --- Setup: create and publish a backing ComponentType ---
+    let ct = await client.componentType.create(
+      {},
       {
-        ...current,
-        sys: { id: current.sys.id, type: 'Fragment', version: current.sys.version },
-        componentTypeId: componentType.sys.id,
-        name: 'Updated Integration Test Fragment',
+        name: `${testRunId} CT for Fragment`,
+        description: 'Backing component type for fragment integration test',
+        viewports: [testViewport],
+        contentProperties: [],
+        designProperties: [],
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+    createdComponentTypeIds.push(ct.sys.id)
+
+    ct = await client.componentType.publish({
+      componentTypeId: ct.sys.id,
+      version: ct.sys.version,
+    })
+
+    // --- Create ---
+    const created = await client.fragment.create(
+      {},
+      {
+        name: `${testRunId} Fragment`,
+        description: 'Created by integration test',
+        componentTypeId: ct.sys.id,
+        viewports: [testViewport],
+        designProperties: {},
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+    createdFragmentIds.push(created.sys.id)
+
+    expect(created.sys.id).toBeDefined()
+    expect(created.sys.type).toBe('Fragment')
+    expect(created.sys.version).toBeGreaterThanOrEqual(1)
+    expect(created.sys.createdAt).toBeDefined()
+    expect(created.sys.createdBy).toBeDefined()
+    expect(created.sys.componentType).toBeDefined()
+    expect(created.sys.componentType.sys.id).toBe(ct.sys.id)
+    expect(created.name).toBe(`${testRunId} Fragment`)
+
+    // --- Get ---
+    const fetched = await client.fragment.get({ fragmentId: created.sys.id })
+
+    expect(fetched.sys.id).toBe(created.sys.id)
+    expect(fetched.sys.type).toBe('Fragment')
+
+    // --- Update ---
+    const updated = await client.fragment.update(
+      { fragmentId: fetched.sys.id },
+      {
+        ...fetched,
+        sys: { id: fetched.sys.id, type: 'Fragment' as const, version: fetched.sys.version },
+        componentTypeId: ct.sys.id,
+        name: `${testRunId} Fragment Updated`,
       },
     )
 
-    expect(updated.name).toBe('Updated Integration Test Fragment')
-    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
-    fragment = updated
-  })
+    expect(updated.name).toBe(`${testRunId} Fragment Updated`)
+    expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
 
-  it('lists fragments with cursor pagination', async () => {
-    const collection = await client.fragment.getMany({
-      query: { limit: 10 },
-    })
+    // --- GetMany (cursor pagination) ---
+    const collection = await client.fragment.getMany({ query: { limit: 10 } })
 
     expect(collection.sys).toBeDefined()
     expect(collection.pages).toBeDefined()
     expect(collection.items).toBeDefined()
     expect(Array.isArray(collection.items)).toBe(true)
-    expect(collection.items.length).toBeGreaterThanOrEqual(1)
-
-    const found = collection.items.find((item) => item.sys.id === fragment.sys.id)
+    const found = collection.items.find((item) => item.sys.id === created.sys.id)
     expect(found).toBeDefined()
-  })
 
-  it('publishes a fragment', async () => {
-    const current = await client.fragment.get({
-      fragmentId: fragment.sys.id,
-    })
-
+    // --- Publish ---
     const published = await client.fragment.publish({
-      fragmentId: current.sys.id,
-      version: current.sys.version,
+      fragmentId: updated.sys.id,
+      version: updated.sys.version,
     })
 
     expect(published.sys.publishedVersion).toBeDefined()
     expect(published.sys.publishedAt).toBeDefined()
-    fragment = published
-  })
 
-  it('unpublishes a fragment', async () => {
-    const current = await client.fragment.get({
-      fragmentId: fragment.sys.id,
-    })
-
+    // --- Unpublish ---
     const unpublished = await client.fragment.unpublish({
-      fragmentId: current.sys.id,
-      version: current.sys.version,
+      fragmentId: published.sys.id,
+      version: published.sys.version,
     })
 
     expect(unpublished.sys.publishedVersion).toBeUndefined()
-    fragment = unpublished
+
+    // --- Delete ---
+    await client.fragment.delete({ fragmentId: unpublished.sys.id })
+
+    await expect(
+      client.fragment.get({ fragmentId: unpublished.sys.id }),
+    ).rejects.toThrow()
+
+    createdFragmentIds.splice(createdFragmentIds.indexOf(created.sys.id), 1)
   })
 })

--- a/test/integration/template-integration.test.ts
+++ b/test/integration/template-integration.test.ts
@@ -39,7 +39,7 @@ describe('Template Integration', () => {
     const created = await client.template.create(
       {},
       {
-        name: `${testRunId} Template`,
+        name: `Integration Test Template [${testRunId}]`,
         description: 'Created by integration test',
         viewports: [testViewport],
         contentProperties: [
@@ -58,7 +58,7 @@ describe('Template Integration', () => {
     expect(created.sys.version).toBeGreaterThanOrEqual(1)
     expect(created.sys.createdAt).toBeDefined()
     expect(created.sys.createdBy).toBeDefined()
-    expect(created.name).toBe(`${testRunId} Template`)
+    expect(created.name).toBe(`Integration Test Template [${testRunId}]`)
 
     // --- Get ---
     const fetched = await client.template.get({ templateId: created.sys.id })
@@ -74,11 +74,11 @@ describe('Template Integration', () => {
       {
         ...fetched,
         sys: { id: fetched.sys.id, type: 'Template' as const, version: fetched.sys.version },
-        name: `${testRunId} Template Updated`,
+        name: `Integration Test Template Updated [${testRunId}]`,
       },
     )
 
-    expect(updated.name).toBe(`${testRunId} Template Updated`)
+    expect(updated.name).toBe(`Integration Test Template Updated [${testRunId}]`)
     expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
 
     // --- GetMany (cursor pagination) ---

--- a/test/integration/template-integration.test.ts
+++ b/test/integration/template-integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
-import type { TemplateProps } from '../../lib/entities/template'
+import { testRunId, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
 
 describe('Template Integration', () => {
   const client = initPlainClient({
@@ -9,47 +9,14 @@ describe('Template Integration', () => {
     environmentId: TestDefaults.environmentId,
   })
 
-  const createdTemplateIds: string[] = []
-  let template: TemplateProps
+  const createdIds: string[] = []
 
   beforeAll(async () => {
-    template = await client.template.create(
-      {},
-      {
-        name: 'Integration Test Template',
-        description: 'Created by integration test',
-        viewports: [
-          {
-            id: 'desktop',
-            query: '(min-width: 1024px)',
-            displayName: 'Desktop',
-            previewSize: '100%',
-          },
-        ],
-        contentProperties: [
-          {
-            id: 'heading',
-            name: 'Heading',
-            type: 'String',
-            required: false,
-          },
-        ],
-        designProperties: [
-          {
-            id: 'bgColor',
-            name: 'Background Color',
-            type: 'Symbol',
-            required: false,
-          },
-        ],
-        dimensionKeyMap: { designProperties: {} },
-      },
-    )
-    createdTemplateIds.push(template.sys.id)
+    await sweepStaleExoEntities(client)
   })
 
   afterAll(async () => {
-    for (const id of createdTemplateIds) {
+    for (const id of createdIds) {
       try {
         const latest = await client.template.get({ templateId: id })
         if (latest.sys.publishedVersion) {
@@ -57,10 +24,8 @@ describe('Template Integration', () => {
             templateId: id,
             version: latest.sys.version,
           })
-          await client.template.delete({ templateId: id })
-        } else {
-          await client.template.delete({ templateId: id })
         }
+        await client.template.delete({ templateId: id })
       } catch {
         // entity already deleted or not found
       }
@@ -69,89 +34,87 @@ describe('Template Integration', () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('creates a template with correct sys fields', () => {
-    expect(template.sys.id).toBeDefined()
-    expect(template.sys.type).toBe('Template')
-    expect(template.sys.version).toBeGreaterThanOrEqual(1)
-    expect(template.sys.createdAt).toBeDefined()
-    expect(template.sys.updatedAt).toBeDefined()
-    expect(template.sys.createdBy).toBeDefined()
-    expect(template.name).toBe('Integration Test Template')
-    expect(template.description).toBe('Created by integration test')
-  })
+  it('full lifecycle: create → get → update → getMany → publish → unpublish → delete', async () => {
+    // --- Create ---
+    const created = await client.template.create(
+      {},
+      {
+        name: `${testRunId} Template`,
+        description: 'Created by integration test',
+        viewports: [testViewport],
+        contentProperties: [
+          { id: 'heading', name: 'Heading', type: 'String', required: false },
+        ],
+        designProperties: [
+          { id: 'bgColor', name: 'Background Color', type: 'Symbol', required: false },
+        ],
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+    createdIds.push(created.sys.id)
 
-  it('gets a template by ID', async () => {
-    const fetched = await client.template.get({
-      templateId: template.sys.id,
-    })
+    expect(created.sys.id).toBeDefined()
+    expect(created.sys.type).toBe('Template')
+    expect(created.sys.version).toBeGreaterThanOrEqual(1)
+    expect(created.sys.createdAt).toBeDefined()
+    expect(created.sys.createdBy).toBeDefined()
+    expect(created.name).toBe(`${testRunId} Template`)
 
-    expect(fetched.sys.id).toBe(template.sys.id)
+    // --- Get ---
+    const fetched = await client.template.get({ templateId: created.sys.id })
+
+    expect(fetched.sys.id).toBe(created.sys.id)
     expect(fetched.sys.type).toBe('Template')
-    expect(fetched.name).toBe('Integration Test Template')
     expect(fetched.contentProperties).toHaveLength(1)
     expect(fetched.designProperties).toHaveLength(1)
-  })
 
-  it('updates a template', async () => {
-    const current = await client.template.get({
-      templateId: template.sys.id,
-    })
-
+    // --- Update ---
     const updated = await client.template.update(
-      { templateId: current.sys.id },
+      { templateId: fetched.sys.id },
       {
-        ...current,
-        sys: { id: current.sys.id, type: 'Template', version: current.sys.version },
-        name: 'Updated Integration Test Template',
+        ...fetched,
+        sys: { id: fetched.sys.id, type: 'Template' as const, version: fetched.sys.version },
+        name: `${testRunId} Template Updated`,
       },
     )
 
-    expect(updated.name).toBe('Updated Integration Test Template')
-    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
-    template = updated
-  })
+    expect(updated.name).toBe(`${testRunId} Template Updated`)
+    expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
 
-  it('lists templates with cursor pagination', async () => {
-    const collection = await client.template.getMany({
-      query: { limit: 10 },
-    })
+    // --- GetMany (cursor pagination) ---
+    const collection = await client.template.getMany({ query: { limit: 10 } })
 
     expect(collection.sys).toBeDefined()
     expect(collection.pages).toBeDefined()
     expect(collection.items).toBeDefined()
     expect(Array.isArray(collection.items)).toBe(true)
-    expect(collection.items.length).toBeGreaterThanOrEqual(1)
-
-    const found = collection.items.find((item) => item.sys.id === template.sys.id)
+    const found = collection.items.find((item) => item.sys.id === created.sys.id)
     expect(found).toBeDefined()
-  })
 
-  it('publishes a template', async () => {
-    const current = await client.template.get({
-      templateId: template.sys.id,
-    })
-
+    // --- Publish ---
     const published = await client.template.publish({
-      templateId: current.sys.id,
-      version: current.sys.version,
+      templateId: updated.sys.id,
+      version: updated.sys.version,
     })
 
     expect(published.sys.publishedVersion).toBeDefined()
     expect(published.sys.publishedAt).toBeDefined()
-    template = published
-  })
 
-  it('unpublishes a template', async () => {
-    const current = await client.template.get({
-      templateId: template.sys.id,
-    })
-
+    // --- Unpublish ---
     const unpublished = await client.template.unpublish({
-      templateId: current.sys.id,
-      version: current.sys.version,
+      templateId: published.sys.id,
+      version: published.sys.version,
     })
 
     expect(unpublished.sys.publishedVersion).toBeUndefined()
-    template = unpublished
+
+    // --- Delete ---
+    await client.template.delete({ templateId: unpublished.sys.id })
+
+    await expect(
+      client.template.get({ templateId: unpublished.sys.id }),
+    ).rejects.toThrow()
+
+    createdIds.splice(createdIds.indexOf(created.sys.id), 1)
   })
 })

--- a/test/integration/template-integration.test.ts
+++ b/test/integration/template-integration.test.ts
@@ -21,9 +21,7 @@ describe('Template Integration', () => {
         name: testName('Template'),
         description: 'Created by integration test',
         viewports: [testViewport],
-        contentProperties: [
-          { id: 'heading', name: 'Heading', type: 'String', required: false },
-        ],
+        contentProperties: [{ id: 'heading', name: 'Heading', type: 'String', required: false }],
         designProperties: [
           { id: 'bgColor', name: 'Background Color', type: 'Symbol', required: false },
         ],
@@ -132,9 +130,7 @@ describe('Template Integration', () => {
 
     await client.template.delete({ templateId: templateId })
 
-    await expect(
-      client.template.get({ templateId: templateId }),
-    ).rejects.toThrow()
+    await expect(client.template.get({ templateId: templateId })).rejects.toThrow()
 
     createdIds.splice(createdIds.indexOf(templateId), 1)
   })

--- a/test/integration/template-integration.test.ts
+++ b/test/integration/template-integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
-import { testRunId, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
+import { testName, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
 
 describe('Template Integration', () => {
   const client = initPlainClient({
@@ -18,7 +18,7 @@ describe('Template Integration', () => {
     const created = await client.template.create(
       {},
       {
-        name: `Integration Test Template ${testRunId}`,
+        name: testName('Template'),
         description: 'Created by integration test',
         viewports: [testViewport],
         contentProperties: [
@@ -62,7 +62,7 @@ describe('Template Integration', () => {
     expect(template.sys.createdAt).toBeDefined()
     expect(template.sys.updatedAt).toBeDefined()
     expect(template.sys.createdBy).toBeDefined()
-    expect(template.name).toBe(`Integration Test Template ${testRunId}`)
+    expect(template.name).toBe(testName('Template'))
     expect(template.description).toBe('Created by integration test')
   })
 
@@ -83,11 +83,11 @@ describe('Template Integration', () => {
       {
         ...current,
         sys: { id: current.sys.id, type: 'Template' as const, version: current.sys.version },
-        name: `Integration Test Template Updated ${testRunId}`,
+        name: testName('Template Updated'),
       },
     )
 
-    expect(updated.name).toBe(`Integration Test Template Updated ${testRunId}`)
+    expect(updated.name).toBe(testName('Template Updated'))
     expect(updated.sys.version).toBeGreaterThan(current.sys.version)
   })
 

--- a/test/integration/template-integration.test.ts
+++ b/test/integration/template-integration.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
+import { TestDefaults } from '../defaults'
+import type { TemplateProps } from '../../lib/entities/template'
+
+describe('Template Integration', () => {
+  const client = initPlainClient({
+    spaceId: TestDefaults.spaceId,
+    environmentId: TestDefaults.environmentId,
+  })
+
+  let template: TemplateProps
+
+  beforeAll(async () => {
+    template = await client.template.create(
+      {},
+      {
+        name: 'Integration Test Template',
+        description: 'Created by integration test',
+        viewports: [
+          {
+            id: 'desktop',
+            query: '(min-width: 1024px)',
+            displayName: 'Desktop',
+            previewSize: '100%',
+          },
+        ],
+        contentProperties: [
+          {
+            id: 'heading',
+            name: 'Heading',
+            type: 'String',
+            required: false,
+          },
+        ],
+        designProperties: [
+          {
+            id: 'bgColor',
+            name: 'Background Color',
+            type: 'Symbol',
+            required: false,
+          },
+        ],
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+  })
+
+  afterAll(async () => {
+    try {
+      const latest = await client.template.get({
+        templateId: template.sys.id,
+      })
+      if (latest.sys.publishedVersion) {
+        await client.template.unpublish({
+          templateId: latest.sys.id,
+          version: latest.sys.version,
+        })
+        const unpublished = await client.template.get({
+          templateId: latest.sys.id,
+        })
+        await client.template.delete({
+          templateId: unpublished.sys.id,
+        })
+      } else {
+        await client.template.delete({
+          templateId: latest.sys.id,
+        })
+      }
+    } catch {
+      // already cleaned up
+    }
+
+    await timeoutToCalmRateLimiting()
+  })
+
+  it('creates a template with correct sys fields', () => {
+    expect(template.sys.id).toBeDefined()
+    expect(template.sys.type).toBe('Template')
+    expect(template.sys.version).toBeGreaterThanOrEqual(1)
+    expect(template.sys.createdAt).toBeDefined()
+    expect(template.sys.updatedAt).toBeDefined()
+    expect(template.sys.createdBy).toBeDefined()
+    expect(template.name).toBe('Integration Test Template')
+    expect(template.description).toBe('Created by integration test')
+  })
+
+  it('gets a template by ID', async () => {
+    const fetched = await client.template.get({
+      templateId: template.sys.id,
+    })
+
+    expect(fetched.sys.id).toBe(template.sys.id)
+    expect(fetched.sys.type).toBe('Template')
+    expect(fetched.name).toBe('Integration Test Template')
+    expect(fetched.contentProperties).toHaveLength(1)
+    expect(fetched.designProperties).toHaveLength(1)
+  })
+
+  it('updates a template', async () => {
+    const current = await client.template.get({
+      templateId: template.sys.id,
+    })
+
+    const updated = await client.template.update(
+      { templateId: current.sys.id },
+      {
+        ...current,
+        sys: { id: current.sys.id, type: 'Template', version: current.sys.version },
+        name: 'Updated Integration Test Template',
+      },
+    )
+
+    expect(updated.name).toBe('Updated Integration Test Template')
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+    template = updated
+  })
+
+  it('lists templates with cursor pagination', async () => {
+    const collection = await client.template.getMany({
+      query: { limit: 10 },
+    })
+
+    expect(collection.sys).toBeDefined()
+    expect(collection.pages).toBeDefined()
+    expect(collection.items).toBeDefined()
+    expect(Array.isArray(collection.items)).toBe(true)
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
+
+    const found = collection.items.find((item) => item.sys.id === template.sys.id)
+    expect(found).toBeDefined()
+  })
+
+  it('publishes a template', async () => {
+    const current = await client.template.get({
+      templateId: template.sys.id,
+    })
+
+    const published = await client.template.publish({
+      templateId: current.sys.id,
+      version: current.sys.version,
+    })
+
+    expect(published.sys.publishedVersion).toBeDefined()
+    expect(published.sys.publishedAt).toBeDefined()
+    template = published
+  })
+
+  it('unpublishes a template', async () => {
+    const current = await client.template.get({
+      templateId: template.sys.id,
+    })
+
+    const unpublished = await client.template.unpublish({
+      templateId: current.sys.id,
+      version: current.sys.version,
+    })
+
+    expect(unpublished.sys.publishedVersion).toBeUndefined()
+    template = unpublished
+  })
+})

--- a/test/integration/template-integration.test.ts
+++ b/test/integration/template-integration.test.ts
@@ -9,6 +9,7 @@ describe('Template Integration', () => {
     environmentId: TestDefaults.environmentId,
   })
 
+  const createdTemplateIds: string[] = []
   let template: TemplateProps
 
   beforeAll(async () => {
@@ -44,31 +45,25 @@ describe('Template Integration', () => {
         dimensionKeyMap: { designProperties: {} },
       },
     )
+    createdTemplateIds.push(template.sys.id)
   })
 
   afterAll(async () => {
-    try {
-      const latest = await client.template.get({
-        templateId: template.sys.id,
-      })
-      if (latest.sys.publishedVersion) {
-        await client.template.unpublish({
-          templateId: latest.sys.id,
-          version: latest.sys.version,
-        })
-        const unpublished = await client.template.get({
-          templateId: latest.sys.id,
-        })
-        await client.template.delete({
-          templateId: unpublished.sys.id,
-        })
-      } else {
-        await client.template.delete({
-          templateId: latest.sys.id,
-        })
+    for (const id of createdTemplateIds) {
+      try {
+        const latest = await client.template.get({ templateId: id })
+        if (latest.sys.publishedVersion) {
+          await client.template.unpublish({
+            templateId: id,
+            version: latest.sys.version,
+          })
+          await client.template.delete({ templateId: id })
+        } else {
+          await client.template.delete({ templateId: id })
+        }
+      } catch {
+        // entity already deleted or not found
       }
-    } catch {
-      // already cleaned up
     }
 
     await timeoutToCalmRateLimiting()

--- a/test/integration/template-integration.test.ts
+++ b/test/integration/template-integration.test.ts
@@ -10,9 +10,28 @@ describe('Template Integration', () => {
   })
 
   const createdIds: string[] = []
+  let templateId: string
 
   beforeAll(async () => {
     await sweepStaleExoEntities(client)
+
+    const created = await client.template.create(
+      {},
+      {
+        name: `Integration Test Template ${testRunId}`,
+        description: 'Created by integration test',
+        viewports: [testViewport],
+        contentProperties: [
+          { id: 'heading', name: 'Heading', type: 'String', required: false },
+        ],
+        designProperties: [
+          { id: 'bgColor', name: 'Background Color', type: 'Symbol', required: false },
+        ],
+        dimensionKeyMap: { designProperties: {} },
+      },
+    )
+    templateId = created.sys.id
+    createdIds.push(templateId)
   })
 
   afterAll(async () => {
@@ -34,87 +53,89 @@ describe('Template Integration', () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('full lifecycle: create → get → update → getMany → publish → unpublish → delete', async () => {
-    // --- Create ---
-    const created = await client.template.create(
-      {},
-      {
-        name: `Integration Test Template ${testRunId}`,
-        description: 'Created by integration test',
-        viewports: [testViewport],
-        contentProperties: [
-          { id: 'heading', name: 'Heading', type: 'String', required: false },
-        ],
-        designProperties: [
-          { id: 'bgColor', name: 'Background Color', type: 'Symbol', required: false },
-        ],
-        dimensionKeyMap: { designProperties: {} },
-      },
-    )
-    createdIds.push(created.sys.id)
+  it('creates a template with correct sys fields', async () => {
+    const template = await client.template.get({ templateId: templateId })
 
-    expect(created.sys.id).toBeDefined()
-    expect(created.sys.type).toBe('Template')
-    expect(created.sys.version).toBeGreaterThanOrEqual(1)
-    expect(created.sys.createdAt).toBeDefined()
-    expect(created.sys.createdBy).toBeDefined()
-    expect(created.name).toBe(`Integration Test Template ${testRunId}`)
+    expect(template.sys.id).toBeDefined()
+    expect(template.sys.type).toBe('Template')
+    expect(template.sys.version).toBeGreaterThanOrEqual(1)
+    expect(template.sys.createdAt).toBeDefined()
+    expect(template.sys.updatedAt).toBeDefined()
+    expect(template.sys.createdBy).toBeDefined()
+    expect(template.name).toBe(`Integration Test Template ${testRunId}`)
+    expect(template.description).toBe('Created by integration test')
+  })
 
-    // --- Get ---
-    const fetched = await client.template.get({ templateId: created.sys.id })
+  it('gets a template by ID', async () => {
+    const fetched = await client.template.get({ templateId: templateId })
 
-    expect(fetched.sys.id).toBe(created.sys.id)
+    expect(fetched.sys.id).toBe(templateId)
     expect(fetched.sys.type).toBe('Template')
     expect(fetched.contentProperties).toHaveLength(1)
     expect(fetched.designProperties).toHaveLength(1)
+  })
 
-    // --- Update ---
+  it('updates a template', async () => {
+    const current = await client.template.get({ templateId: templateId })
+
     const updated = await client.template.update(
-      { templateId: fetched.sys.id },
+      { templateId: templateId },
       {
-        ...fetched,
-        sys: { id: fetched.sys.id, type: 'Template' as const, version: fetched.sys.version },
+        ...current,
+        sys: { id: current.sys.id, type: 'Template' as const, version: current.sys.version },
         name: `Integration Test Template Updated ${testRunId}`,
       },
     )
 
     expect(updated.name).toBe(`Integration Test Template Updated ${testRunId}`)
-    expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+  })
 
-    // --- GetMany (cursor pagination) ---
+  it('lists templates with cursor pagination', async () => {
     const collection = await client.template.getMany({ query: { limit: 10 } })
 
     expect(collection.sys).toBeDefined()
     expect(collection.pages).toBeDefined()
     expect(collection.items).toBeDefined()
     expect(Array.isArray(collection.items)).toBe(true)
-    const found = collection.items.find((item) => item.sys.id === created.sys.id)
-    expect(found).toBeDefined()
 
-    // --- Publish ---
+    const found = collection.items.find((item) => item.sys.id === templateId)
+    expect(found).toBeDefined()
+  })
+
+  it('publishes a template', async () => {
+    const current = await client.template.get({ templateId: templateId })
+
     const published = await client.template.publish({
-      templateId: updated.sys.id,
-      version: updated.sys.version,
+      templateId: templateId,
+      version: current.sys.version,
     })
 
     expect(published.sys.publishedVersion).toBeDefined()
     expect(published.sys.publishedAt).toBeDefined()
+  })
 
-    // --- Unpublish ---
+  it('unpublishes a template', async () => {
+    const current = await client.template.get({ templateId: templateId })
+
     const unpublished = await client.template.unpublish({
-      templateId: published.sys.id,
-      version: published.sys.version,
+      templateId: templateId,
+      version: current.sys.version,
     })
 
     expect(unpublished.sys.publishedVersion).toBeUndefined()
+  })
 
-    // --- Delete ---
-    await client.template.delete({ templateId: unpublished.sys.id })
+  it('deletes a template', async () => {
+    const current = await client.template.get({ templateId: templateId })
+    expect(current.sys.publishedVersion).toBeUndefined()
+
+    await client.template.delete({ templateId: templateId })
 
     await expect(
-      client.template.get({ templateId: unpublished.sys.id }),
+      client.template.get({ templateId: templateId }),
     ).rejects.toThrow()
 
-    createdIds.splice(createdIds.indexOf(created.sys.id), 1)
+    createdIds.splice(createdIds.indexOf(templateId), 1)
   })
 })

--- a/test/integration/template-integration.test.ts
+++ b/test/integration/template-integration.test.ts
@@ -39,7 +39,7 @@ describe('Template Integration', () => {
     const created = await client.template.create(
       {},
       {
-        name: `Integration Test Template [${testRunId}]`,
+        name: `Integration Test Template ${testRunId}`,
         description: 'Created by integration test',
         viewports: [testViewport],
         contentProperties: [
@@ -58,7 +58,7 @@ describe('Template Integration', () => {
     expect(created.sys.version).toBeGreaterThanOrEqual(1)
     expect(created.sys.createdAt).toBeDefined()
     expect(created.sys.createdBy).toBeDefined()
-    expect(created.name).toBe(`Integration Test Template [${testRunId}]`)
+    expect(created.name).toBe(`Integration Test Template ${testRunId}`)
 
     // --- Get ---
     const fetched = await client.template.get({ templateId: created.sys.id })
@@ -74,11 +74,11 @@ describe('Template Integration', () => {
       {
         ...fetched,
         sys: { id: fetched.sys.id, type: 'Template' as const, version: fetched.sys.version },
-        name: `Integration Test Template Updated [${testRunId}]`,
+        name: `Integration Test Template Updated ${testRunId}`,
       },
     )
 
-    expect(updated.name).toBe(`Integration Test Template Updated [${testRunId}]`)
+    expect(updated.name).toBe(`Integration Test Template Updated ${testRunId}`)
     expect(updated.sys.version).toBeGreaterThan(fetched.sys.version)
 
     // --- GetMany (cursor pagination) ---

--- a/test/integration/template-integration.test.ts
+++ b/test/integration/template-integration.test.ts
@@ -3,7 +3,7 @@ import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
 import { testName, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
 
-describe('Template Integration', () => {
+describe('Template Integration', { sequential: true }, () => {
   const client = initPlainClient({
     spaceId: TestDefaults.spaceId,
     environmentId: TestDefaults.environmentId,
@@ -51,7 +51,7 @@ describe('Template Integration', () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('creates a template with correct sys fields', async () => {
+  it('has correct sys fields after creation', async () => {
     const template = await client.template.get({ templateId: templateId })
 
     expect(template.sys.id).toBeDefined()
@@ -76,6 +76,7 @@ describe('Template Integration', () => {
   it('updates a template', async () => {
     const current = await client.template.get({ templateId: templateId })
 
+    // Update types require minimal sys — full entity sys is not assignable
     const updated = await client.template.update(
       { templateId: templateId },
       {
@@ -92,10 +93,8 @@ describe('Template Integration', () => {
   it('lists templates with cursor pagination', async () => {
     const collection = await client.template.getMany({ query: { limit: 10 } })
 
-    expect(collection.sys).toBeDefined()
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
     expect(collection.pages).toBeDefined()
-    expect(collection.items).toBeDefined()
-    expect(Array.isArray(collection.items)).toBe(true)
 
     const found = collection.items.find((item) => item.sys.id === templateId)
     expect(found).toBeDefined()
@@ -124,6 +123,24 @@ describe('Template Integration', () => {
     expect(unpublished.sys.publishedVersion).toBeUndefined()
   })
 
+  it('rejects delete on a published entity', async () => {
+    const current = await client.template.get({ templateId: templateId })
+    if (!current.sys.publishedVersion) {
+      await client.template.publish({
+        templateId: templateId,
+        version: current.sys.version,
+      })
+    }
+
+    await expect(client.template.delete({ templateId: templateId })).rejects.toThrow()
+
+    const latest = await client.template.get({ templateId: templateId })
+    await client.template.unpublish({
+      templateId: templateId,
+      version: latest.sys.version,
+    })
+  })
+
   it('deletes a template', async () => {
     const current = await client.template.get({ templateId: templateId })
     expect(current.sys.publishedVersion).toBeUndefined()
@@ -132,6 +149,7 @@ describe('Template Integration', () => {
 
     await expect(client.template.get({ templateId: templateId })).rejects.toThrow()
 
-    createdIds.splice(createdIds.indexOf(templateId), 1)
+    const idx = createdIds.indexOf(templateId)
+    if (idx !== -1) createdIds.splice(idx, 1)
   })
 })

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -142,6 +142,7 @@ export async function sweepStaleExoEntities(
   }
 
   // Sweep dependents first, then parents
-  await Promise.all([sweepExperiences(), sweepFragments(), sweepDataAssemblies(), sweepTemplates()])
+  await Promise.all([sweepExperiences(), sweepFragments(), sweepDataAssemblies()])
+  await sweepTemplates()
   await sweepComponentTypes()
 }

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -1,8 +1,8 @@
 import type { PlainClientAPI } from '../../../lib/index'
 
-export const TEST_PREFIX = 'CI-TEST-ExO'
+export const TEST_PREFIX = 'Integration Test'
 
-export const testRunId = `${TEST_PREFIX}-${Date.now()}`
+export const testRunId = `ci-${Date.now()}`
 
 export const testViewport = {
   id: 'desktop',

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -1,8 +1,9 @@
 import type { PlainClientAPI } from '../../../lib/index'
+import { generateRandomId } from '../../helpers'
 
 export const TEST_PREFIX = 'Integration Test'
 
-export const testRunId = `ci-${Date.now()}`
+export const testRunId = generateRandomId('exo')
 
 export const testViewport = {
   id: 'desktop',

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -1,0 +1,144 @@
+import type { PlainClientAPI } from '../../../lib/index'
+
+export const TEST_PREFIX = 'CI-TEST-ExO'
+
+export const testRunId = `${TEST_PREFIX}-${Date.now()}`
+
+export const testViewport = {
+  id: 'desktop',
+  query: '(min-width: 1024px)',
+  displayName: 'Desktop',
+  previewSize: '100%',
+} as const
+
+/**
+ * Sweeps stale test entities from prior runs that may have been orphaned
+ * (e.g., from CI timeouts, process kills, or flaky runs).
+ * Deletes entities whose names start with TEST_PREFIX and were created more
+ * than `maxAgeMs` milliseconds ago.
+ */
+export async function sweepStaleExoEntities(
+  client: PlainClientAPI,
+  maxAgeMs = 10 * 60 * 1000,
+): Promise<void> {
+  const cutoff = new Date(Date.now() - maxAgeMs)
+
+  const sweepComponentTypes = async () => {
+    try {
+      const { items } = await client.componentType.getMany({ query: { limit: 100 } })
+      for (const item of items) {
+        if (item.name.startsWith(TEST_PREFIX) && new Date(item.sys.createdAt) < cutoff) {
+          try {
+            if (item.sys.publishedVersion) {
+              await client.componentType.unpublish({
+                componentTypeId: item.sys.id,
+                version: item.sys.version,
+              })
+            }
+            await client.componentType.delete({ componentTypeId: item.sys.id })
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    } catch {
+      // ignore if listing fails
+    }
+  }
+
+  const sweepTemplates = async () => {
+    try {
+      const { items } = await client.template.getMany({ query: { limit: 100 } })
+      for (const item of items) {
+        if (item.name.startsWith(TEST_PREFIX) && new Date(item.sys.createdAt) < cutoff) {
+          try {
+            if (item.sys.publishedVersion) {
+              await client.template.unpublish({
+                templateId: item.sys.id,
+                version: item.sys.version,
+              })
+            }
+            await client.template.delete({ templateId: item.sys.id })
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    } catch {
+      // ignore if listing fails
+    }
+  }
+
+  const sweepDataAssemblies = async () => {
+    try {
+      const { items } = await client.dataAssembly.getMany({ query: { limit: 100 } })
+      for (const item of items) {
+        if (item.name.startsWith(TEST_PREFIX) && new Date(String(item.sys.createdAt)) < cutoff) {
+          try {
+            if (item.sys.publishedVersion) {
+              await client.dataAssembly.unpublish({
+                dataAssemblyId: item.sys.id,
+                version: item.sys.version,
+              })
+            }
+            await client.dataAssembly.delete({ dataAssemblyId: item.sys.id })
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    } catch {
+      // ignore if listing fails
+    }
+  }
+
+  const sweepExperiences = async () => {
+    try {
+      const { items } = await client.experience.getMany({ query: { limit: 100 } })
+      for (const item of items) {
+        if (item.name.startsWith(TEST_PREFIX) && new Date(item.sys.createdAt) < cutoff) {
+          try {
+            if (item.sys.publishedVersion) {
+              await client.experience.unpublish({
+                experienceId: item.sys.id,
+                version: item.sys.version,
+              })
+            }
+            await client.experience.delete({ experienceId: item.sys.id })
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    } catch {
+      // ignore if listing fails
+    }
+  }
+
+  const sweepFragments = async () => {
+    try {
+      const { items } = await client.fragment.getMany({ query: { limit: 100 } })
+      for (const item of items) {
+        if (item.name.startsWith(TEST_PREFIX) && new Date(item.sys.createdAt) < cutoff) {
+          try {
+            if (item.sys.publishedVersion) {
+              await client.fragment.unpublish({
+                fragmentId: item.sys.id,
+                version: item.sys.version,
+              })
+            }
+            await client.fragment.delete({ fragmentId: item.sys.id })
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    } catch {
+      // ignore if listing fails
+    }
+  }
+
+  // Sweep dependents first, then parents
+  await Promise.all([sweepExperiences(), sweepFragments(), sweepDataAssemblies(), sweepTemplates()])
+  await sweepComponentTypes()
+}

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -1,9 +1,11 @@
 import type { PlainClientAPI } from '../../../lib/index'
 import { generateRandomId } from '../../helpers'
 
-export const TEST_PREFIX = 'Integration Test'
+export const TEST_PREFIX = '[ExO Integration Test]'
 
-export const testRunId = generateRandomId('exo')
+const testRunId = generateRandomId('exo')
+
+export const testName = (entity: string) => `${TEST_PREFIX} ${entity} ${testRunId}`
 
 export const testViewport = {
   id: 'desktop',

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -14,16 +14,23 @@ export const testViewport = {
   previewSize: '100%',
 } as const
 
+const SWEEP_KEY = '__exoIntegrationSwept'
+
 /**
  * Sweeps stale test entities from prior runs that may have been orphaned
  * (e.g., from CI timeouts, process kills, or flaky runs).
  * Deletes entities whose names start with TEST_PREFIX and were created more
  * than `maxAgeMs` milliseconds ago.
+ *
+ * Guarded to run only once per test process — safe across sequential file execution.
  */
 export async function sweepStaleExoEntities(
   client: PlainClientAPI,
   maxAgeMs = 10 * 60 * 1000,
 ): Promise<void> {
+  if ((globalThis as Record<string, unknown>)[SWEEP_KEY]) return
+  ;(globalThis as Record<string, unknown>)[SWEEP_KEY] = true
+
   const cutoff = new Date(Date.now() - maxAgeMs)
 
   const sweepComponentTypes = async () => {


### PR DESCRIPTION
## Summary

- Adds integration tests for **all 5 ExO entities**: ComponentType, Template, DataAssembly, Experience, Fragment
- Each test covers the full CRUD + publish lifecycle against the live Bridge API
- DataAssembly tests additionally cover `getPublished` / `getManyPublished`
- Experience tests cover locale-aware publishing (`{ add: ['en-US'] }`)
- Tests are self-contained — no dependency on pre-seeded data, cleanup in `afterAll`
- Negative-path tests validate that the SDK surfaces Bridge API errors correctly (invalid create payloads, delete-while-published)

### Test hardening

- `{ sequential: true }` on all describe blocks (matches repo convention used by 10+ other integration tests)
- `sweepStaleExoEntities` guarded to run once per process — avoids redundant API calls across sequential files
- Defensive `indexOf` check before `splice` in cleanup to prevent silent array corruption
- Tighter pagination assertions (length checks instead of bare `toBeDefined`)

## Test plan

- [ ] Run integration tests with valid CMA token against Bridge API:
  ```
  CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN=<token> CONTENTFUL_ORGANIZATION_ID=<org_id> \
    npx vitest --project integration --run \
    test/integration/component-type-integration.test.ts \
    test/integration/template-integration.test.ts \
    test/integration/data-assembly-integration.test.ts \
    test/integration/experience-integration.test.ts \
    test/integration/fragment-integration.test.ts
  ```
- [ ] Verify no leftover entities in test space after run
- [ ] Confirm negative-path tests reject with API errors (not timeouts)
- [ ] Confirm cursor pagination shape (`sys`, `pages`, `items`) in getMany responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)