### PR TITLE
fix: remove Legacy design property types and align with upstream schema [DX-1172]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -31,19 +31,6 @@ export type ComponentTypeContentProperty = DataTypeDefinition & {
   defaultValue?: unknown
 }
 
-// Validation entry for legacy design property validations.in
-export type ComponentTypeDesignPropertyValidation =
-  | {
-      type: 'ManualDesignValue'
-      value: string | number | boolean
-      name?: string
-    }
-  | {
-      type: 'DesignToken'
-      value: string
-      name?: string
-    }
-
 // Regexp validation shape for String design properties
 export type StringDesignPropertyRegexpValidation = {
   regexp: {
@@ -80,36 +67,30 @@ type DesignPropertyCommonFields = {
   description?: string
 }
 
-// Legacy design property — Symbol, Number, Boolean
-export type LegacyDesignProperty = DesignPropertyCommonFields & {
-  type: 'Symbol' | 'Number' | 'Boolean'
-  defaultValue?: DesignPropertyDefinitionValue
-  fallbackValue?: DesignPropertyDefinitionValue
-  validations?: {
-    in?: ComponentTypeDesignPropertyValidation[]
-  }
-}
-
 // String design property — free-text with optional regexp validations
 export type StringDesignProperty = DesignPropertyCommonFields & {
   type: 'String'
-  defaultValue?: { type: 'ManualDesignValue'; value: string }
   fallbackValue?: { type: 'ManualDesignValue'; value: string }
   validations?: StringDesignPropertyRegexpValidation[]
+}
+
+// Boolean design property — narrowed fallbackValue to boolean only
+export type BooleanDesignProperty = DesignPropertyCommonFields & {
+  type: 'Boolean'
+  fallbackValue?: { type: 'ManualDesignValue'; value: boolean }
 }
 
 // Token-backed design property — DTCG types with optional allowedResources
 export type TokenBackedDesignProperty = DesignPropertyCommonFields & {
   type: DTCGDesignPropertyType
-  defaultValue?: DesignTokenValue
   fallbackValue?: DesignTokenValue
   allowedResources?: DesignTokenAllowedResource[]
 }
 
-// Discriminated union covering all three upstream arms
+// Discriminated union covering all upstream design property arms
 export type ComponentTypeDesignProperty =
-  | LegacyDesignProperty
   | StringDesignProperty
+  | BooleanDesignProperty
   | TokenBackedDesignProperty
 
 // Dimension key map
@@ -134,8 +115,6 @@ export type DesignTokenValue = {
   /** Must be non-empty (min length 1) */
   value: string
 }
-
-export type DesignPropertyDefinitionValue = ManualDesignValue | DesignTokenValue
 
 export type DesignPropertyValue = ManualDesignValue | DesignTokenValue
 

--- a/test/integration/component-type-integration.test.ts
+++ b/test/integration/component-type-integration.test.ts
@@ -22,7 +22,7 @@ describe('ComponentType Integration', { sequential: true }, () => {
         description: 'Created by integration test',
         viewports: [testViewport],
         contentProperties: [{ id: 'title', name: 'Title', type: 'String', required: false }],
-        designProperties: [{ id: 'color', name: 'Color', type: 'Symbol' }],
+        designProperties: [{ id: 'color', name: 'Color', type: 'String' }],
         dimensionKeyMap: { designProperties: {} },
       },
     )

--- a/test/integration/template-integration.test.ts
+++ b/test/integration/template-integration.test.ts
@@ -22,7 +22,7 @@ describe('Template Integration', { sequential: true }, () => {
         description: 'Created by integration test',
         viewports: [testViewport],
         contentProperties: [{ id: 'heading', name: 'Heading', type: 'String', required: false }],
-        designProperties: [{ id: 'bgColor', name: 'Background Color', type: 'Symbol' }],
+        designProperties: [{ id: 'bgColor', name: 'Background Color', type: 'String' }],
         dimensionKeyMap: { designProperties: {} },
       },
     )


### PR DESCRIPTION
[DX-1172](https://contentful.atlassian.net/browse/DX-1172)

## Summary

Upstream removed `Symbol`/`Number` design property types entirely (INTEG-4052: normalized on read, rejected on write) and renamed `defaultValue` to `fallbackValue` (INTEG-4033). This PR aligns the SDK to match upstream exactly — the union is now `String | Boolean | TokenBacked` with no legacy arms.

- Remove `LegacyDesignProperty` type — API normalizes Symbol→String and filters Number on read; these types never appear in responses
- Remove `ComponentTypeDesignPropertyValidation` — only existed for the legacy `validations.in` field
- Remove `DesignPropertyDefinitionValue` — unused after Legacy removal
- Remove `defaultValue` from all arms (rejected by `z.strictObject` as `unrecognized_keys`)
- Add `BooleanDesignProperty` with `fallbackValue` narrowed to `{ type: 'ManualDesignValue'; value: boolean }` matching upstream `ManualBooleanDesignValueSchema`
- Update integration test fixtures from `type: 'Symbol'` to `type: 'String'`

## Test plan
- [x] `tsc --noEmit` passes
- [x] Unit tests pass
- [ ] Integration tests pass in CI (fixtures now use valid `String` type)

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1172]: https://contentful.atlassian.net/browse/DX-1172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ