### PR TITLE
fix: split DataAssemblyDataTypeField into canonical and legacy arms [DX-1182]

### DIFF
--- a/lib/entities/data-assembly.ts
+++ b/lib/entities/data-assembly.ts
@@ -8,12 +8,25 @@ import type {
   ResourceLink,
 } from '../common-types'
 
-// DataTypeField — DataTypeDefinition extended with id, name, and optional source
-export type DataAssemblyDataTypeField = DataTypeDefinition & {
+export type CanonicalDataAssemblyDataTypeField = DataTypeDefinition & {
   id: string
   name: string
-  source?: string
 }
+
+// Permissive shape for pre-cutover stored records. Will be removed after the
+// assemblies API completes its backfill to the canonical DataTypeDefinition.
+export type LegacyDataAssemblyDataTypeField = {
+  id: string
+  name: string
+  type: string
+  required?: boolean
+  source?: string
+  ref?: unknown
+}
+
+export type DataAssemblyDataTypeField =
+  | CanonicalDataAssemblyDataTypeField
+  | LegacyDataAssemblyDataTypeField
 
 export type DataAssemblyLinkParameter = {
   name?: string


### PR DESCRIPTION
[DX-1182](https://contentful.atlassian.net/browse/DX-1182)

## Summary
- Match upstream `DataTypeFieldSchema` (`assemblies/libs/assemblies-types/src/lib/data-assembly.ts:42`): canonical variants no longer carry `source?`, and a permissive `LegacyDataAssemblyDataTypeField` arm accepts pre-cutover stored records that have not yet been migrated to the canonical `DataTypeDefinition` vocabulary.
- Removes the spurious `source?` from every canonical variant — it had no upstream basis (was added in the original SDK port and never trimmed during the canonical migration in DX-1163).
- The legacy arm is a temporary shim: it exists upstream solely to validate pre-ARC-1584 stored records on read, and is expected to be deleted once the assemblies API completes its backfill. Tracked as a follow-up.

## Why this is breaking
- Users currently writing `field.source` on canonical-typed fields will see a TS error. Pre-cutover field shapes (e.g. `type: 'Symbol'`, `type: 'DataType'`) now narrow into `LegacyDataAssemblyDataTypeField` instead of being implicitly accepted on the canonical arm.
- This is intentional and aligns the SDK with the contract today.

## Test plan
- [x] `npx tsc --noEmit` passes on `feat/exo`
- [x] `npx vitest --project unit --run test/unit/adapters/REST/endpoints/data-assembly.test.ts` (12 passed)
- [x] `npx vitest --project types --run` (8 passed, no type errors)

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1182]: https://contentful.atlassian.net/browse/DX-1182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ