### PR TITLE
fix: align optionality with upstream schemas [DX-1086] [DX-1087]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -238,14 +238,17 @@ export type ComponentTypeProps = {
   source?: ResourceLink<'Contentful:DesignSystemSource'>
 }
 
-export type CreateComponentTypeProps = Except<ComponentTypeProps, 'sys'>
+export type CreateComponentTypeProps = Except<ComponentTypeProps, 'sys' | 'source'> & {
+  source?: ResourceLink<'Contentful:DesignSystemSource'> | null
+}
 
-export type UpsertComponentTypeProps = Except<ComponentTypeProps, 'sys'> & {
+export type UpsertComponentTypeProps = Except<ComponentTypeProps, 'sys' | 'source'> & {
   sys: {
     id: string
     type: 'ComponentType'
     version?: number
   }
+  source?: ResourceLink<'Contentful:DesignSystemSource'> | null
 }
 
 export type ComponentTypeCollection = ExoCursorPaginatedCollectionProp<ComponentTypeProps>

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -27,7 +27,7 @@ export type ExperienceSys = {
   version: number
   space: Link<'Space'>
   environment: Link<'Environment'>
-  template?: ResourceLink<'Contentful:Template'>
+  template: ResourceLink<'Contentful:Template'>
   createdAt: string
   updatedAt: string
   createdBy: Link<'User'>

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -96,10 +96,9 @@ describe('Experience Integration', { sequential: true }, () => {
     expect(exp.sys.createdAt).toBeDefined()
     expect(exp.sys.updatedAt).toBeDefined()
     expect(exp.sys.createdBy).toBeDefined()
-    expect(exp.sys.template).toBeDefined()
-    expect(exp.sys.template!.sys.type).toBe('ResourceLink')
-    expect(exp.sys.template!.sys.linkType).toBe('Contentful:Template')
-    expect(exp.sys.template!.sys.urn).toContain(templateId)
+    expect(exp.sys.template.sys.type).toBe('ResourceLink')
+    expect(exp.sys.template.sys.linkType).toBe('Contentful:Template')
+    expect(exp.sys.template.sys.urn).toContain(templateId)
     expect(exp.name).toBe(testName('Experience'))
   })
 


### PR DESCRIPTION
[DX-1086](https://contentful.atlassian.net/browse/DX-1086) | [DX-1087](https://contentful.atlassian.net/browse/DX-1087)

## Summary
- **DX-1087**: Make `ExperienceSys.template` required — upstream `ManagementExperienceSys` always includes it; the SDK's optionality was stale from a pre-migration era
- **DX-1086**: Allow `null` in `CreateComponentTypeProps.source` and `UpsertComponentTypeProps.source` to support three-way semantics (`absent` = preserve, `null` = clear, `ResourceLink` = set)
- Removes unnecessary non-null assertions (`!`) from integration tests now that `template` is required

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Integration tests pass in CI (template assertions still valid, `source: null` passthrough verified by existing adapter behavior)

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1086]: https://contentful.atlassian.net/browse/DX-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-1087]: https://contentful.atlassian.net/browse/DX-1087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ