### PR TITLE
fix: make UpsertFragmentProps.sys.version optional [DX-1194]

### DIFF
--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -57,7 +57,7 @@ export type UpsertFragmentProps = Omit<FragmentProps, 'sys'> & {
   sys: {
     id: string
     type: 'Fragment'
-    version: number
+    version?: number
   }
   componentType?: ResourceLink<'Contentful:ComponentType'>
 }


### PR DESCRIPTION
[DX-1194](https://contentful.atlassian.net/browse/DX-1194)

## Summary
- Aligns `UpsertFragmentProps.sys.version` with peer ExO entities (`Experience`, `Template`, `ComponentType`), all of which type `version?: number`.
- Matches the upstream contract — `[CONTENTFUL_VERSION]: z.optional(numberFromString())` in `assemblies/libs/experiences-management-api-contract/src/fragment.ts`. Fragment was the only outlier.
- The REST adapter (`lib/adapters/REST/endpoints/fragment.ts`) already conditionally adds the `X-Contentful-Version` header when `sys?.version !== undefined`, so no runtime change is needed.

## Test plan
- [x] `tsc --noEmit` passes on `feat/exo`
- [ ] Existing Fragment upsert integration tests still pass in CI
- [ ] Optional follow-up: add a test calling `client.fragment.upsert(...)` without `sys.version` to confirm the type allows it and the header is omitted

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1194]: https://contentful.atlassian.net/browse/DX-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ