### PR TITLE
fix: remove required field and add fallbackValue to DesignProperty types [DX-1166] [DX-1151]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -91,7 +91,6 @@ export type DTCGDesignPropertyType =
 type DesignPropertyCommonFields = {
   id: string
   name: string
-  required: boolean
   description?: string
 }
 
@@ -99,6 +98,7 @@ type DesignPropertyCommonFields = {
 export type LegacyDesignProperty = DesignPropertyCommonFields & {
   type: 'Symbol' | 'Number' | 'Boolean'
   defaultValue?: DesignPropertyDefinitionValue
+  fallbackValue?: DesignPropertyDefinitionValue
   validations?: {
     in?: ComponentTypeDesignPropertyValidation[]
   }
@@ -108,6 +108,7 @@ export type LegacyDesignProperty = DesignPropertyCommonFields & {
 export type StringDesignProperty = DesignPropertyCommonFields & {
   type: 'String'
   defaultValue?: { type: 'ManualDesignValue'; value: string }
+  fallbackValue?: { type: 'ManualDesignValue'; value: string }
   validations?: StringDesignPropertyRegexpValidation[]
 }
 
@@ -115,6 +116,7 @@ export type StringDesignProperty = DesignPropertyCommonFields & {
 export type TokenBackedDesignProperty = DesignPropertyCommonFields & {
   type: DTCGDesignPropertyType
   defaultValue?: DesignTokenValue
+  fallbackValue?: DesignTokenValue
   allowedResources?: DesignTokenAllowedResource[]
 }
 

--- a/test/integration/component-type-integration.test.ts
+++ b/test/integration/component-type-integration.test.ts
@@ -22,7 +22,7 @@ describe('ComponentType Integration', { sequential: true }, () => {
         description: 'Created by integration test',
         viewports: [testViewport],
         contentProperties: [{ id: 'title', name: 'Title', type: 'String', required: false }],
-        designProperties: [{ id: 'color', name: 'Color', type: 'Symbol', required: false }],
+        designProperties: [{ id: 'color', name: 'Color', type: 'Symbol' }],
         dimensionKeyMap: { designProperties: {} },
       },
     )

--- a/test/integration/template-integration.test.ts
+++ b/test/integration/template-integration.test.ts
@@ -22,9 +22,7 @@ describe('Template Integration', { sequential: true }, () => {
         description: 'Created by integration test',
         viewports: [testViewport],
         contentProperties: [{ id: 'heading', name: 'Heading', type: 'String', required: false }],
-        designProperties: [
-          { id: 'bgColor', name: 'Background Color', type: 'Symbol', required: false },
-        ],
+        designProperties: [{ id: 'bgColor', name: 'Background Color', type: 'Symbol' }],
         dimensionKeyMap: { designProperties: {} },
       },
     )


### PR DESCRIPTION
[DX-1166](https://contentful.atlassian.net/browse/DX-1166) | [DX-1151](https://contentful.atlassian.net/browse/DX-1151)

## Summary
- Remove `required: boolean` from `DesignPropertyCommonFields` — upstream API (SPA-4416) now rejects it with 422 via `z.strictObject`
- Add `fallbackValue?` to all three design property arms (`LegacyDesignProperty`, `StringDesignProperty`, `TokenBackedDesignProperty`) with type-appropriate value shapes matching upstream
- Update integration test fixtures to stop sending `required` on design properties

## Test plan
- [x] `tsc --noEmit` passes
- [x] Unit tests pass (component-type, template)
- [ ] Integration tests pass in CI (component-type, template — previously failing with 422)

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1166]: https://contentful.atlassian.net/browse/DX-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-1151]: https://contentful.atlassian.net/browse/DX-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ