### PR TITLE
feat: add TypeRefDataTypeField variant to DataAssembly DataTypeField union [DX-1080]

### DIFF
--- a/lib/entities/data-assembly.ts
+++ b/lib/entities/data-assembly.ts
@@ -3,16 +3,29 @@ import type {
   ExoCursorPaginatedCollectionProp,
   Link,
   MetadataProps,
+  ResourceLink,
 } from '../common-types'
 import { User } from './user'
 
-export type DataAssemblyDataTypeField = {
+export type DataAssemblyPrimitiveDataTypeField = {
   id: string
   name: string
   type: string
   required: boolean
   source?: string
 }
+
+export type DataAssemblyTypeRefDataTypeField = {
+  id: string
+  name: string
+  type: 'TypeRef'
+  ref: ResourceLink<'Contentful:DataAssembly'>
+  required: boolean
+}
+
+export type DataAssemblyDataTypeField =
+  | DataAssemblyPrimitiveDataTypeField
+  | DataAssemblyTypeRefDataTypeField
 
 export type DataAssemblyLinkParameter = {
   name?: string


### PR DESCRIPTION
## Summary

- Expands `DataAssemblyDataTypeField` from a flat object into a discriminated union matching upstream
- Adds `DataAssemblyTypeRefDataTypeField` variant (`type: 'TypeRef'`, `ref: ResourceLink<'Contentful:DataAssembly'>`)
- Renames the original shape to `DataAssemblyPrimitiveDataTypeField` for clarity

## Context

The upstream `DataTypeFieldSchema` in `assemblies-types` is a union of `PrimitiveDataTypeField` and `TypeRefDataTypeField`. The SDK only modeled the primitive arm — any DA response with a TypeRef field would silently lose the `ref` property at the type level.

## Test plan

- [x] `npx tsc --noEmit` passes cleanly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)