### PR TITLE
fix: widen LiteralDataTypeDefinition value and valueType [DX-1173]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -320,10 +320,18 @@ export type TypeRefDataTypeDefinition = BaseDataTypeDefinition & {
   ref: ResourceLink<string>
 }
 
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
 export type LiteralDataTypeDefinition = BaseDataTypeDefinition & {
   type: 'Literal'
-  value: string | number | boolean
-  valueType: PrimitiveDataTypeDefinition
+  value: JsonValue
+  valueType: DataTypeDefinition
 }
 
 export type DiscriminatedUnionDataTypeDefinition = BaseDataTypeDefinition & {


### PR DESCRIPTION
[DX-1173](https://contentful.atlassian.net/browse/DX-1173)

## Summary
- Widen `LiteralDataTypeDefinition.value` from `string | number | boolean` to `JsonValue` (recursive JSON type matching upstream — includes `null`, arrays, nested objects)
- Widen `LiteralDataTypeDefinition.valueType` from `PrimitiveDataTypeDefinition` to full `DataTypeDefinition` union (upstream allows any of the 7 variants)
- Add `JsonValue` type to `lib/common-types.ts`

## Test plan
- [x] `tsc --noEmit` passes
- [ ] CI integration tests pass

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1173]: https://contentful.atlassian.net/browse/DX-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ