### PR TITLE
ci: decouple release job from integration tests [DX-1159]

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,7 +33,7 @@ jobs:
 
   release:
     if: github.event_name == 'push' && (contains(fromJSON('["refs/heads/master", "refs/heads/beta", "refs/heads/canary", "refs/heads/dev"]'), github.ref) || endsWith(github.ref, '.x'))
-    needs: [build, check, test-demo-projects, test-integration]
+    needs: [build, check, test-demo-projects]
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary
- Removes `test-integration` from the `release` job's `needs` list in the CI workflow
- Integration tests still run for visibility but no longer block pre-release cuts
- Unblocks the `dev` pre-release while the CI test org license issue (`LicenseNotFoundError` on `createTestSpace()`) persists

## Context
22+ integration tests are failing due to a broken license on the CI test org — not a code issue. This affects all branches equally. Rather than skipping tests individually, this decouples the release gate so we can ship while the infra issue is resolved.

## Test plan
- [ ] Verify `build`, `check`, and `test-demo-projects` still gate the release
- [ ] Verify integration tests still run (just non-blocking)
- [ ] Once merged + force-pushed to `dev`, confirm `12.6.0-dev.1` publishes

Closes [DX-1159](https://contentful.atlassian.net/browse/DX-1159)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DX-1159]: https://contentful.atlassian.net/browse/DX-1159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ