### PR TITLE
feat: add TypeRefContentProperty variant to ComponentTypeContentProperty union [DX-1082]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -22,14 +22,28 @@ export type ComponentTypeViewport = {
   previewSize: string
 }
 
-// Content property definition
-export type ComponentTypeContentProperty = {
+// Primitive content property — String, Number, Boolean
+export type ComponentTypePrimitiveContentProperty = {
   id: string
   name: string
   type: 'String' | 'Number' | 'Boolean'
   required: boolean
   defaultValue?: unknown
 }
+
+// TypeRef content property — references a DataAssembly or ComponentType
+export type ComponentTypeTypeRefContentProperty = {
+  id: string
+  name: string
+  type: 'TypeRef'
+  ref: ResourceLink<'Contentful:DataAssembly'> | ResourceLink<'Contentful:ComponentType'>
+  required: boolean
+}
+
+// Discriminated union covering all content property variants
+export type ComponentTypeContentProperty =
+  | ComponentTypePrimitiveContentProperty
+  | ComponentTypeTypeRefContentProperty
 
 // Validation entry for legacy design property validations.in
 export type ComponentTypeDesignPropertyValidation =


### PR DESCRIPTION
## Summary

- Expands `ComponentTypeContentProperty` from a flat primitive-only type into a discriminated union on `type`
- Adds `ComponentTypeTypeRefContentProperty` variant (`type: 'TypeRef'`, `ref: ResourceLink<'Contentful:DataAssembly'> | ResourceLink<'Contentful:ComponentType'>`)
- Renames the original shape to `ComponentTypePrimitiveContentProperty`
- `TemplateProps` inherits the fix automatically via its existing import

## Context

The upstream `ContentPropertySchema` supports both primitive values and TypeRef references (to DataAssemblies or ComponentTypes). The SDK only modeled the primitive arm, meaning SDK consumers couldn't type-check or construct compositional content properties.

## Test plan

- [x] `npx tsc --noEmit` passes cleanly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)