### PR TITLE
fix: send X-Contentful-Version header on space delete

### DIFF
--- a/lib/adapters/REST/endpoints/space.ts
+++ b/lib/adapters/REST/endpoints/space.ts
@@ -83,5 +83,10 @@ export const unarchive: RestEndpoint<'Space', 'unarchive'> = (
   })
 }
 
-export const del: RestEndpoint<'Space', 'delete'> = (http: AxiosInstance, params: GetSpaceParams) =>
-  raw.del(http, `/spaces/${params.spaceId}`)
+export const del: RestEndpoint<'Space', 'delete'> = (
+  http: AxiosInstance,
+  params: GetSpaceParams & { version: number },
+) =>
+  raw.del(http, `/spaces/${params.spaceId}`, {
+    headers: { 'X-Contentful-Version': params.version },
+  })

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -2386,7 +2386,7 @@ export type MRActions = {
       headers?: RawAxiosRequestHeaders
       return: SpaceProps
     }
-    delete: { params: GetSpaceParams; return: void }
+    delete: { params: GetSpaceParams & { version: number }; return: void }
   }
   SpaceMember: {
     get: { params: GetSpaceParams & { spaceMemberId: string }; return: SpaceMemberProps }

--- a/lib/create-space-api.ts
+++ b/lib/create-space-api.ts
@@ -75,7 +75,7 @@ export default function createSpaceApi(makeRequest: MakeRequest) {
       return makeRequest({
         entityType: 'Space',
         action: 'delete',
-        params: { spaceId: raw.sys.id },
+        params: { spaceId: raw.sys.id, version: raw.sys.version },
       })
     },
     /**


### PR DESCRIPTION
## Summary
- The Contentful API started requiring `X-Contentful-Version` on `DELETE /spaces/:spaceId` requests, causing integration test teardown to fail with `409 Conflict: Please pass sys.version as HTTP header "x-contentful-version"`
- Added `version: number` to `Space.delete` params type and updated the REST adapter to pass the header
- Updated `space.delete()` entity method to forward `sys.version` from the space object

## Test plan
- [ ] `npm run test:unit` passes
- [ ] `npx tsc --noEmit` clean
- [ ] Integration tests pass (specifically `locale-integration.test.ts` teardown no longer 409s on space delete)

Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes a Contentful API compatibility issue where DELETE /spaces/:spaceId requests now require the X-Contentful-Version header. Without this header, the API returns a 409 Conflict error, causing integration test teardown to fail. The fix adds version parameter support to the space delete endpoint across the type definitions, REST adapter, and Space entity.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates Space.delete REST endpoint to accept version parameter and send X-Contentful-Version header in space.ts</li>

<li>Adds { version: number } to Space.delete params type in common-types.ts MRActions definition</li>

<li>Modifies Space.delete() method in create-space-api.ts to forward sys.version from the space object to the request params</li>

</ul>
</details>

</div>