### PR TITLE
fix: correct NestedDataAssemblyResolver source type and add dataAssembly field [DX-1081]

### DIFF
--- a/lib/entities/data-assembly.ts
+++ b/lib/entities/data-assembly.ts
@@ -3,6 +3,7 @@ import type {
   ExoCursorPaginatedCollectionProp,
   Link,
   MetadataProps,
+  ResourceLink,
 } from '../common-types'
 import { User } from './user'
 
@@ -31,7 +32,8 @@ export type DataAssemblyGraphQLResolver = {
 }
 
 export type DataAssemblyNestedResolver = {
-  source: `Contentful:DataAssembly:${string}`
+  source: 'Contentful:DataAssembly'
+  dataAssembly: ResourceLink<'Contentful:DataAssembly'>
   parameters?: Record<string, unknown>
 }
 


### PR DESCRIPTION
## Summary

- Narrows `DataAssemblyNestedResolver.source` from template literal `` `Contentful:DataAssembly:${string}` `` to fixed literal `'Contentful:DataAssembly'`
- Adds required `dataAssembly: ResourceLink<'Contentful:DataAssembly'>` field

## Context

The upstream design separated the referenced assembly ID into a dedicated `dataAssembly` ResourceLink field. The `source` became a fixed discriminant, not a carrier of the ID. The SDK was never updated, making nested resolver configs structurally wrong in both directions.

## Test plan

- [x] `npx tsc --noEmit` passes cleanly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)