### PR TITLE
fix: drop dimensionKeyMap from ExO entity types [DX-1180]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -93,11 +93,6 @@ export type ComponentTypeDesignProperty =
   | BooleanDesignProperty
   | TokenBackedDesignProperty
 
-// Dimension key map
-export type ComponentTypeDimensionKeyMap = {
-  designProperties: Record<string, Record<string, string>>
-}
-
 // Content property pointer value types
 export type ContentPropertyPointerValue = `$contentProperties/${string}`
 
@@ -197,7 +192,6 @@ export type ComponentTypeProps = {
   viewports: ComponentTypeViewport[]
   contentProperties: ComponentTypeContentProperty[]
   designProperties: ComponentTypeDesignProperty[]
-  dimensionKeyMap: ComponentTypeDimensionKeyMap
   componentTree?: TreeNode[]
   slots?: ComponentTypeSlotDefinition[]
   metadata?: ExoMetadataProps

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -12,10 +12,6 @@ import type {
   FragmentNode,
 } from './component-type'
 
-export type ExperienceDimensionKeyMap = {
-  designProperties: Record<string, { breakpoint: string }>
-}
-
 export type ExperienceContentBindings = {
   sys: ResourceLink<'Contentful:DataAssembly'>['sys']
   parameters: Record<string, ResourceLink<string>>
@@ -51,7 +47,6 @@ type ExperienceCommonProps = {
   description: string
   viewports: ComponentTypeViewport[]
   designProperties: Record<string, DimensionedDesignPropertyValue>
-  dimensionKeyMap: ExperienceDimensionKeyMap
   contentBindings?: ExperienceContentBindings
   metadata?: ExperienceMetadataProps
   slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -12,11 +12,7 @@ import type {
   DimensionedDesignPropertyValue,
   FragmentNode,
 } from './component-type'
-import type {
-  ExperienceContentBindings,
-  ExperienceDimensionKeyMap,
-  InlineFragmentNode,
-} from './experience'
+import type { ExperienceContentBindings, InlineFragmentNode } from './experience'
 
 export type FragmentSys = {
   id: string
@@ -48,7 +44,6 @@ export type FragmentProps = {
   description: string
   viewports: ComponentTypeViewport[]
   designProperties: Record<string, DimensionedDesignPropertyValue>
-  dimensionKeyMap: ExperienceDimensionKeyMap
   contentBindings?: ExperienceContentBindings
   metadata?: ExperienceMetadataProps
   slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>

--- a/lib/entities/template.ts
+++ b/lib/entities/template.ts
@@ -9,7 +9,6 @@ import type {
 import type {
   ComponentTypeContentProperty,
   ComponentTypeDesignProperty,
-  ComponentTypeDimensionKeyMap,
   ComponentTypeSlotDefinition,
   ComponentTypeViewport,
   DataAssemblyLink,
@@ -46,7 +45,6 @@ export type TemplateProps = {
   viewports: ComponentTypeViewport[]
   contentProperties: ComponentTypeContentProperty[]
   designProperties: ComponentTypeDesignProperty[]
-  dimensionKeyMap: ComponentTypeDimensionKeyMap
   componentTree?: TreeNode[]
   slots?: ComponentTypeSlotDefinition[]
   metadata?: ExoMetadataProps

--- a/lib/plain/entities/component-type.ts
+++ b/lib/plain/entities/component-type.ts
@@ -71,7 +71,6 @@ export type ComponentTypePlainClientAPI = {
    *   viewports: [],
    *   contentProperties: [],
    *   designProperties: [],
-   *   dimensionKeyMap: { designProperties: {} },
    * });
    * ```
    */

--- a/lib/plain/entities/experience.ts
+++ b/lib/plain/entities/experience.ts
@@ -70,7 +70,6 @@ export type ExperiencePlainClientAPI = {
    *   viewports: [],
    *   contentProperties: {},
    *   designProperties: {},
-   *   dimensionKeyMap: { designProperties: {} },
    * });
    * ```
    */

--- a/lib/plain/entities/fragment.ts
+++ b/lib/plain/entities/fragment.ts
@@ -68,7 +68,6 @@ export type FragmentPlainClientAPI = {
    *   componentType: { sys: { type: 'Link', linkType: 'ComponentType', id: '<component_type_id>' } },
    *   viewports: [],
    *   designProperties: {},
-   *   dimensionKeyMap: { designProperties: {} },
    * });
    * ```
    */

--- a/lib/plain/entities/template.ts
+++ b/lib/plain/entities/template.ts
@@ -68,7 +68,6 @@ export type TemplatePlainClientAPI = {
    *   viewports: [],
    *   contentProperties: [],
    *   designProperties: [],
-   *   dimensionKeyMap: { designProperties: {} },
    * });
    * ```
    */

--- a/test/integration/component-type-integration.test.ts
+++ b/test/integration/component-type-integration.test.ts
@@ -23,7 +23,6 @@ describe('ComponentType Integration', { sequential: true }, () => {
         viewports: [testViewport],
         contentProperties: [{ id: 'title', name: 'Title', type: 'String', required: false }],
         designProperties: [{ id: 'color', name: 'Color', type: 'String' }],
-        dimensionKeyMap: { designProperties: {} },
       },
     )
     componentTypeId = created.sys.id
@@ -127,7 +126,6 @@ describe('ComponentType Integration', { sequential: true }, () => {
         description: 'Should fail — missing name and viewports',
         contentProperties: [],
         designProperties: [],
-        dimensionKeyMap: { designProperties: {} },
       } as any),
     ).rejects.toThrow()
   })

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -26,7 +26,6 @@ describe('Experience Integration', { sequential: true }, () => {
         viewports: [testViewport],
         contentProperties: [],
         designProperties: [],
-        dimensionKeyMap: { designProperties: {} },
       },
     )
     templateId = tmpl.sys.id
@@ -45,7 +44,6 @@ describe('Experience Integration', { sequential: true }, () => {
         template: makeResourceLink('Contentful:Template', templateId),
         viewports: [testViewport],
         designProperties: {},
-        dimensionKeyMap: { designProperties: {} },
       },
     )
     experienceId = exp.sys.id

--- a/test/integration/fragment-integration.test.ts
+++ b/test/integration/fragment-integration.test.ts
@@ -25,7 +25,6 @@ describe('Fragment Integration', { sequential: true }, () => {
         viewports: [testViewport],
         contentProperties: [],
         designProperties: [],
-        dimensionKeyMap: { designProperties: {} },
       },
     )
     componentTypeId = ct.sys.id
@@ -44,7 +43,6 @@ describe('Fragment Integration', { sequential: true }, () => {
         componentType: makeResourceLink('Contentful:ComponentType', componentTypeId),
         viewports: [testViewport],
         designProperties: {},
-        dimensionKeyMap: { designProperties: {} },
       },
     )
     fragmentId = frag.sys.id

--- a/test/integration/template-integration.test.ts
+++ b/test/integration/template-integration.test.ts
@@ -23,7 +23,6 @@ describe('Template Integration', { sequential: true }, () => {
         viewports: [testViewport],
         contentProperties: [{ id: 'heading', name: 'Heading', type: 'String', required: false }],
         designProperties: [{ id: 'bgColor', name: 'Background Color', type: 'String' }],
-        dimensionKeyMap: { designProperties: {} },
       },
     )
     templateId = created.sys.id

--- a/test/unit/adapters/REST/endpoints/component-type.test.ts
+++ b/test/unit/adapters/REST/endpoints/component-type.test.ts
@@ -144,7 +144,6 @@ describe('Rest ComponentType', { concurrent: true }, () => {
       viewports: [],
       contentProperties: [],
       designProperties: [],
-      dimensionKeyMap: { designProperties: {} },
     }
 
     const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
@@ -184,7 +183,6 @@ describe('Rest ComponentType', { concurrent: true }, () => {
       viewports: [],
       contentProperties: [],
       designProperties: [],
-      dimensionKeyMap: { designProperties: {} },
     }
 
     const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
@@ -237,7 +235,6 @@ describe('Rest ComponentType', { concurrent: true }, () => {
       viewports: [],
       contentProperties: [],
       designProperties: [],
-      dimensionKeyMap: { designProperties: {} },
     }
 
     const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
@@ -259,7 +256,6 @@ describe('Rest ComponentType', { concurrent: true }, () => {
           viewports: [],
           contentProperties: [],
           designProperties: [],
-          dimensionKeyMap: { designProperties: {} },
         },
       })
       .then((r) => {
@@ -281,7 +277,6 @@ describe('Rest ComponentType', { concurrent: true }, () => {
       viewports: [],
       contentProperties: [],
       designProperties: [],
-      dimensionKeyMap: { designProperties: {} },
     }
 
     const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
@@ -303,7 +298,6 @@ describe('Rest ComponentType', { concurrent: true }, () => {
           viewports: [],
           contentProperties: [],
           designProperties: [],
-          dimensionKeyMap: { designProperties: {} },
         },
       })
       .then((r) => {
@@ -325,7 +319,6 @@ describe('Rest ComponentType', { concurrent: true }, () => {
       viewports: [],
       contentProperties: [],
       designProperties: [],
-      dimensionKeyMap: { designProperties: {} },
     }
 
     const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
@@ -345,7 +338,6 @@ describe('Rest ComponentType', { concurrent: true }, () => {
           viewports: [],
           contentProperties: [],
           designProperties: [],
-          dimensionKeyMap: { designProperties: {} },
         },
       })
       .then((r) => {
@@ -359,7 +351,6 @@ describe('Rest ComponentType', { concurrent: true }, () => {
           viewports: [],
           contentProperties: [],
           designProperties: [],
-          dimensionKeyMap: { designProperties: {} },
         })
       })
   })

--- a/test/unit/adapters/REST/endpoints/experience.test.ts
+++ b/test/unit/adapters/REST/endpoints/experience.test.ts
@@ -106,7 +106,6 @@ describe('Rest Experience', { concurrent: true }, () => {
       description: 'A test experience',
       viewports: [],
       designProperties: {},
-      dimensionKeyMap: { designProperties: {} },
     }
 
     const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
@@ -208,7 +207,6 @@ describe('Rest Experience', { concurrent: true }, () => {
       description: 'A new experience',
       viewports: [],
       designProperties: {},
-      dimensionKeyMap: { designProperties: {} },
     }
 
     const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
@@ -230,7 +228,6 @@ describe('Rest Experience', { concurrent: true }, () => {
           template: templateLink,
           viewports: [],
           designProperties: {},
-          dimensionKeyMap: { designProperties: {} },
         },
       })
       .then((r) => {
@@ -250,7 +247,6 @@ describe('Rest Experience', { concurrent: true }, () => {
       description: 'An updated experience',
       viewports: [],
       designProperties: {},
-      dimensionKeyMap: { designProperties: {} },
     }
 
     const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
@@ -271,7 +267,6 @@ describe('Rest Experience', { concurrent: true }, () => {
           description: 'An updated experience',
           viewports: [],
           designProperties: {},
-          dimensionKeyMap: { designProperties: {} },
         },
       })
       .then((r) => {
@@ -292,7 +287,6 @@ describe('Rest Experience', { concurrent: true }, () => {
       description: 'Created via upsert',
       viewports: [],
       designProperties: {},
-      dimensionKeyMap: { designProperties: {} },
     }
 
     const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
@@ -313,7 +307,6 @@ describe('Rest Experience', { concurrent: true }, () => {
           description: 'Created via upsert',
           viewports: [],
           designProperties: {},
-          dimensionKeyMap: { designProperties: {} },
         },
       })
       .then((r) => {
@@ -361,7 +354,6 @@ describe('Rest Experience', { concurrent: true }, () => {
       description: 'A test experience',
       viewports: [],
       designProperties: {},
-      dimensionKeyMap: { designProperties: {} },
     }
 
     const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))

--- a/test/unit/adapters/REST/endpoints/fragment.test.ts
+++ b/test/unit/adapters/REST/endpoints/fragment.test.ts
@@ -148,7 +148,6 @@ describe('Rest Fragment', { concurrent: true }, () => {
           componentType: { sys: { type: 'Link', linkType: 'ComponentType', id: 'ct-abc' } },
           viewports: [],
           designProperties: {},
-          dimensionKeyMap: { designProperties: {} },
         },
       })
       .then((r) => {


### PR DESCRIPTION
[DX-1180](https://contentful.atlassian.net/browse/DX-1180)

## Summary

Upstream commit `6578c838f` ([SPA-4414](https://contentful.atlassian.net/browse/SPA-4414)) removed `dimensionKeyMap` from the ExO API response schemas. The field now exists upstream only on input config schemas as `z.optional(z.unknown())` — accepted-and-ignored for gradual migration. Once the API ships the strict-reject behavior, integration tests on `feat/exo` will fail because the SDK still requires the field.

This PR brings the SDK in line ahead of that:

- Remove `dimensionKeyMap` field from `ComponentTypeProps`, `ExperienceCommonProps` (covers Experience + ReleaseExperience), `TemplateProps`, `FragmentProps`
- Delete the orphan `ComponentTypeDimensionKeyMap` and `ExperienceDimensionKeyMap` types (no upstream equivalent)
- Strip the field from JSDoc examples in plain-entity files
- Strip the field from unit + integration test fixtures
- **No** `dimensionKeyMap?: unknown` migration slot added on Create/Upsert payloads — `feat/exo` has no shipped consumers, so we match upstream cleanly rather than carry a deprecated input shape

> [!NOTE]
> The DX-1183 Fragment-upsert rename was originally bundled in this PR but split out for clarity. See the follow-up PR for that change.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Unit tests pass (850/850)
- [x] Type tests pass (8/8)
- [ ] Integration tests on `feat/exo` once SPA-4414 has shipped to staging (intentionally not run locally — would fail until upstream API change is live)

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1180]: https://contentful.atlassian.net/browse/DX-1180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SPA-4414]: https://contentful.atlassian.net/browse/SPA-4414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ