### PR TITLE
fix: align ComponentTypeSlotDefinition with upstream SlotDefinitionSchema [DX-1152] [DX-1165]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -192,9 +192,13 @@ export type DataAssemblyLink = Link<'DataAssembly'>
 export type ComponentTypeSlotDefinition = {
   id: string
   name: string
-  componentTypeId: string[]
   required: boolean
-  validations: unknown[]
+  validations: Array<{ size?: { min?: number; max?: number } }>
+  allowedResources?: Array<{
+    type: 'Contentful:ComponentType'
+    source: string
+    allowedTypes: string[]
+  }>
 }
 
 // ComponentType sys properties (management API shape)


### PR DESCRIPTION
[DX-1152](https://contentful.atlassian.net/browse/DX-1152) | [DX-1165](https://contentful.atlassian.net/browse/DX-1165)

## Summary
- Remove legacy `componentTypeId: string[]` field from `ComponentTypeSlotDefinition` — upstream `SlotDefinitionSchema` uses `strictObject` and rejects unrecognized keys
- Add `allowedResources?: Array<{ type: 'Contentful:ComponentType'; source: string; allowedTypes: string[] }>` matching `ComponentTypeAllowedResourceSchema`
- Tighten `validations` from `unknown[]` to `Array<{ size?: { min?: number; max?: number } }>` per `SlotSizeValidationSchema`

## Test plan
- [x] `tsc --noEmit` passes on `feat/exo`
- [x] `lint-staged` (prettier + eslint) passes
- [ ] CI green
- [ ] Verify `TemplateProps` (shared import of `ComponentTypeSlotDefinition`) still type-checks downstream

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1152]: https://contentful.atlassian.net/browse/DX-1152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-1165]: https://contentful.atlassian.net/browse/DX-1165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ