### PR TITLE
fix: narrow ComponentTypeSlotDefinition source to literal CRN [DX-1191]

### DIFF
--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -149,6 +149,9 @@ export type TreeNode = ComponentNode | FragmentNode | SlotNode
 // DataAssembly link type
 export type DataAssemblyLink = ResourceLink<'Contentful:DataAssembly'>
 
+export const COMPONENT_TYPE_ALLOWED_RESOURCE_SOURCE =
+  'crn:contentful:::experience:spaces/$self/environments/$self' as const
+
 // Slot definition
 export type ComponentTypeSlotDefinition = {
   id: string
@@ -157,7 +160,7 @@ export type ComponentTypeSlotDefinition = {
   validations: Array<{ size?: { min?: number; max?: number } }>
   allowedResources?: Array<{
     type: 'Contentful:ComponentType'
-    source: string
+    source: typeof COMPONENT_TYPE_ALLOWED_RESOURCE_SOURCE
     allowedTypes: string[]
   }>
 }


### PR DESCRIPTION
[DX-1191](https://contentful.atlassian.net/browse/DX-1191)

## Summary
- Adds the `COMPONENT_TYPE_ALLOWED_RESOURCE_SOURCE` const (`'crn:contentful:::experience:spaces/$self/environments/$self'`) and narrows `ComponentTypeSlotDefinition.allowedResources[].source` from `string` to `typeof COMPONENT_TYPE_ALLOWED_RESOURCE_SOURCE`.
- Mirrors the upstream tightening in `ARC-1526` (commit `7169b5119`) where `ComponentTypeAllowedResourceSchema.source` became `z.literal(COMPONENT_TYPE_ALLOWED_RESOURCE_SOURCE)`.
- Follows the [DX-1187](https://contentful.atlassian.net/browse/DX-1187) pattern for `SAME_SPACE_CONTENT_SOURCE` in `data-assembly.ts`: co-locate the const with the entity, narrow the field to `typeof <const>`. No public re-export needed (matches DX-1187's surface decision).
- No fixtures to migrate — `grep` for slot `allowedResources` usages turned up zero hardcoded `experience:` CRN strings in `lib` or `test`.

## Test plan
- [x] `tsc --noEmit` passes on `feat/exo`
- [ ] CI green
- [ ] Spot-check that the new const is exported from `lib/entities/component-type.ts` and importable downstream

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1191]: https://contentful.atlassian.net/browse/DX-1191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-1187]: https://contentful.atlassian.net/browse/DX-1187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ