### PR TITLE
fix: add TypeRef and DataAssembly variants to ContentProperty [DX-1163] [DX-1164]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -289,6 +289,58 @@ export interface ResourceLink<T extends string> {
   }
 }
 
+// Canonical DataTypeDefinition — mirrors @contentful/data-type
+export type PrimitiveDataTypeName = 'String' | 'Number' | 'Integer' | 'Boolean'
+
+export type BaseDataTypeDefinition = {
+  name?: string
+  required?: boolean
+}
+
+export type PrimitiveDataTypeDefinition = BaseDataTypeDefinition & {
+  type: PrimitiveDataTypeName
+}
+
+export type RichTextDataTypeDefinition = BaseDataTypeDefinition & {
+  type: 'RichText'
+}
+
+export type ArrayDataTypeDefinition = BaseDataTypeDefinition & {
+  type: 'Array'
+  items: DataTypeDefinition
+}
+
+export type RecordDataTypeDefinition = BaseDataTypeDefinition & {
+  type: 'Record'
+  fields: Record<string, DataTypeDefinition>
+}
+
+export type TypeRefDataTypeDefinition = BaseDataTypeDefinition & {
+  type: 'TypeRef'
+  ref: ResourceLink<string>
+}
+
+export type LiteralDataTypeDefinition = BaseDataTypeDefinition & {
+  type: 'Literal'
+  value: string | number | boolean
+  valueType: PrimitiveDataTypeDefinition
+}
+
+export type DiscriminatedUnionDataTypeDefinition = BaseDataTypeDefinition & {
+  type: 'DiscriminatedUnion'
+  discriminator: string
+  members: DataTypeDefinition[]
+}
+
+export type DataTypeDefinition =
+  | PrimitiveDataTypeDefinition
+  | RichTextDataTypeDefinition
+  | ArrayDataTypeDefinition
+  | RecordDataTypeDefinition
+  | TypeRefDataTypeDefinition
+  | LiteralDataTypeDefinition
+  | DiscriminatedUnionDataTypeDefinition
+
 export interface VersionedLink<T extends string> {
   sys: {
     type: 'Link'

--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -1,6 +1,7 @@
 import type { Except } from 'type-fest'
 import type {
   CursorPaginationParams,
+  DataTypeDefinition,
   ExoCursorPaginatedCollectionProp,
   ExoMetadataProps,
   ExoQueryFilters,
@@ -22,28 +23,13 @@ export type ComponentTypeViewport = {
   previewSize: string
 }
 
-// Primitive content property — String, Number, Boolean
-export type ComponentTypePrimitiveContentProperty = {
+// Content property — DataTypeDefinition extended with id, name, required, defaultValue
+export type ComponentTypeContentProperty = DataTypeDefinition & {
   id: string
   name: string
-  type: 'String' | 'Number' | 'Boolean'
   required: boolean
   defaultValue?: unknown
 }
-
-// TypeRef content property — references a DataAssembly or ComponentType
-export type ComponentTypeTypeRefContentProperty = {
-  id: string
-  name: string
-  type: 'TypeRef'
-  ref: ResourceLink<'Contentful:DataAssembly'> | ResourceLink<'Contentful:ComponentType'>
-  required: boolean
-}
-
-// Discriminated union covering all content property variants
-export type ComponentTypeContentProperty =
-  | ComponentTypePrimitiveContentProperty
-  | ComponentTypeTypeRefContentProperty
 
 // Validation entry for legacy design property validations.in
 export type ComponentTypeDesignPropertyValidation =

--- a/lib/entities/data-assembly.ts
+++ b/lib/entities/data-assembly.ts
@@ -1,31 +1,18 @@
 import type {
   CursorPaginationParams,
+  DataTypeDefinition,
   ExoCursorPaginatedCollectionProp,
   Link,
   MetadataProps,
   ResourceLink,
 } from '../common-types'
-import { User } from './user'
 
-export type DataAssemblyPrimitiveDataTypeField = {
+// DataTypeField — DataTypeDefinition extended with id, name, and optional source
+export type DataAssemblyDataTypeField = DataTypeDefinition & {
   id: string
   name: string
-  type: string
-  required: boolean
   source?: string
 }
-
-export type DataAssemblyTypeRefDataTypeField = {
-  id: string
-  name: string
-  type: 'TypeRef'
-  ref: ResourceLink<'Contentful:DataAssembly'>
-  required: boolean
-}
-
-export type DataAssemblyDataTypeField =
-  | DataAssemblyPrimitiveDataTypeField
-  | DataAssemblyTypeRefDataTypeField
 
 export type DataAssemblyLinkParameter = {
   name?: string


### PR DESCRIPTION
[DX-1163](https://contentful.atlassian.net/browse/DX-1163) | [DX-1164](https://contentful.atlassian.net/browse/DX-1164)

## Summary

The SDK's content property and data type field types only covered Primitive and TypeRef variants. Upstream supports 7 — this PR brings us to parity.

- Add a shared `DataTypeDefinition` discriminated union to `lib/common-types.ts` (Primitive, RichText, Array, Record, TypeRef, Literal, DiscriminatedUnion) matching `@contentful/data-type`
- Redefine `ComponentTypeContentProperty` as `DataTypeDefinition & { id, name, required, defaultValue? }` — replaces the old Primitive/TypeRef split, picks up Integer + 5 complex variants
- Redefine `DataAssemblyDataTypeField` as `DataTypeDefinition & { id, name, source? }` with `required` optional per upstream

## Test plan
- [x] `tsc --noEmit` passes on `feat/exo`
- [x] `lint-staged` (prettier + eslint) passes
- [ ] CI green
- [ ] Verify `TemplateProps` (shares `ComponentTypeContentProperty`) still type-checks

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1163]: https://contentful.atlassian.net/browse/DX-1163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-1164]: https://contentful.atlassian.net/browse/DX-1164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ