### PR TITLE
fix: align PointerExpressionValue and Fragment upsert type [DX-1174] [DX-1175]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -320,10 +320,18 @@ export type TypeRefDataTypeDefinition = BaseDataTypeDefinition & {
   ref: ResourceLink<string>
 }
 
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
 export type LiteralDataTypeDefinition = BaseDataTypeDefinition & {
   type: 'Literal'
-  value: string | number | boolean
-  valueType: PrimitiveDataTypeDefinition
+  value: JsonValue
+  valueType: DataTypeDefinition
 }
 
 export type DiscriminatedUnionDataTypeDefinition = BaseDataTypeDefinition & {
@@ -340,6 +348,11 @@ export type DataTypeDefinition =
   | TypeRefDataTypeDefinition
   | LiteralDataTypeDefinition
   | DiscriminatedUnionDataTypeDefinition
+
+export type PointerExpressionValue =
+  | string
+  | { $literal: JsonValue }
+  | { [key: string]: PointerExpressionValue }
 
 export interface VersionedLink<T extends string> {
   sys: {

--- a/lib/entities/data-assembly.ts
+++ b/lib/entities/data-assembly.ts
@@ -4,6 +4,7 @@ import type {
   ExoCursorPaginatedCollectionProp,
   Link,
   MetadataProps,
+  PointerExpressionValue,
   ResourceLink,
 } from '../common-types'
 
@@ -38,13 +39,13 @@ export type DataAssemblyParameterConfig = Record<
 export type DataAssemblyGraphQLResolver = {
   source: 'Contentful:GraphQL'
   query: string
-  parameters?: Record<string, unknown>
+  parameters?: PointerExpressionValue
 }
 
 export type DataAssemblyNestedResolver = {
   source: 'Contentful:DataAssembly'
   dataAssembly: ResourceLink<'Contentful:DataAssembly'>
-  parameters?: Record<string, unknown>
+  parameters?: PointerExpressionValue
 }
 
 export type DataAssemblyResolverDefinition =
@@ -53,29 +54,7 @@ export type DataAssemblyResolverDefinition =
 
 export type DataAssemblyResolverConfig = Record<string, DataAssemblyResolverDefinition>
 
-export type DataAssemblyReturnMappingSelectValue =
-  | string
-  | {
-      $on: {
-        type: Record<string, DataAssemblyReturnMappingSelectValue>
-        default?: DataAssemblyReturnMappingSelectValue
-      }
-    }
-  | { [key: string]: DataAssemblyReturnMappingSelectValue }
-
-export type DataAssemblyReturnMappingFromObject = {
-  $from: {
-    source: string
-    select?: DataAssemblyReturnMappingSelectValue
-  }
-}
-
-export type DataAssemblyReturnMappingValue =
-  | string
-  | DataAssemblyReturnMappingFromObject
-  | { [key: string]: DataAssemblyReturnMappingValue }
-
-export type DataAssemblyReturnMappingConfig = Record<string, DataAssemblyReturnMappingValue>
+export type DataAssemblyReturnMappingConfig = Record<string, PointerExpressionValue>
 
 export type DataAssemblySys = {
   id: string

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -64,6 +64,7 @@ export type UpdateFragmentProps = Omit<FragmentProps, 'sys'> & {
     type: 'Fragment'
     version: number
   }
+  componentType?: ResourceLink<'Contentful:ComponentType'>
 }
 
 export type FragmentQueryOptions = CursorPaginationParams &

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -364,6 +364,4 @@ export type { FragmentCollection } from './entities/fragment'
 export type {
   DataAssemblyCollection,
   DataAssemblyResourceLinkParameter,
-  DataAssemblyReturnMappingFromObject,
-  DataAssemblyReturnMappingSelectValue,
 } from './entities/data-assembly'


### PR DESCRIPTION
[DX-1174](https://contentful.atlassian.net/browse/DX-1174) | [DX-1175](https://contentful.atlassian.net/browse/DX-1175)

## Summary
- **DX-1174**: Replace bespoke `DataAssemblyReturnMappingSelectValue`, `DataAssemblyReturnMappingFromObject`, and `DataAssemblyReturnMappingValue` with a unified `PointerExpressionValue` type matching `@contentful/pointer-syntax`. Adds missing `$literal` variant and `$from` string shorthand. Types resolver `parameters` as `PointerExpressionValue` instead of `Record<string, unknown>`.
- **DX-1175**: Add optional `componentType` to `UpdateFragmentProps` for create-via-PUT (upsert) semantics — required when creating a new fragment via the PUT endpoint, omitted on update.
- Also includes `JsonValue` type and fixes `LiteralDataTypeDefinition` inner types (overlaps with DX-1173 — will dedup on rebase)

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Integration tests pass in CI

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1174]: https://contentful.atlassian.net/browse/DX-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-1175]: https://contentful.atlassian.net/browse/DX-1175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ