### PR TITLE
fix: stop sending immutable fields in update payloads [DX-1102, DX-1104]

### DIFF
--- a/lib/adapters/REST/endpoints/experience.ts
+++ b/lib/adapters/REST/endpoints/experience.ts
@@ -1,7 +1,6 @@
 import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type { SetOptional } from 'type-fest'
 import type { GetSpaceEnvironmentParams, GetExperienceParams } from '../../../common-types'
 import type {
   CreateExperienceProps,
@@ -54,19 +53,10 @@ export const update: RestEndpoint<'Experience', 'update'> = (
   rawData: UpdateExperienceProps,
   headers?: RawAxiosRequestHeaders,
 ) => {
-  const data: SetOptional<typeof rawData, 'sys'> & {
-    componentTypeId?: string
-    templateId?: string
-  } = copy(rawData)
-  if (rawData.sys.componentType) {
-    data.componentTypeId = rawData.sys.componentType.sys.id
-  } else if (rawData.sys.template) {
-    data.templateId = rawData.sys.template.sys.id
-  }
-  delete data.sys
-  return raw.put<ExperienceProps>(http, getBaseUrl(params) + `/${params.experienceId}`, data, {
+  const { sys, ...body } = copy(rawData)
+  return raw.put<ExperienceProps>(http, getBaseUrl(params) + `/${params.experienceId}`, body, {
     headers: {
-      'X-Contentful-Version': rawData.sys.version ?? 0,
+      'X-Contentful-Version': sys.version ?? 0,
       ...headers,
     },
   })

--- a/lib/adapters/REST/endpoints/fragment.ts
+++ b/lib/adapters/REST/endpoints/fragment.ts
@@ -1,7 +1,6 @@
 import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
 import copy from 'fast-copy'
-import type { SetOptional } from 'type-fest'
 import type { GetFragmentParams, GetSpaceEnvironmentParams } from '../../../common-types'
 import type {
   CreateFragmentProps,
@@ -51,12 +50,11 @@ export const update: RestEndpoint<'Fragment', 'update'> = (
   rawData: UpdateFragmentProps,
   headers?: RawAxiosRequestHeaders,
 ) => {
-  const data: SetOptional<typeof rawData, 'sys'> = copy(rawData)
-  delete data.sys
-  return raw.put<FragmentProps>(http, getBaseUrl(params) + `/${params.fragmentId}`, data, {
+  const { sys, ...body } = copy(rawData)
+  return raw.put<FragmentProps>(http, getBaseUrl(params) + `/${params.fragmentId}`, body, {
     headers: {
-      ...(rawData.sys?.version !== undefined && {
-        'X-Contentful-Version': rawData.sys.version,
+      ...(sys?.version !== undefined && {
+        'X-Contentful-Version': sys.version,
       }),
       ...headers,
     },

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -84,7 +84,13 @@ export type CreateExperienceProps = ExperienceCommonProps &
     | { templateId: string; componentTypeId?: never }
   )
 
-export type UpdateExperienceProps = ExperienceProps
+export type UpdateExperienceProps = ExperienceCommonProps & {
+  sys: {
+    id: string
+    type: 'Experience'
+    version: number
+  }
+}
 
 export type InlineFragmentNode = {
   id: string

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -63,7 +63,6 @@ export type UpdateFragmentProps = Omit<FragmentProps, 'sys'> & {
     type: 'Fragment'
     version: number
   }
-  componentTypeId: string
 }
 
 export type FragmentQueryOptions = CursorPaginationParams &

--- a/test/integration/fragment-integration.test.ts
+++ b/test/integration/fragment-integration.test.ts
@@ -115,7 +115,6 @@ describe('Fragment Integration', { sequential: true }, () => {
       {
         ...current,
         sys: { id: current.sys.id, type: 'Fragment' as const, version: current.sys.version },
-        componentTypeId: componentTypeId,
         name: testName('Fragment Updated'),
       },
     )

--- a/test/unit/adapters/REST/endpoints/experience.test.ts
+++ b/test/unit/adapters/REST/endpoints/experience.test.ts
@@ -300,7 +300,7 @@ describe('Rest Experience', { concurrent: true }, () => {
       })
   })
 
-  test('update calls correct URL with version header', async () => {
+  test('update calls correct URL with version header and strips sys', async () => {
     const mockResponse = {
       sys: { id: 'experience123', type: 'Experience', version: 2 },
       name: 'Updated Experience',
@@ -345,58 +345,6 @@ describe('Rest Experience', { concurrent: true }, () => {
         )
         expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
         const body = httpMock.put.mock.calls[0][1]
-        expect(body.componentTypeId).to.eql('ct-123')
-        expect(body.sys).to.be.undefined
-      })
-  })
-
-  test('update sends templateId when experience is template-backed', async () => {
-    const mockResponse = {
-      sys: { id: 'experience123', type: 'Experience', version: 2 },
-      name: 'Updated Experience',
-      description: 'A template-backed experience',
-      viewports: [],
-      contentProperties: {},
-      designProperties: {},
-      dimensionKeyMap: { designProperties: {} },
-    }
-
-    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
-
-    return adapterMock
-      .makeRequest({
-        entityType: 'Experience',
-        action: 'update',
-        userAgent: 'mocked',
-        params: {
-          spaceId: 'space123',
-          environmentId: 'master',
-          experienceId: 'experience123',
-        },
-        payload: {
-          sys: {
-            version: 1,
-            template: {
-              sys: { type: 'Link', linkType: 'Template', id: 'tmpl-456' },
-            },
-          },
-          name: 'Updated Experience',
-          description: 'A template-backed experience',
-          viewports: [],
-          contentProperties: {},
-          designProperties: {},
-          dimensionKeyMap: { designProperties: {} },
-        },
-      })
-      .then((r) => {
-        expect(r).to.eql(mockResponse)
-        expect(httpMock.put.mock.calls[0][0]).to.eql(
-          '/spaces/space123/environments/master/experiences/experience123',
-        )
-        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
-        const body = httpMock.put.mock.calls[0][1]
-        expect(body.templateId).to.eql('tmpl-456')
-        expect(body.componentTypeId).to.be.undefined
         expect(body.sys).to.be.undefined
       })
   })

--- a/test/unit/adapters/REST/endpoints/fragment.test.ts
+++ b/test/unit/adapters/REST/endpoints/fragment.test.ts
@@ -182,6 +182,8 @@ describe('Rest Fragment', { concurrent: true }, () => {
           '/spaces/space123/environments/master/fragments/fragment123',
         )
         expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
+        const body = httpMock.put.mock.calls[0][1]
+        expect(body.sys).to.be.undefined
       })
   })
 


### PR DESCRIPTION
## Summary

- **Fragment**: Remove `componentTypeId` from `UpdateFragmentProps` and refactor the REST adapter to destructure-and-spread, so only mutable fields reach the PUT body.
- **Experience**: Replace `ExperienceProps` alias with an explicit `ExperienceCommonProps & { sys: { id, type, version } }` update type. Refactor the adapter to remove the logic that extracted `sys.componentType`/`sys.template` links into `componentTypeId`/`templateId` — now it's a clean `const { sys, ...body }` destructure.
- **Tests**: Remove fragment integration test's `componentTypeId` from the update payload. Collapse redundant experience unit tests that asserted on fields that can no longer exist.

## Motivation

The upstream `experiences-api-schemas` already defines separate update schemas (`FragmentUpdateConfigSchema`, `ExperienceUpdateConfig`) that exclude immutable creation-only fields. The SDK adapter was never updated to reflect this — it actively synthesized `componentTypeId`/`templateId` from sys links and injected them into the PUT body.

This went unnoticed until the upstream API enforced validation:
- **Fragment**: `strictObject` rejects with `"Unrecognized key: componentTypeId"`
- **Experience**: business rule rejects with `"templateId is immutable after creation"`

The SDK update types now align 1:1 with the upstream update schemas.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Unit tests pass (20/20)
- [x] Type tests pass (16/16)
- [ ] Integration tests pass in CI (fragment + experience update calls no longer send immutable fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)