### PR TITLE
fix: align return mapping and resolver parameters with PointerExpressionValue [DX-1174]

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -349,14 +349,6 @@ export type DataTypeDefinition =
   | LiteralDataTypeDefinition
   | DiscriminatedUnionDataTypeDefinition
 
-export type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | JsonValue[]
-  | { [key: string]: JsonValue }
-
 export type PointerExpressionValue =
   | string
   | { $literal: JsonValue }

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -341,6 +341,19 @@ export type DataTypeDefinition =
   | LiteralDataTypeDefinition
   | DiscriminatedUnionDataTypeDefinition
 
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+export type PointerExpressionValue =
+  | string
+  | { $literal: JsonValue }
+  | { [key: string]: PointerExpressionValue }
+
 export interface VersionedLink<T extends string> {
   sys: {
     type: 'Link'

--- a/lib/entities/data-assembly.ts
+++ b/lib/entities/data-assembly.ts
@@ -4,6 +4,7 @@ import type {
   ExoCursorPaginatedCollectionProp,
   Link,
   MetadataProps,
+  PointerExpressionValue,
   ResourceLink,
 } from '../common-types'
 
@@ -38,13 +39,13 @@ export type DataAssemblyParameterConfig = Record<
 export type DataAssemblyGraphQLResolver = {
   source: 'Contentful:GraphQL'
   query: string
-  parameters?: Record<string, unknown>
+  parameters?: PointerExpressionValue
 }
 
 export type DataAssemblyNestedResolver = {
   source: 'Contentful:DataAssembly'
   dataAssembly: ResourceLink<'Contentful:DataAssembly'>
-  parameters?: Record<string, unknown>
+  parameters?: PointerExpressionValue
 }
 
 export type DataAssemblyResolverDefinition =
@@ -53,29 +54,7 @@ export type DataAssemblyResolverDefinition =
 
 export type DataAssemblyResolverConfig = Record<string, DataAssemblyResolverDefinition>
 
-export type DataAssemblyReturnMappingSelectValue =
-  | string
-  | {
-      $on: {
-        type: Record<string, DataAssemblyReturnMappingSelectValue>
-        default?: DataAssemblyReturnMappingSelectValue
-      }
-    }
-  | { [key: string]: DataAssemblyReturnMappingSelectValue }
-
-export type DataAssemblyReturnMappingFromObject = {
-  $from: {
-    source: string
-    select?: DataAssemblyReturnMappingSelectValue
-  }
-}
-
-export type DataAssemblyReturnMappingValue =
-  | string
-  | DataAssemblyReturnMappingFromObject
-  | { [key: string]: DataAssemblyReturnMappingValue }
-
-export type DataAssemblyReturnMappingConfig = Record<string, DataAssemblyReturnMappingValue>
+export type DataAssemblyReturnMappingConfig = Record<string, PointerExpressionValue>
 
 export type DataAssemblySys = {
   id: string

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -364,6 +364,4 @@ export type { FragmentCollection } from './entities/fragment'
 export type {
   DataAssemblyCollection,
   DataAssemblyResourceLinkParameter,
-  DataAssemblyReturnMappingFromObject,
-  DataAssemblyReturnMappingSelectValue,
 } from './entities/data-assembly'


### PR DESCRIPTION
[DX-1174](https://contentful.atlassian.net/browse/DX-1174)

## Summary
- Replace bespoke `DataAssemblyReturnMappingSelectValue`, `DataAssemblyReturnMappingFromObject`, and `DataAssemblyReturnMappingValue` with unified `PointerExpressionValue` type matching `@contentful/pointer-syntax`
- Adds missing `$literal` variant and `$from` string shorthand
- Types resolver `parameters` as `PointerExpressionValue` instead of `Record<string, unknown>`
- Adds `JsonValue` and `PointerExpressionValue` types to `lib/common-types.ts`

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Integration tests pass in CI

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1174]: https://contentful.atlassian.net/browse/DX-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ