### PR TITLE
fix: remove contentProperties from Experience types [DX-1136]

### DIFF
--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -50,7 +50,6 @@ type ExperienceCommonProps = {
   name: string
   description: string
   viewports: ComponentTypeViewport[]
-  contentProperties: Record<string, unknown>
   designProperties: Record<string, DimensionedDesignPropertyValue>
   dimensionKeyMap: ExperienceDimensionKeyMap
   contentBindings?: ExperienceContentBindings

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -44,7 +44,6 @@ describe('Experience Integration', { sequential: true }, () => {
         description: 'Created by integration test',
         template: makeResourceLink('Contentful:Template', templateId),
         viewports: [testViewport],
-        contentProperties: {},
         designProperties: {},
         dimensionKeyMap: { designProperties: {} },
       },

--- a/test/unit/adapters/REST/endpoints/experience.test.ts
+++ b/test/unit/adapters/REST/endpoints/experience.test.ts
@@ -105,7 +105,6 @@ describe('Rest Experience', { concurrent: true }, () => {
       name: 'Test Experience',
       description: 'A test experience',
       viewports: [],
-
       designProperties: {},
       dimensionKeyMap: { designProperties: {} },
     }
@@ -208,7 +207,6 @@ describe('Rest Experience', { concurrent: true }, () => {
       name: 'New Experience',
       description: 'A new experience',
       viewports: [],
-
       designProperties: {},
       dimensionKeyMap: { designProperties: {} },
     }
@@ -231,7 +229,6 @@ describe('Rest Experience', { concurrent: true }, () => {
           description: 'A new experience',
           template: templateLink,
           viewports: [],
-
           designProperties: {},
           dimensionKeyMap: { designProperties: {} },
         },
@@ -252,7 +249,6 @@ describe('Rest Experience', { concurrent: true }, () => {
       name: 'Updated Experience',
       description: 'An updated experience',
       viewports: [],
-
       designProperties: {},
       dimensionKeyMap: { designProperties: {} },
     }
@@ -274,7 +270,6 @@ describe('Rest Experience', { concurrent: true }, () => {
           name: 'Updated Experience',
           description: 'An updated experience',
           viewports: [],
-
           designProperties: {},
           dimensionKeyMap: { designProperties: {} },
         },
@@ -296,7 +291,6 @@ describe('Rest Experience', { concurrent: true }, () => {
       name: 'New Experience via Upsert',
       description: 'Created via upsert',
       viewports: [],
-
       designProperties: {},
       dimensionKeyMap: { designProperties: {} },
     }
@@ -318,7 +312,6 @@ describe('Rest Experience', { concurrent: true }, () => {
           name: 'New Experience via Upsert',
           description: 'Created via upsert',
           viewports: [],
-
           designProperties: {},
           dimensionKeyMap: { designProperties: {} },
         },
@@ -367,7 +360,6 @@ describe('Rest Experience', { concurrent: true }, () => {
       name: 'Test Experience',
       description: 'A test experience',
       viewports: [],
-
       designProperties: {},
       dimensionKeyMap: { designProperties: {} },
     }

--- a/test/unit/adapters/REST/endpoints/experience.test.ts
+++ b/test/unit/adapters/REST/endpoints/experience.test.ts
@@ -105,7 +105,7 @@ describe('Rest Experience', { concurrent: true }, () => {
       name: 'Test Experience',
       description: 'A test experience',
       viewports: [],
-      contentProperties: {},
+
       designProperties: {},
       dimensionKeyMap: { designProperties: {} },
     }
@@ -208,7 +208,7 @@ describe('Rest Experience', { concurrent: true }, () => {
       name: 'New Experience',
       description: 'A new experience',
       viewports: [],
-      contentProperties: {},
+
       designProperties: {},
       dimensionKeyMap: { designProperties: {} },
     }
@@ -231,7 +231,7 @@ describe('Rest Experience', { concurrent: true }, () => {
           description: 'A new experience',
           template: templateLink,
           viewports: [],
-          contentProperties: {},
+
           designProperties: {},
           dimensionKeyMap: { designProperties: {} },
         },
@@ -252,7 +252,7 @@ describe('Rest Experience', { concurrent: true }, () => {
       name: 'Updated Experience',
       description: 'An updated experience',
       viewports: [],
-      contentProperties: {},
+
       designProperties: {},
       dimensionKeyMap: { designProperties: {} },
     }
@@ -274,7 +274,7 @@ describe('Rest Experience', { concurrent: true }, () => {
           name: 'Updated Experience',
           description: 'An updated experience',
           viewports: [],
-          contentProperties: {},
+
           designProperties: {},
           dimensionKeyMap: { designProperties: {} },
         },
@@ -296,7 +296,7 @@ describe('Rest Experience', { concurrent: true }, () => {
       name: 'New Experience via Upsert',
       description: 'Created via upsert',
       viewports: [],
-      contentProperties: {},
+
       designProperties: {},
       dimensionKeyMap: { designProperties: {} },
     }
@@ -318,7 +318,7 @@ describe('Rest Experience', { concurrent: true }, () => {
           name: 'New Experience via Upsert',
           description: 'Created via upsert',
           viewports: [],
-          contentProperties: {},
+
           designProperties: {},
           dimensionKeyMap: { designProperties: {} },
         },
@@ -367,7 +367,7 @@ describe('Rest Experience', { concurrent: true }, () => {
       name: 'Test Experience',
       description: 'A test experience',
       viewports: [],
-      contentProperties: {},
+
       designProperties: {},
       dimensionKeyMap: { designProperties: {} },
     }


### PR DESCRIPTION
[DX-1136](https://contentful.atlassian.net/browse/DX-1136)

## Summary

Upstream ExO API (SPA-4355) fully removed `contentProperties` from the Experience schema — the field is now rejected on write (422 via `z.strictObject`) and stripped from responses. This removes it from `ExperienceCommonProps` (which flows into `ExperienceProps`, `CreateExperienceProps`, and `UpsertExperienceProps`) and updates all test fixtures.

- Remove `contentProperties: Record<string, unknown>` from `ExperienceCommonProps`
- Update integration test to stop sending `contentProperties` in the create payload
- Remove `contentProperties` from all unit test mock responses and payloads

## Test plan
- [x] `tsc --noEmit` passes on `feat/exo`
- [x] Unit tests pass (11/11)
- [ ] Integration tests pass in CI (experience — previously failing with 422 `unrecognized_keys`)

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1136]: https://contentful.atlassian.net/browse/DX-1136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ