### PR TITLE
feat(comment): add ExO parent entity support [CFISO-3346]

### DIFF
--- a/lib/adapters/REST/endpoints/comment.ts
+++ b/lib/adapters/REST/endpoints/comment.ts
@@ -18,6 +18,7 @@ import type {
   PlainTextBodyFormat,
   RichTextBodyFormat,
   RichTextCommentBodyPayload,
+  CommentParentEntityType,
 } from '../../../entities/comment'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
@@ -33,7 +34,7 @@ const getSpaceEnvBaseUrl = (params: GetSpaceEnvironmentParams) =>
 const getEntityCommentUrl = (params: GetCommentParams) =>
   `${getEntityBaseUrl(params)}/${params.commentId}`
 
-function getParentPlural(parentEntityType: 'ContentType' | 'Entry' | 'Workflow') {
+function getParentPlural(parentEntityType: CommentParentEntityType) {
   switch (parentEntityType) {
     case 'ContentType':
       return 'content_types'
@@ -41,12 +42,20 @@ function getParentPlural(parentEntityType: 'ContentType' | 'Entry' | 'Workflow')
       return 'entries'
     case 'Workflow':
       return 'workflows'
+    case 'Experience':
+      return 'experiences'
+    case 'Fragment':
+      return 'fragments'
+    case 'ComponentType':
+      return 'component_types'
+    case 'Template':
+      return 'templates'
   }
 }
 
 /**
- * Comments can be added to a content type, an entry, and a workflow. Workflow comments requires a version
- * to be set as part of the URL path. Workflow comments only support `create` (with
+ * Comments can be added to a content type, an entry, a workflow, or ExO entities. Workflow comments requires a version
+ * to be set as part of the URL path for versioned operations. Workflow comments only support `create` (with
  * versionized URL) and `getMany` (without version). The API might support more methods
  * in the future with new use cases being discovered.
  */

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -23,6 +23,17 @@ interface LinkWithReference<T extends string> extends Link<T> {
   }
 }
 
+export type CommentParentEntityType =
+  | 'ContentType'
+  | 'Entry'
+  | 'Workflow'
+  | 'Experience'
+  | 'Fragment'
+  | 'ComponentType'
+  | 'Template'
+
+type NonWorkflowCommentParentEntityType = Exclude<CommentParentEntityType, 'Workflow'>
+
 export type CommentSysProps = Pick<
   BasicMetaSysProps,
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
@@ -31,10 +42,8 @@ export type CommentSysProps = Pick<
   space: SysLink
   environment: SysLink
   parentEntity:
-    | Link<'ContentType'>
-    | LinkWithReference<'ContentType'>
-    | Link<'Entry'>
-    | LinkWithReference<'Entry'>
+    | Link<NonWorkflowCommentParentEntityType>
+    | LinkWithReference<NonWorkflowCommentParentEntityType>
     | VersionedLink<'Workflow'>
   parent: Link<'Comment'> | null
 }
@@ -93,12 +102,7 @@ export type RichTextCommentProps = Omit<CommentProps, 'body'> & RichTextCommentB
 export type GetCommentParentEntityParams = GetSpaceEnvironmentParams &
   (
     | {
-        parentEntityType: 'ContentType'
-        parentEntityId: string
-        parentEntityReference?: string
-      }
-    | {
-        parentEntityType: 'Entry'
+        parentEntityType: NonWorkflowCommentParentEntityType
         parentEntityId: string
         parentEntityReference?: string
       }
@@ -139,12 +143,17 @@ export interface RichTextComment
  * @internal
  */
 export default function createCommentApi(makeRequest: MakeRequest): CommentApi {
-  const getParams = (comment: CommentProps): GetCommentParams => ({
-    spaceId: comment.sys.space.sys.id,
-    environmentId: comment.sys.environment.sys.id,
-    entryId: comment.sys.parentEntity.sys.id,
-    commentId: comment.sys.id,
-  })
+  const getParams = (comment: CommentProps): GetCommentParams => {
+    const parentEntity = comment.sys.parentEntity
+
+    return {
+      spaceId: comment.sys.space.sys.id,
+      environmentId: comment.sys.environment.sys.id,
+      commentId: comment.sys.id,
+      parentEntityType: parentEntity.sys.linkType,
+      parentEntityId: parentEntity.sys.id,
+    }
+  }
 
   return {
     update: async function () {

--- a/test/unit/adapters/REST/endpoints/comment.test.ts
+++ b/test/unit/adapters/REST/endpoints/comment.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+
+const response = { data: { sys: { type: 'Comment' }, body: 'Looks good', status: 'active' } }
+
+describe('Rest Comment', { concurrent: true }, () => {
+  const request = (action, params) => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve(response))
+
+    adapterMock.makeRequest({
+      entityType: 'Comment',
+      action,
+      userAgent: 'mocked',
+      params,
+      payload: { body: 'Looks good', status: 'active', sys: { version: 1 } },
+    })
+
+    return httpMock
+  }
+
+  test.each([
+    ['Experience', 'experiences'],
+    ['Fragment', 'fragments'],
+    ['ComponentType', 'component_types'],
+    ['Template', 'templates'],
+  ] as const)('getMany supports %s comments', (parentEntityType, path) => {
+    const httpMock = request('getMany', {
+      spaceId: 'space',
+      environmentId: 'env',
+      parentEntityType,
+      parentEntityId: 'parent',
+    })
+
+    expect(httpMock.get.mock.calls[0][0]).toBe(`/spaces/space/environments/env/${path}/parent/comments`)
+  })
+
+  test.each([
+    ['create', 'post', ''],
+    ['update', 'put', '/comment'],
+    ['delete', 'delete', '/comment'],
+  ] as const)('%s supports ExO comments', (action, method, suffix) => {
+    const httpMock = request(action, {
+      spaceId: 'space',
+      environmentId: 'env',
+      parentEntityType: 'ComponentType',
+      parentEntityId: 'component-type',
+      commentId: 'comment',
+      version: 1,
+    })
+
+    expect(httpMock[method].mock.calls[0][0]).toBe(
+      `/spaces/space/environments/env/component_types/component-type/comments${suffix}`,
+    )
+  })
+})

--- a/test/unit/adapters/REST/endpoints/comment.test.ts
+++ b/test/unit/adapters/REST/endpoints/comment.test.ts
@@ -31,7 +31,9 @@ describe('Rest Comment', { concurrent: true }, () => {
       parentEntityId: 'parent',
     })
 
-    expect(httpMock.get.mock.calls[0][0]).toBe(`/spaces/space/environments/env/${path}/parent/comments`)
+    expect(httpMock.get.mock.calls[0][0]).toBe(
+      `/spaces/space/environments/env/${path}/parent/comments`,
+    )
   })
 
   test.each([


### PR DESCRIPTION
## Summary

Add comment URL support for ExO parent entities in contentful-management:

- Experience comments use `/experiences/{id}/comments`
- Fragment comments use `/fragments/{id}/comments`
- Component type comments use `/component_types/{id}/comments`
- Template comments use `/templates/{id}/comments`

Also extends comment parent entity types and adds REST endpoint coverage for ExO comment URLs.

## Ticket

https://contentful.atlassian.net/browse/CFISO-3346

## Why

CMA API supports comments for ExO entities, but the SDK only mapped Entry, ContentType, and Workflow parent URLs. This enables UI code to use the standard `client.comment.*` methods for ExO comments.

## Risk and Rollout

Low risk. Existing Entry, ContentType, and Workflow URL behavior is preserved; the change only adds new parent entity mappings and types.
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds support for Experience Optimization (ExO) entity comments in the contentful-management SDK, enabling standard client.comment.* methods to work with Experience, Fragment, ComponentType, and Template parent entities. Existing Entry, ContentType, and Workflow comment behavior is preserved while the type system is refactored to use a unified CommentParentEntityType union.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds CommentParentEntityType union type supporting Experience, Fragment, ComponentType, and Template alongside existing ContentType, Entry, and Workflow types in lib/entities/comment.ts</li>

<li>Extends getParentPlural function in comment.ts REST endpoint to map ExO entity types to their plural URL path segments (experiences, fragments, component_types, templates)</li>

<li>Refactors getParams function to dynamically extract parentEntityType and parentEntityId from comment.sys.parentEntity.sys instead of assuming entryId field, enabling generic parent entity support</li>

<li>Adds unit tests validating ExO comment URL generation for create, update, delete, and getMany operations across all four new entity types</li>

</ul>
</details>

</div>