### PR TITLE
fix: migrate ExO cross-entity references from Link to ResourceLink [DX-1154]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -163,18 +163,17 @@ export type ComponentNode = {
   id: string
   name?: string
   nodeType: 'Component'
-  componentTypeId: string
+  componentType: ResourceLink<'Contentful:ComponentType'>
   contentProperties: Record<string, ContentPropertyPointerValue | unknown> | string
   designProperties: Record<string, ComponentTreeDesignPropertyValue>
   slots: Record<string, TreeNode[]>
-  contentBindings?: string
 }
 
 export type FragmentNode = {
   id: string
   name?: string
   nodeType: 'Fragment'
-  fragmentId: string
+  fragment: ResourceLink<'Contentful:Fragment'>
 }
 
 export type SlotNode = {
@@ -186,7 +185,7 @@ export type SlotNode = {
 export type TreeNode = ComponentNode | FragmentNode | SlotNode
 
 // DataAssembly link type
-export type DataAssemblyLink = Link<'DataAssembly'>
+export type DataAssemblyLink = ResourceLink<'Contentful:DataAssembly'>
 
 // Slot definition
 export type ComponentTypeSlotDefinition = {

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -4,6 +4,7 @@ import type {
   ExperienceMetadataProps,
   ExoQueryFilters,
   Link,
+  ResourceLink,
 } from '../common-types'
 import type {
   ComponentTypeViewport,
@@ -16,12 +17,8 @@ export type ExperienceDimensionKeyMap = {
 }
 
 export type ExperienceContentBindings = {
-  sys: {
-    type: 'Link'
-    id: string
-    linkType: 'DataAssembly'
-  }
-  parameters: Record<string, Link<string>>
+  sys: ResourceLink<'Contentful:DataAssembly'>['sys']
+  parameters: Record<string, ResourceLink<string>>
 }
 
 export type ExperienceSys = {
@@ -30,7 +27,7 @@ export type ExperienceSys = {
   version: number
   space: Link<'Space'>
   environment: Link<'Environment'>
-  template?: Link<'Template'>
+  template?: ResourceLink<'Contentful:Template'>
   createdAt: string
   updatedAt: string
   createdBy: Link<'User'>
@@ -76,7 +73,7 @@ export type ExperienceQueryOptions = CursorPaginationParams &
 export type ExperienceLocalePublishPayload = { add: string[] } | { remove: string[] }
 
 export type CreateExperienceProps = ExperienceCommonProps & {
-  template: Link<'Template'>
+  template: ResourceLink<'Contentful:Template'>
 }
 
 export type UpsertExperienceProps = ExperienceCommonProps & {
@@ -85,13 +82,13 @@ export type UpsertExperienceProps = ExperienceCommonProps & {
     type: 'Experience'
     version?: number
   }
-  template?: Link<'Template'>
+  template?: ResourceLink<'Contentful:Template'>
 }
 
 export type InlineFragmentNode = {
   id: string
   nodeType: 'InlineFragment'
-  componentTypeId: string
+  componentType: ResourceLink<'Contentful:ComponentType'>
   designProperties: Record<string, DimensionedDesignPropertyValue>
   contentBindings?: ExperienceContentBindings
   slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -5,6 +5,7 @@ import type {
   ExoQueryFilters,
   ExperienceMetadataProps,
   Link,
+  ResourceLink,
 } from '../common-types'
 import type {
   ComponentTypeViewport,
@@ -23,7 +24,7 @@ export type FragmentSys = {
   version: number
   space: Link<'Space'>
   environment: Link<'Environment'>
-  componentType: Link<'ComponentType'>
+  componentType: ResourceLink<'Contentful:ComponentType'>
   archivedAt?: string
   archivedBy?: Link<'User'>
   archivedVersion?: number
@@ -54,7 +55,7 @@ export type FragmentProps = {
 }
 
 export type CreateFragmentProps = Except<FragmentProps, 'sys'> & {
-  componentType: Link<'ComponentType'>
+  componentType: ResourceLink<'Contentful:ComponentType'>
 }
 
 export type UpdateFragmentProps = Omit<FragmentProps, 'sys'> & {

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
-import { testName, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
+import { testName, testViewport, sweepStaleExoEntities, makeResourceLink } from './utils/exo.utils'
 
 describe('Experience Integration', { sequential: true }, () => {
   const client = initPlainClient({
@@ -42,7 +42,7 @@ describe('Experience Integration', { sequential: true }, () => {
       {
         name: testName('Experience'),
         description: 'Created by integration test',
-        template: { sys: { type: 'Link', linkType: 'Template', id: templateId } },
+        template: makeResourceLink('Contentful:Template', templateId),
         viewports: [testViewport],
         contentProperties: {},
         designProperties: {},
@@ -97,7 +97,9 @@ describe('Experience Integration', { sequential: true }, () => {
     expect(exp.sys.updatedAt).toBeDefined()
     expect(exp.sys.createdBy).toBeDefined()
     expect(exp.sys.template).toBeDefined()
-    expect(exp.sys.template!.sys.id).toBe(templateId)
+    expect(exp.sys.template!.sys.type).toBe('ResourceLink')
+    expect(exp.sys.template!.sys.linkType).toBe('Contentful:Template')
+    expect(exp.sys.template!.sys.urn).toContain(templateId)
     expect(exp.name).toBe(testName('Experience'))
   })
 

--- a/test/integration/fragment-integration.test.ts
+++ b/test/integration/fragment-integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
 import { TestDefaults } from '../defaults'
-import { testName, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
+import { testName, testViewport, sweepStaleExoEntities, makeResourceLink } from './utils/exo.utils'
 
 describe('Fragment Integration', { sequential: true }, () => {
   const client = initPlainClient({
@@ -41,7 +41,7 @@ describe('Fragment Integration', { sequential: true }, () => {
       {
         name: testName('Fragment'),
         description: 'Created by integration test',
-        componentType: { sys: { type: 'Link', linkType: 'ComponentType', id: componentTypeId } },
+        componentType: makeResourceLink('Contentful:ComponentType', componentTypeId),
         viewports: [testViewport],
         designProperties: {},
         dimensionKeyMap: { designProperties: {} },
@@ -95,7 +95,9 @@ describe('Fragment Integration', { sequential: true }, () => {
     expect(frag.sys.updatedAt).toBeDefined()
     expect(frag.sys.createdBy).toBeDefined()
     expect(frag.sys.componentType).toBeDefined()
-    expect(frag.sys.componentType.sys.id).toBe(componentTypeId)
+    expect(frag.sys.componentType.sys.type).toBe('ResourceLink')
+    expect(frag.sys.componentType.sys.linkType).toBe('Contentful:ComponentType')
+    expect(frag.sys.componentType.sys.urn).toContain(componentTypeId)
     expect(frag.name).toBe(testName('Fragment'))
   })
 

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -1,5 +1,6 @@
-import type { PlainClientAPI } from '../../../lib/index'
+import type { PlainClientAPI, ResourceLink } from '../../../lib/index'
 import { generateRandomId } from '../../helpers'
+import { TestDefaults } from '../../defaults'
 
 export const TEST_PREFIX = '[ExO Integration Test]'
 
@@ -13,6 +14,24 @@ export const testViewport = {
   displayName: 'Desktop',
   previewSize: '100%',
 } as const
+
+const entityPaths: Record<string, string> = {
+  'Contentful:Template': 'templates',
+  'Contentful:ComponentType': 'component_types',
+  'Contentful:Fragment': 'fragments',
+  'Contentful:DataAssembly': 'data_assemblies',
+}
+
+export function makeResourceLink<T extends string>(linkType: T, id: string): ResourceLink<T> {
+  const path = entityPaths[linkType] ?? linkType.toLowerCase().replace('contentful:', '') + 's'
+  return {
+    sys: {
+      type: 'ResourceLink',
+      linkType,
+      urn: `crn:contentful:::content:spaces/${TestDefaults.spaceId}/environments/${TestDefaults.environmentId}/${path}/${id}`,
+    },
+  }
+}
 
 const SWEEP_KEY = '__exoIntegrationSwept'
 

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -1,6 +1,5 @@
 import type { PlainClientAPI, ResourceLink } from '../../../lib/index'
 import { generateRandomId } from '../../helpers'
-import { TestDefaults } from '../../defaults'
 
 export const TEST_PREFIX = '[ExO Integration Test]'
 
@@ -15,20 +14,22 @@ export const testViewport = {
   previewSize: '100%',
 } as const
 
+const EXO_CRN_PREFIX = 'crn:contentful:::experience:spaces/$self/environments/$self'
+
 const entityPaths: Record<string, string> = {
   'Contentful:Template': 'templates',
-  'Contentful:ComponentType': 'component_types',
+  'Contentful:ComponentType': 'componentTypes',
   'Contentful:Fragment': 'fragments',
-  'Contentful:DataAssembly': 'data_assemblies',
+  'Contentful:DataAssembly': 'dataAssemblies',
 }
 
 export function makeResourceLink<T extends string>(linkType: T, id: string): ResourceLink<T> {
-  const path = entityPaths[linkType] ?? linkType.toLowerCase().replace('contentful:', '') + 's'
+  const path = entityPaths[linkType] ?? linkType.replace('Contentful:', '').toLowerCase() + 's'
   return {
     sys: {
       type: 'ResourceLink',
       linkType,
-      urn: `crn:contentful:::content:spaces/${TestDefaults.spaceId}/environments/${TestDefaults.environmentId}/${path}/${id}`,
+      urn: `${EXO_CRN_PREFIX}/${path}/${id}`,
     },
   }
 }


### PR DESCRIPTION
[DX-1154](https://contentful.atlassian.net/browse/DX-1154)

## Summary
- Migrate all ExO cross-entity references from `Link<T>` to `ResourceLink<'Contentful:T'>` — upstream API (SPA-4273) now rejects classic Link format with 422 validation errors
- Affected types: `ComponentNode`, `FragmentNode`, `DataAssemblyLink`, `ExperienceSys.template`, `ExperienceContentBindings`, `InlineFragmentNode`, `FragmentSys.componentType`, `CreateExperienceProps.template`, `UpsertExperienceProps.template`, `CreateFragmentProps.componentType`
- Removes `ComponentNode.contentBindings` (no upstream equivalent — upstream `ComponentNode` doesn't have this field)

## Test plan
- [x] `tsc --noEmit` passes on `feat/exo`
- [x] `lint-staged` (prettier + eslint) passes
- [ ] CI green
- [ ] Integration tests (separate follow-up — tests need ResourceLink payload construction with CRN URNs)

## Notes
- Integration tests were already failing pre-PR due to SPA-4273 deployment (2026-05-22)
- `designProperties` schema drift (`fallbackValue` field) is out of scope — separate ticket
- `TemplateProps.dataAssemblies` automatically picks up the fix via shared `DataAssemblyLink` type alias

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1154]: https://contentful.atlassian.net/browse/DX-1154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ