### PR TITLE
[HEJO-8664]feat: adds new query params

### DIFF
--- a/lib/adapters/REST/endpoints/space.ts
+++ b/lib/adapters/REST/endpoints/space.ts
@@ -7,6 +7,7 @@ import type {
   GetOrganizationParams,
   GetSpaceParams,
   QueryParams,
+  SpaceQueryOptions,
 } from '../../../common-types'
 import type { SpaceProps, UnarchiveProps } from '../../../entities/space'
 import type { RestEndpoint } from '../types'
@@ -22,17 +23,26 @@ export const get: RestEndpoint<'Space', 'get'> = (
 
 export const getMany: RestEndpoint<'Space', 'getMany'> = (
   http: AxiosInstance,
-  params: QueryParams & {
+  params: {
+    query?: SpaceQueryOptions
     organizationId?: string
     include?: 'sys.license'
   },
-) =>
-  raw.get<CollectionProp<SpaceProps>>(http, `/spaces`, {
-    params: { ...params.query, ...(params.include ? { include: params.include } : {}) },
+) => {
+  // Build query parameters according to OpenAPI spec
+  // Supports: skip, limit, order, cursor, pageNext, pagePrev, query (search), type (filter)
+  const queryParams = {
+    ...params.query,
+    ...(params.include ? { include: params.include } : {}),
+  }
+
+  return raw.get<CollectionProp<SpaceProps>>(http, `/spaces`, {
+    params: queryParams,
     headers: params.organizationId
       ? { 'X-Contentful-Organization': params.organizationId }
       : undefined,
   })
+}
 
 export const getManyForOrganization: RestEndpoint<'Space', 'getManyForOrganization'> = (
   http: AxiosInstance,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -293,6 +293,18 @@ export interface QueryOptions extends PaginationQueryOptions {
 /** @internal */
 export interface SpaceQueryOptions extends PaginationQueryOptions {
   spaceId?: string
+  /** Search spaces by exact key (ID) match or partial name match */
+  query?: string
+  /** Filter spaces by type. Cannot be used together with sys.archivedAt.
+   * The 'templated' type requires the X-Contentful-Organization header.
+   */
+  type?: 'active' | 'archived' | 'templated'
+  /** Enable cursor-based pagination (default: false for offset pagination) */
+  cursor?: boolean
+  /** Cursor for the next page of results (cursor pagination) */
+  pageNext?: string
+  /** Cursor for the previous page of results (cursor pagination) */
+  pagePrev?: string
 }
 
 export interface BasicMetaSysProps {
@@ -2359,7 +2371,7 @@ export type MRActions = {
       return: SpaceProps & { includes?: SpaceIncludes }
     }
     getMany: {
-      params: QueryParams & { organizationId?: string } & SpaceIncludeParam
+      params: { query?: SpaceQueryOptions; organizationId?: string } & SpaceIncludeParam
       return: (CollectionProp<SpaceProps> | CursorPaginatedCollectionProp<SpaceProps>) & {
         includes?: SpaceIncludes
       }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -87,6 +87,23 @@ export async function getTestOrganization(): Promise<Organization> {
   return org
 }
 
+export async function getTestProductId(): Promise<string> {
+  if (process.env.CONTENTFUL_PRODUCT_ID) {
+    return process.env.CONTENTFUL_PRODUCT_ID
+  }
+
+  const organization = await getTestOrganization()
+  const availableLicenses = await organization.getAvailableLicenses()
+  const license = availableLicenses.items.find(({ count }) => count > 0)
+
+  if (!license) {
+    throw new Error('No available license found for integration test space creation')
+  }
+
+  // AvailableLicense.id is the product/offer id used when creating a space.
+  return license.id
+}
+
 export async function getTestUser() {
   const { userId } = TestDefaults
   const organization = await getTestOrganization()
@@ -141,13 +158,17 @@ export async function createAppInstallation(appDefinitionId) {
 }
 
 export const createTestSpace = async (client, testSuiteName = '') => {
-  return testUtils.createTestSpace({
-    client,
-    organizationId: orgId,
-    repo: 'CMA',
-    language: 'JS',
-    testSuiteName,
-  }) as unknown as Space
+  const spaceName = `%JS CMA ${testSuiteName}`
+  const productId = await getTestProductId()
+
+  return client.createSpace(
+    {
+      name: spaceName,
+      productId,
+      defaultLocale: 'en',
+    },
+    orgId,
+  ) as unknown as Space
 }
 
 export const createTestEnvironment = async (space, environmentName) => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -87,23 +87,6 @@ export async function getTestOrganization(): Promise<Organization> {
   return org
 }
 
-export async function getTestProductId(): Promise<string> {
-  if (process.env.CONTENTFUL_PRODUCT_ID) {
-    return process.env.CONTENTFUL_PRODUCT_ID
-  }
-
-  const organization = await getTestOrganization()
-  const availableLicenses = await organization.getAvailableLicenses()
-  const license = availableLicenses.items.find(({ count }) => count > 0)
-
-  if (!license) {
-    throw new Error('No available license found for integration test space creation')
-  }
-
-  // AvailableLicense.id is the product/offer id used when creating a space.
-  return license.id
-}
-
 export async function getTestUser() {
   const { userId } = TestDefaults
   const organization = await getTestOrganization()
@@ -158,17 +141,13 @@ export async function createAppInstallation(appDefinitionId) {
 }
 
 export const createTestSpace = async (client, testSuiteName = '') => {
-  const spaceName = `%JS CMA ${testSuiteName}`
-  const productId = await getTestProductId()
-
-  return client.createSpace(
-    {
-      name: spaceName,
-      productId,
-      defaultLocale: 'en',
-    },
-    orgId,
-  ) as unknown as Space
+  return testUtils.createTestSpace({
+    client,
+    organizationId: orgId,
+    repo: 'CMA',
+    language: 'JS',
+    testSuiteName,
+  }) as unknown as Space
 }
 
 export const createTestEnvironment = async (space, environmentName) => {

--- a/test/integration/space-integration.test.ts
+++ b/test/integration/space-integration.test.ts
@@ -1,14 +1,20 @@
 import { describe, it, beforeAll, afterAll } from 'vitest'
 import { expect } from 'vitest'
-import { defaultClient, getTestOrganization, timeoutToCalmRateLimiting } from '../helpers'
+import {
+  defaultClient,
+  getTestOrganization,
+  getTestProductId,
+  timeoutToCalmRateLimiting,
+} from '../helpers'
 import type { Organization } from '../../lib/export-types'
 
 describe('Space API', () => {
   let organization: Organization
-  const INTERNAL_PRODUCT_ID = process.env.CONTENTFUL_PRODUCT_ID || '54jwueRJC2BOihxYMIdYoD'
+  let productId: string
 
   beforeAll(async () => {
     organization = await getTestOrganization()
+    productId = await getTestProductId()
   })
 
   afterAll(timeoutToCalmRateLimiting)
@@ -24,7 +30,7 @@ describe('Space API', () => {
     const space = await defaultClient.createSpace(
       {
         name: 'test space',
-        productId: INTERNAL_PRODUCT_ID,
+        productId,
         defaultLocale: 'en',
       },
       organization.sys.id,
@@ -40,13 +46,13 @@ describe('Space API', () => {
     const space = await defaultClient.createSpace(
       {
         name: 'test space for unarchive',
-        productId: INTERNAL_PRODUCT_ID,
+        productId,
         defaultLocale: 'en',
       },
       organization.sys.id,
     )
     try {
-      await space.unarchive(INTERNAL_PRODUCT_ID)
+      await space.unarchive(productId)
     } catch (e) {
       expect((e as { name: string }).name).toEqual('ValidationFailed')
     } finally {

--- a/test/integration/space-integration.test.ts
+++ b/test/integration/space-integration.test.ts
@@ -1,20 +1,14 @@
 import { describe, it, beforeAll, afterAll } from 'vitest'
 import { expect } from 'vitest'
-import {
-  defaultClient,
-  getTestOrganization,
-  getTestProductId,
-  timeoutToCalmRateLimiting,
-} from '../helpers'
+import { defaultClient, getTestOrganization, timeoutToCalmRateLimiting } from '../helpers'
 import type { Organization } from '../../lib/export-types'
 
 describe('Space API', () => {
   let organization: Organization
-  let productId: string
+  const INTERNAL_PRODUCT_ID = process.env.CONTENTFUL_PRODUCT_ID || '54jwueRJC2BOihxYMIdYoD'
 
   beforeAll(async () => {
     organization = await getTestOrganization()
-    productId = await getTestProductId()
   })
 
   afterAll(timeoutToCalmRateLimiting)
@@ -30,7 +24,6 @@ describe('Space API', () => {
     const space = await defaultClient.createSpace(
       {
         name: 'test space',
-        productId,
         defaultLocale: 'en',
       },
       organization.sys.id,
@@ -46,13 +39,12 @@ describe('Space API', () => {
     const space = await defaultClient.createSpace(
       {
         name: 'test space for unarchive',
-        productId,
         defaultLocale: 'en',
       },
       organization.sys.id,
     )
     try {
-      await space.unarchive(productId)
+      await space.unarchive(INTERNAL_PRODUCT_ID)
     } catch (e) {
       expect((e as { name: string }).name).toEqual('ValidationFailed')
     } finally {


### PR DESCRIPTION
https://contentful.atlassian.net/browse/HEJO-8664

## Summary

The PR updates the /spaces API with the following new params 
  - query - Search spaces by exact key (ID) match or partial name match
  - type - Filter by space type ('active', 'archived', or 'templated')
  - cursor - Enable cursor-based pagination
  - pageNext - Cursor for the next page of results
  - pagePrev - Cursor for the previous page of results

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR simplifies the test infrastructure for creating test spaces by removing the custom dynamic product ID resolution helper and delegating space creation to the centralized `@contentful/integration-test-utils` library. The changes affect two test files: test/helpers.ts and test/integration/space-integration.test.ts.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes getTestProductId() async helper function from test/helpers.ts that previously resolved product ID from CONTENTFUL_PRODUCT_ID env var or queried available organization licenses</li>

<li>Refactors createTestSpace() in test/helpers.ts to use testUtils.createTestSpace() instead of manually calling client.createSpace() with dynamic productId and hardcoded locale</li>

<li>Updates space-integration.test.ts to replace dynamic productId variable (set in beforeAll hook) with a hardcoded INTERNAL_PRODUCT_ID constant that falls back to '54jwueRJC2BOihxYMIdYoD'</li>

<li>Removes productId parameter from createSpace() calls in space-integration.test.ts while retaining INTERNAL_PRODUCT_ID usage for the space.unarchive() test case</li>

</ul>
</details>

</div>