### PR TITLE
feat: add ReleaseFragment type family [DX-1085]

### DIFF
--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -71,3 +71,16 @@ export type FragmentQueryOptions = CursorPaginationParams &
   }
 
 export type FragmentCollection = ExoCursorPaginatedCollectionProp<FragmentProps>
+
+export type ReleaseFragmentSys = Omit<
+  FragmentSys,
+  'variant' | 'variantType' | 'variantDimension'
+> & {
+  release: Link<'Release'>
+}
+
+export type ReleaseFragment = Omit<FragmentProps, 'sys'> & {
+  sys: ReleaseFragmentSys
+}
+
+export type ReleaseFragmentCollection = ExoCursorPaginatedCollectionProp<ReleaseFragment>

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -360,5 +360,10 @@ export type {
   ReleaseExperienceCollection,
   ReleaseExperienceSys,
 } from './entities/experience'
-export type { FragmentCollection } from './entities/fragment'
+export type {
+  FragmentCollection,
+  ReleaseFragment,
+  ReleaseFragmentCollection,
+  ReleaseFragmentSys,
+} from './entities/fragment'
 export type { DataAssemblyCollection } from './entities/data-assembly'

--- a/test/unit/entities/fragment-types.test.ts
+++ b/test/unit/entities/fragment-types.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expectTypeOf } from 'vitest'
+import type {
+  ReleaseFragmentSys,
+  ReleaseFragment,
+  ReleaseFragmentCollection,
+} from '../../../lib/entities/fragment'
+import type { Link, ExoCursorPaginatedCollectionProp } from '../../../lib/common-types'
+
+describe('ReleaseFragment types', () => {
+  test('ReleaseFragmentSys has release link', () => {
+    expectTypeOf<ReleaseFragmentSys['release']>().toEqualTypeOf<Link<'Release'>>()
+  })
+
+  test('ReleaseFragmentSys omits variant fields', () => {
+    type HasVariant = 'variant' extends keyof ReleaseFragmentSys ? true : false
+    expectTypeOf<HasVariant>().toEqualTypeOf<false>()
+
+    type HasVariantType = 'variantType' extends keyof ReleaseFragmentSys ? true : false
+    expectTypeOf<HasVariantType>().toEqualTypeOf<false>()
+
+    type HasVariantDimension = 'variantDimension' extends keyof ReleaseFragmentSys ? true : false
+    expectTypeOf<HasVariantDimension>().toEqualTypeOf<false>()
+  })
+
+  test('ReleaseFragmentSys retains base fields from FragmentSys', () => {
+    expectTypeOf<ReleaseFragmentSys['id']>().toBeString()
+    expectTypeOf<ReleaseFragmentSys['type']>().toEqualTypeOf<'Fragment'>()
+  })
+
+  test('ReleaseFragment has ReleaseFragmentSys', () => {
+    expectTypeOf<ReleaseFragment['sys']>().toEqualTypeOf<ReleaseFragmentSys>()
+  })
+
+  test('ReleaseFragment has name and description from FragmentProps', () => {
+    expectTypeOf<ReleaseFragment['name']>().toBeString()
+    expectTypeOf<ReleaseFragment['description']>().toBeString()
+  })
+
+  test('ReleaseFragmentCollection is a paginated collection of ReleaseFragment', () => {
+    expectTypeOf<ReleaseFragmentCollection>().toMatchTypeOf<
+      ExoCursorPaginatedCollectionProp<ReleaseFragment>
+    >()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `ReleaseFragmentSys` — `FragmentSys` minus variant fields, plus `release: Link<'Release'>`
- Adds `ReleaseFragment` — `FragmentProps` with `ReleaseFragmentSys`
- Adds `ReleaseFragmentCollection` — cursor-paginated collection wrapper
- Exports all three types from public surface (`lib/export-types.ts`)

## Context
The upstream schema defines `ReleaseFragment`, `ReleaseFragmentSys`, and `ReleaseFragmentCollection`. The Experience equivalent was added in DX-1001 but the Fragment counterpart was not. This brings Fragment into parity.

## Test plan
- [x] Type-level unit tests verify release link presence, variant field omission, base field retention, and collection typing
- [x] Tests pass locally (`vitest run --project unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)