### PR TITLE
fix: rename Fragment update -> upsert for naming parity [DX-1183]

### DIFF
--- a/lib/adapters/REST/endpoints/fragment.ts
+++ b/lib/adapters/REST/endpoints/fragment.ts
@@ -6,7 +6,7 @@ import type {
   CreateFragmentProps,
   FragmentProps,
   FragmentQueryOptions,
-  UpdateFragmentProps,
+  UpsertFragmentProps,
   FragmentCollection,
 } from '../../../entities/fragment'
 import type { RestEndpoint } from '../types'
@@ -44,10 +44,10 @@ export const create: RestEndpoint<'Fragment', 'create'> = (
   return raw.post<FragmentProps>(http, getBaseUrl(params), data, { headers })
 }
 
-export const update: RestEndpoint<'Fragment', 'update'> = (
+export const upsert: RestEndpoint<'Fragment', 'upsert'> = (
   http: AxiosInstance,
   params: GetFragmentParams,
-  rawData: UpdateFragmentProps,
+  rawData: UpsertFragmentProps,
   headers?: RawAxiosRequestHeaders,
 ) => {
   const { sys, ...body } = copy(rawData)

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -71,7 +71,7 @@ import type {
   CreateFragmentProps,
   FragmentProps,
   FragmentQueryOptions,
-  UpdateFragmentProps,
+  UpsertFragmentProps,
 } from './entities/fragment'
 import type {
   CreateTemplateProps,
@@ -1102,7 +1102,7 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Fragment', 'getMany', UA>): MRReturn<'Fragment', 'getMany'>
   (opts: MROpts<'Fragment', 'get', UA>): MRReturn<'Fragment', 'get'>
   (opts: MROpts<'Fragment', 'create', UA>): MRReturn<'Fragment', 'create'>
-  (opts: MROpts<'Fragment', 'update', UA>): MRReturn<'Fragment', 'update'>
+  (opts: MROpts<'Fragment', 'upsert', UA>): MRReturn<'Fragment', 'upsert'>
   (opts: MROpts<'Fragment', 'delete', UA>): MRReturn<'Fragment', 'delete'>
   (opts: MROpts<'Fragment', 'publish', UA>): MRReturn<'Fragment', 'publish'>
   (opts: MROpts<'Fragment', 'unpublish', UA>): MRReturn<'Fragment', 'unpublish'>
@@ -2841,9 +2841,9 @@ export type MRActions = {
       payload: CreateFragmentProps
       return: FragmentProps
     }
-    update: {
+    upsert: {
       params: GetFragmentParams
-      payload: UpdateFragmentProps
+      payload: UpsertFragmentProps
       return: FragmentProps
     }
     delete: {

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -58,7 +58,7 @@ export type CreateFragmentProps = Except<FragmentProps, 'sys'> & {
   componentType: ResourceLink<'Contentful:ComponentType'>
 }
 
-export type UpdateFragmentProps = Omit<FragmentProps, 'sys'> & {
+export type UpsertFragmentProps = Omit<FragmentProps, 'sys'> & {
   sys: {
     id: string
     type: 'Fragment'

--- a/lib/plain/entities/fragment.ts
+++ b/lib/plain/entities/fragment.ts
@@ -7,7 +7,7 @@ import type {
   CreateFragmentProps,
   FragmentProps,
   FragmentQueryOptions,
-  UpdateFragmentProps,
+  UpsertFragmentProps,
 } from '../../entities/fragment'
 import type { OptionalDefaults } from '../wrappers/wrap'
 
@@ -78,24 +78,24 @@ export type FragmentPlainClientAPI = {
   ): Promise<FragmentProps>
 
   /**
-   * Updates a fragment with PUT
+   * Upserts a fragment (creates or updates via PUT)
    * @param params the space, environment, and fragment IDs
-   * @param data the fragment data (including sys.version)
-   * @returns the updated fragment
+   * @param data the fragment data to upsert (include sys.version for updates, omit for creates)
+   * @returns the upserted fragment
    * @throws if the request fails, or the space, environment, or fragment is not found
    * @internal - Experimental endpoint, subject to breaking changes without notice
    * @example
    * ```javascript
-   * const fragment = await client.fragment.update({
+   * const fragment = await client.fragment.upsert({
    *   spaceId: '<space_id>',
    *   environmentId: '<environment_id>',
    *   fragmentId: '<fragment_id>',
    * }, fragmentData);
    * ```
    */
-  update(
+  upsert(
     params: OptionalDefaults<GetFragmentParams>,
-    data: UpdateFragmentProps,
+    data: UpsertFragmentProps,
   ): Promise<FragmentProps>
 
   /**

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -632,7 +632,7 @@ export const createPlainClient = (
       getMany: wrap(wrapParams, 'Fragment', 'getMany'),
       get: wrap(wrapParams, 'Fragment', 'get'),
       create: wrap(wrapParams, 'Fragment', 'create'),
-      update: wrap(wrapParams, 'Fragment', 'update'),
+      upsert: wrap(wrapParams, 'Fragment', 'upsert'),
       delete: wrap(wrapParams, 'Fragment', 'delete'),
       publish: wrap(wrapParams, 'Fragment', 'publish'),
       unpublish: wrap(wrapParams, 'Fragment', 'unpublish'),

--- a/test/integration/fragment-integration.test.ts
+++ b/test/integration/fragment-integration.test.ts
@@ -108,11 +108,11 @@ describe('Fragment Integration', { sequential: true }, () => {
     expect(fetched.sys.type).toBe('Fragment')
   })
 
-  it('updates a fragment', async () => {
+  it('upserts a fragment', async () => {
     const current = await client.fragment.get({ fragmentId: fragmentId })
 
-    // Update types require minimal sys — full entity sys is not assignable
-    const updated = await client.fragment.update(
+    // Upsert types require minimal sys — full entity sys is not assignable
+    const updated = await client.fragment.upsert(
       { fragmentId: fragmentId },
       {
         ...current,

--- a/test/unit/adapters/REST/endpoints/fragment.test.ts
+++ b/test/unit/adapters/REST/endpoints/fragment.test.ts
@@ -163,7 +163,7 @@ describe('Rest Fragment', { concurrent: true }, () => {
       })
   })
 
-  test('update calls correct URL with PUT and X-Contentful-Version header', async () => {
+  test('upsert calls correct URL with PUT and X-Contentful-Version header', async () => {
     const mockResponse = {
       sys: { id: 'fragment123', type: 'Fragment', version: 2 },
       name: 'Updated Fragment',
@@ -174,7 +174,7 @@ describe('Rest Fragment', { concurrent: true }, () => {
     return adapterMock
       .makeRequest({
         entityType: 'Fragment',
-        action: 'update',
+        action: 'upsert',
         userAgent: 'mocked',
         params: {
           spaceId: 'space123',


### PR DESCRIPTION
[DX-1183](https://contentful.atlassian.net/browse/DX-1183)

## Summary

The Fragment `PUT /fragments/:id` endpoint is upstream-named `upsert` (`experiences-management-api-contract/src/fragment.ts:90`) — it accepts an optional `componentType` so the same endpoint handles both create-via-PUT and update. ComponentType, Template, and Experience were renamed `UpdateXxxProps → UpsertXxxProps` in [DX-1108](https://contentful.atlassian.net/browse/DX-1108), and their plain-client methods already expose `.upsert()`. Fragment was the odd one out.

This brings Fragment in line:

- Rename `UpdateFragmentProps` → `UpsertFragmentProps` (entity + import sites in plain client, REST adapter, `common-types.ts`)
- Rename plain-client method `client.fragment.update(...)` → `client.fragment.upsert(...)` (and JSDoc)
- Rename REST adapter export `update` → `upsert` and the `RestEndpoint` type tag
- Rename `Fragment.update` → `Fragment.upsert` in the `common-types.ts` endpoint table and `MROpts` overload
- Update unit + integration test references

**No deprecated aliases** — `feat/exo` has no shipped consumers.

> [!NOTE]
> Originally bundled with [DX-1180 (#3066)](https://github.com/contentful/contentful-management.js/pull/3066) and split out for clarity. No conflict with that PR — disjoint file scope (Fragment-rename hunks only) and no overlap with the dimensionKeyMap drift cleanup.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Fragment unit tests pass (9/9)
- [ ] Full suite + integration once both PRs land on `feat/exo`

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1183]: https://contentful.atlassian.net/browse/DX-1183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-1108]: https://contentful.atlassian.net/browse/DX-1108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ