### PR TITLE
feat(task): add ExO parent entity support [CFISO-3354]

### DIFF
--- a/lib/adapters/REST/endpoints/task.ts
+++ b/lib/adapters/REST/endpoints/task.ts
@@ -4,6 +4,8 @@ import type { SetOptional } from 'type-fest'
 import type {
   CollectionProp,
   GetEntryParams,
+  GetSpaceEnvironmentParams,
+  GetTaskParentEntityParams,
   GetTaskParams,
   PaginationQueryOptions,
   QueryParams,
@@ -12,6 +14,8 @@ import type {
   CreateTaskParams,
   CreateTaskProps,
   DeleteTaskParams,
+  TaskParentEntityPath,
+  TaskParentEntityType,
   TaskProps,
   UpdateTaskProps,
 } from '../../../entities/task'
@@ -19,8 +23,42 @@ import type { RestEndpoint } from '../types'
 import * as raw from './raw'
 import { normalizeSelect } from './utils'
 
-const getBaseUrl = (params: GetEntryParams) =>
-  `/spaces/${params.spaceId}/environments/${params.environmentId}/entries/${params.entryId}/tasks`
+const getSpaceEnvBaseUrl = (params: GetSpaceEnvironmentParams) =>
+  `/spaces/${params.spaceId}/environments/${params.environmentId}`
+
+function getParentPlural(parentEntityType: TaskParentEntityType): TaskParentEntityPath {
+  switch (parentEntityType) {
+    case 'Entry':
+      return 'entries'
+    case 'Experience':
+      return 'experiences'
+    case 'Fragment':
+      return 'fragments'
+    case 'Template':
+      return 'templates'
+    case 'ComponentType':
+      return 'component_types'
+  }
+}
+
+const normalizeTaskParentParams = (
+  paramsOrg: GetEntryParams | GetTaskParentEntityParams,
+): GetTaskParentEntityParams =>
+  'entryId' in paramsOrg
+    ? {
+        spaceId: paramsOrg.spaceId,
+        environmentId: paramsOrg.environmentId,
+        parentEntityType: 'Entry' as const,
+        parentEntityId: paramsOrg.entryId,
+      }
+    : paramsOrg
+
+const getBaseUrl = (paramsOrg: GetEntryParams | GetTaskParentEntityParams) => {
+  const params = normalizeTaskParentParams(paramsOrg)
+  const parentPlural = getParentPlural(params.parentEntityType)
+
+  return `${getSpaceEnvBaseUrl(params)}/${parentPlural}/${params.parentEntityId}/tasks`
+}
 const getTaskUrl = (params: GetTaskParams) => `${getBaseUrl(params)}/${params.taskId}`
 
 export const get: RestEndpoint<'Task', 'get'> = (http: AxiosInstance, params: GetTaskParams) =>
@@ -28,7 +66,7 @@ export const get: RestEndpoint<'Task', 'get'> = (http: AxiosInstance, params: Ge
 
 export const getMany: RestEndpoint<'Task', 'getMany'> = (
   http: AxiosInstance,
-  params: GetEntryParams & QueryParams & PaginationQueryOptions,
+  params: (GetEntryParams | GetTaskParentEntityParams) & QueryParams & PaginationQueryOptions,
 ) =>
   raw.get<CollectionProp<TaskProps>>(http, getBaseUrl(params), {
     params: normalizeSelect(params.query),

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -128,6 +128,7 @@ import type {
   CreateTaskParams,
   CreateTaskProps,
   DeleteTaskParams,
+  TaskParentEntityType,
   TaskProps,
   UpdateTaskParams,
   UpdateTaskProps,
@@ -2450,11 +2451,15 @@ export type MRActions = {
   Task: {
     get: { params: GetTaskParams; return: TaskProps }
     getMany: {
-      params: GetEntryParams & QueryParams
+      // Keep GetEntryParams for backwards compatibility with existing entry task callers.
+      // New task parent entity support should use GetTaskParentEntityParams.
+      params: (GetEntryParams | GetTaskParentEntityParams) & QueryParams
       return: CollectionProp<TaskProps>
     }
     getAll: {
-      params: GetEntryParams & QueryParams
+      // Keep GetEntryParams for backwards compatibility with existing entry task callers.
+      // New task parent entity support should use GetTaskParentEntityParams.
+      params: (GetEntryParams | GetTaskParentEntityParams) & QueryParams
       return: CollectionProp<TaskProps>
     }
     create: { params: CreateTaskParams; payload: CreateTaskProps; return: TaskProps }
@@ -2898,7 +2903,14 @@ export type GetSpaceParams = { spaceId: string }
 /** @internal */
 export type GetTagParams = GetSpaceEnvironmentParams & { tagId: string }
 /** @internal */
-export type GetTaskParams = GetEntryParams & { taskId: string }
+export type GetTaskParentEntityParams = GetSpaceEnvironmentParams & {
+  parentEntityType: TaskParentEntityType
+  parentEntityId: string
+}
+/** @internal */
+// Keep GetEntryParams for backwards compatibility with existing entry task callers.
+// New task parent entity support should use GetTaskParentEntityParams.
+export type GetTaskParams = (GetEntryParams | GetTaskParentEntityParams) & { taskId: string }
 /** @internal */
 export type GetTeamMembershipParams = GetTeamParams & { teamMembershipId: string }
 /** @internal */

--- a/lib/entities/task.ts
+++ b/lib/entities/task.ts
@@ -4,6 +4,7 @@ import type {
   BasicMetaSysProps,
   DefaultElements,
   GetEntryParams,
+  GetTaskParentEntityParams,
   GetTaskParams,
   Link,
   MakeRequest,
@@ -14,6 +15,20 @@ import enhanceWithMethods from '../enhance-with-methods'
 
 export type TaskStatus = 'active' | 'resolved'
 
+export type TaskParentEntityType =
+  | 'Entry'
+  | 'Experience'
+  | 'Fragment'
+  | 'Template'
+  | 'ComponentType'
+
+export type TaskParentEntityPath =
+  | 'entries'
+  | 'experiences'
+  | 'fragments'
+  | 'templates'
+  | 'component_types'
+
 export type TaskSysProps = Pick<
   BasicMetaSysProps,
   'id' | 'version' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
@@ -21,7 +36,7 @@ export type TaskSysProps = Pick<
   type: 'Task'
   space: SysLink
   environment: SysLink
-  parentEntity: Link<'Entry'>
+  parentEntity: Link<TaskParentEntityType>
 }
 
 export type TaskProps = {
@@ -35,7 +50,9 @@ export type TaskProps = {
 export type CreateTaskProps = Omit<TaskProps, 'sys'>
 export type UpdateTaskProps = Omit<TaskProps, 'sys'> & { sys: Pick<TaskSysProps, 'version'> }
 
-export type CreateTaskParams = GetEntryParams
+// Keep GetEntryParams for backwards compatibility with existing entry task callers.
+// New task parent entity support should use GetTaskParentEntityParams.
+export type CreateTaskParams = GetEntryParams | GetTaskParentEntityParams
 export type UpdateTaskParams = GetTaskParams
 export type DeleteTaskParams = GetTaskParams & { version: number }
 
@@ -50,12 +67,17 @@ export interface Task extends TaskProps, DefaultElements<TaskProps>, TaskApi {}
  * @internal
  */
 export default function createTaskApi(makeRequest: MakeRequest): TaskApi {
-  const getParams = (task: TaskProps): GetTaskParams => ({
-    spaceId: task.sys.space.sys.id,
-    environmentId: task.sys.environment.sys.id,
-    entryId: task.sys.parentEntity.sys.id,
-    taskId: task.sys.id,
-  })
+  const getParams = (task: TaskProps): GetTaskParams => {
+    const parentEntity = task.sys.parentEntity
+
+    return {
+      spaceId: task.sys.space.sys.id,
+      environmentId: task.sys.environment.sys.id,
+      parentEntityType: parentEntity.sys.linkType,
+      parentEntityId: parentEntity.sys.id,
+      taskId: task.sys.id,
+    }
+  }
 
   return {
     update: function () {

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -249,7 +249,14 @@ export type {
   SpaceMembershipProps,
 } from './entities/space-membership'
 export type { CreateTagProps, Tag, TagProps, TagSysProps, TagVisibility } from './entities/tag'
-export type { CreateTaskProps, Task, TaskProps, UpdateTaskProps } from './entities/task'
+export type {
+  CreateTaskProps,
+  Task,
+  TaskParentEntityPath,
+  TaskParentEntityType,
+  TaskProps,
+  UpdateTaskProps,
+} from './entities/task'
 export type { CreateTeamProps, Team, TeamProps } from './entities/team'
 export type {
   CreateTeamMembershipProps,

--- a/lib/plain/entities/task.ts
+++ b/lib/plain/entities/task.ts
@@ -1,5 +1,11 @@
 import type { RawAxiosRequestHeaders } from 'axios'
-import type { GetTaskParams, GetEntryParams, QueryParams, CollectionProp } from '../../common-types'
+import type {
+  GetTaskParams,
+  GetEntryParams,
+  GetTaskParentEntityParams,
+  QueryParams,
+  CollectionProp,
+} from '../../common-types'
 import type {
   CreateTaskParams,
   UpdateTaskParams,
@@ -13,7 +19,7 @@ import type { OptionalDefaults } from '../wrappers/wrap'
 export type TaskPlainClientAPI = {
   /** Fetches a task
    *
-   * @param params Space ID, Entry ID, Environment ID, and Task ID
+   * @param params Space ID, Environment ID, parent entity (or legacy Entry ID), and Task ID
    * @returns the task
    * @throws if the request fails or the task is not found
    * @example
@@ -24,12 +30,20 @@ export type TaskPlainClientAPI = {
    *   environmentId: '<environment_id>',
    *   taskId: '<task_id>',
    * });
+   *
+   * const experienceTask = await client.task.get({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   parentEntityType: 'Experience',
+   *   parentEntityId: '<experience_id>',
+   *   taskId: '<task_id>',
+   * });
    * ```
    */
   get(params: OptionalDefaults<GetTaskParams>): Promise<TaskProps>
-  /** Fetches all tasks for a given entry
+  /** Fetches all tasks for a given parent entity
    *
-   * @param params Space ID, Entry ID, Environment ID, and query parameters
+   * @param params Space ID, Environment ID, parent entity (or legacy Entry ID), and query parameters
    * @returns a collection of tasks
    * @throws if the request fails or the tasks are not found
    * @example
@@ -42,14 +56,24 @@ export type TaskPlainClientAPI = {
    *    limit: 100,
    *   }
    * });
+   *
+   * const experienceTasks = await client.task.getMany({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   parentEntityType: 'Experience',
+   *   parentEntityId: '<experience_id>',
+   *   query: {
+   *    limit: 100,
+   *   }
+   * });
    * ```
    */
   getMany(
-    params: OptionalDefaults<GetEntryParams & QueryParams>,
+    params: OptionalDefaults<(GetEntryParams | GetTaskParentEntityParams) & QueryParams>,
   ): Promise<CollectionProp<TaskProps>>
   /** Creates a task
    *
-   * @param params Space ID, Entry ID, Environment ID
+   * @param params Space ID, Environment ID, and parent entity (or legacy Entry ID)
    * @param rawData the task to create
    * @returns the created task
    * @throws if the request fails or or the payload is malformed
@@ -73,6 +97,26 @@ export type TaskPlainClientAPI = {
    *     }
    *   }
    * );
+   *
+   * const fragmentTask = await client.task.create(
+   *   {
+   *     spaceId: '<space_id>',
+   *     environmentId: '<environment_id>',
+   *     parentEntityType: 'Fragment',
+   *     parentEntityId: '<fragment_id>',
+   *   },
+   *   {
+   *     body: "Review Translation",
+   *     status: "active",
+   *     assignedTo: {
+   *       sys: {
+   *         type: "Link",
+   *          linkType: "User",
+   *          id: <user_id>
+   *       }
+   *     }
+   *   }
+   * );
    * ```
    */
   create(
@@ -82,7 +126,7 @@ export type TaskPlainClientAPI = {
   ): Promise<TaskProps>
   /** Updates a task
    *
-   * @param params Space ID, Entry ID, Environment ID, and Task ID
+   * @param params Space ID, Environment ID, parent entity (or legacy Entry ID), and Task ID
    * @param rawData the task update
    * @returns the updated task
    * @throws if the request fails, the task is not found, or the payload is malformed
@@ -107,6 +151,27 @@ export type TaskPlainClientAPI = {
    *     }
    *   }
    * );
+   *
+   * const templateTask = await client.task.update(
+   *   {
+   *     spaceId: '<space_id>',
+   *     environmentId: '<environment_id>',
+   *     parentEntityType: 'Template',
+   *     parentEntityId: '<template_id>',
+   *     taskId: '<task_id>',
+   *   },
+   *   {
+   *     body: "Review Translation",
+   *     status: "active",
+   *     assignedTo: {
+   *       sys: {
+   *         type: "Link",
+   *          linkType: "User",
+   *          id: <user_id>
+   *       }
+   *     }
+   *   }
+   * );
    * ```
    */
   update(
@@ -116,7 +181,7 @@ export type TaskPlainClientAPI = {
   ): Promise<TaskProps>
   /** Deletes a task
    *
-   * @param params Space ID, Entry ID, Environment ID, and Task ID
+   * @param params Space ID, Environment ID, parent entity (or legacy Entry ID), and Task ID
    * @throws if the request fails or the task is not found
    * @example
    * ```javascript
@@ -125,6 +190,16 @@ export type TaskPlainClientAPI = {
    *   entryId: '<entry_id>',
    *   environmentId: '<environment_id>',
    *   taskId: '<task_id>',
+   *   version: 1,
+   * });
+   *
+   * await client.task.delete({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   parentEntityType: 'ComponentType',
+   *   parentEntityId: '<component_type_id>',
+   *   taskId: '<task_id>',
+   *   version: 1,
    * });
    * ```
    */

--- a/test/unit/adapters/REST/endpoints/task.test.ts
+++ b/test/unit/adapters/REST/endpoints/task.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'vitest'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+
+const response = { data: { sys: { type: 'Task' }, body: 'Looks good', status: 'active' } }
+const payload = {
+  body: 'Looks good',
+  status: 'active',
+  assignedTo: { sys: { type: 'Link', linkType: 'User', id: 'user' } },
+  sys: { version: 2 },
+}
+
+describe('Rest Task', { concurrent: true }, () => {
+  const request = (action, params) => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve(response))
+
+    adapterMock.makeRequest({
+      entityType: 'Task',
+      action,
+      userAgent: 'mocked',
+      params,
+      payload,
+    })
+
+    return httpMock
+  }
+
+  test('getMany supports legacy entryId tasks', () => {
+    const httpMock = request('getMany', {
+      spaceId: 'space',
+      environmentId: 'env',
+      entryId: 'entry',
+    })
+
+    expect(httpMock.get.mock.calls[0][0]).toBe('/spaces/space/environments/env/entries/entry/tasks')
+  })
+
+  test.each([
+    ['Experience', 'experiences'],
+    ['Fragment', 'fragments'],
+    ['Template', 'templates'],
+    ['ComponentType', 'component_types'],
+  ] as const)('getMany supports %s tasks', (parentEntityType, path) => {
+    const httpMock = request('getMany', {
+      spaceId: 'space',
+      environmentId: 'env',
+      parentEntityType,
+      parentEntityId: 'parent',
+    })
+
+    expect(httpMock.get.mock.calls[0][0]).toBe(
+      `/spaces/space/environments/env/${path}/parent/tasks`,
+    )
+  })
+
+  test.each([
+    ['get', 'get', '/task'],
+    ['create', 'post', ''],
+    ['update', 'put', '/task'],
+    ['delete', 'delete', '/task'],
+  ] as const)('%s supports ExO tasks', (action, method, suffix) => {
+    const httpMock = request(action, {
+      spaceId: 'space',
+      environmentId: 'env',
+      parentEntityType: 'ComponentType',
+      parentEntityId: 'component-type',
+      taskId: 'task',
+      version: 2,
+    })
+
+    expect(httpMock[method].mock.calls[0][0]).toBe(
+      `/spaces/space/environments/env/component_types/component-type/tasks${suffix}`,
+    )
+  })
+
+  test.each([
+    ['update', 'put'],
+    ['delete', 'delete'],
+  ] as const)('%s sends the version header', (action, method) => {
+    const httpMock = request(action, {
+      spaceId: 'space',
+      environmentId: 'env',
+      parentEntityType: 'Experience',
+      parentEntityId: 'experience',
+      taskId: 'task',
+      version: 2,
+    })
+
+    const config =
+      method === 'put' ? httpMock[method].mock.calls[0][2] : httpMock[method].mock.calls[0][1]
+
+    expect(config.headers['X-Contentful-Version']).toBe(2)
+  })
+})

--- a/test/unit/entities/task.test.ts
+++ b/test/unit/entities/task.test.ts
@@ -1,4 +1,6 @@
-import { describe, test } from 'vitest'
+import { describe, expect, expectTypeOf, test } from 'vitest'
+import type { Link } from '../../../lib/common-types'
+import type { TaskProps } from '../../../lib/entities/task'
 import { wrapTask, wrapTaskCollection } from '../../../lib/entities/task'
 import { cloneMock } from '../mocks/entities'
 import setupMakeRequest from '../mocks/makeRequest'
@@ -54,6 +56,27 @@ describe('Entity Task', () => {
     return failingActionTest(setup, {
       wrapperMethod: wrapTask,
       actionMethod: 'delete',
+    })
+  })
+
+  test('Task parent entity typing supports ExO entities', () => {
+    expectTypeOf<TaskProps['sys']['parentEntity']>().toEqualTypeOf<
+      Link<'Entry' | 'Experience' | 'Fragment' | 'Template' | 'ComponentType'>
+    >()
+  })
+
+  test('Task update uses parent entity params', async () => {
+    const { makeRequest, entityMock } = setup(Promise.resolve({}))
+    entityMock.sys.parentEntity.sys.linkType = 'Experience'
+    entityMock.sys.parentEntity.sys.id = 'experience-id'
+
+    const task = wrapTask(makeRequest, entityMock)
+    await task.update()
+
+    expect(makeRequest.mock.calls[0][0].params).toMatchObject({
+      parentEntityType: 'Experience',
+      parentEntityId: 'experience-id',
+      taskId: entityMock.sys.id,
     })
   })
 })


### PR DESCRIPTION
## Summary

Adds polymorphic task parent entity support to `contentful-management.js` so task APIs can target Entry and ExO parent entities: Experience, Fragment, Template, and ComponentType.

## Ticket

https://contentful.atlassian.net/browse/CFISO-3354

## Why

The ExO toolbar needs task CRUD for ExO entities, but CMA JS task typings and REST routing were entry-specific. This keeps existing `entryId` task usage working while enabling the new `{ parentEntityType, parentEntityId }` API shape.

## Risk and Rollout

Low risk. Entry task routes are preserved and now flow through the generalized URL builder. Covered with focused unit tests for legacy entry routing, ExO routes, version headers, and parent entity typings.
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Adds polymorphic task parent entity support to contentful-management.js, enabling task CRUD operations for ExO entities (Experience, Fragment, Template, ComponentType) while preserving backward compatibility with existing Entry-based task APIs. The REST endpoint URL builder is generalized to route requests based on a new TaskParentEntityType parameter.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Refactored task.ts URL builder to use getParentPlural() function mapping TaskParentEntityType to REST paths (entries, experiences, fragments, templates, component_types), replacing hardcoded entry-specific URLs</li>

<li>Added TaskParentEntityType and TaskParentEntityPath union types supporting Entry, Experience, Fragment, Template, and ComponentType; updated TaskProps.parentEntity from Link<'Entry'> to Link<TaskParentEntityType></li>

<li>Introduced backward-compatible parameter types: GetTaskParams, CreateTaskParams, and getMany params now accept either legacy GetEntryParams or new GetTaskParentEntityParams</li>

<li>Added normalizeTaskParentParams() helper to convert entryId-based params to parentEntityType/parentEntityId format, ensuring existing entry task callers continue working unchanged</li>

<li>New unit tests cover legacy entry routing, ExO entity routes, version header transmission, and parent entity type inference in both REST adapter and entity tests</li>

</ul>
</details>

</div>