### PR TITLE
fix: add componentType to Fragment upsert type for create-via-PUT [DX-1175]

### DIFF
--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -64,6 +64,7 @@ export type UpdateFragmentProps = Omit<FragmentProps, 'sys'> & {
     type: 'Fragment'
     version: number
   }
+  componentType?: ResourceLink<'Contentful:ComponentType'>
 }
 
 export type FragmentQueryOptions = CursorPaginationParams &


### PR DESCRIPTION
[DX-1175](https://contentful.atlassian.net/browse/DX-1175)

## Summary
- Add optional `componentType` to `UpdateFragmentProps` for create-via-PUT (upsert) semantics
- Required when creating a new fragment via the PUT endpoint, omitted on update
- Matches upstream `FragmentUpsertConfigSchema` which includes `componentType: z.optional(ResourceLinkSchema('Contentful:ComponentType'))`

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Integration tests pass in CI

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1175]: https://contentful.atlassian.net/browse/DX-1175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ