### PR TITLE
feat(usage): add getAggregated and getDetailedAssetBandwidth, deprecate legacy usage methods [MOI-6817]

### DIFF
--- a/lib/adapters/REST/endpoints/usage.ts
+++ b/lib/adapters/REST/endpoints/usage.ts
@@ -1,9 +1,17 @@
 import type { AxiosInstance } from 'contentful-sdk-core'
 import type { CollectionProp, QueryParams } from '../../../common-types'
-import type { UsageProps } from '../../../entities/usage'
+import type {
+  AggregatedUsageCollectionProps,
+  AggregatedUsageMetricKey,
+  UsageProps,
+} from '../../../entities/usage'
 import type { RestEndpoint } from '../types'
 import * as raw from './raw'
 
+/**
+ * @deprecated Use {@link getAggregated} instead, calling it once per metric key and
+ * filtering by `filter[sys.dimensions.space.sys.id]` to scope to a space. Sunset: 2026-12-31.
+ */
 export const getManyForSpace: RestEndpoint<'Usage', 'getManyForSpace'> = (
   http: AxiosInstance,
   params: { organizationId: string } & QueryParams,
@@ -17,6 +25,11 @@ export const getManyForSpace: RestEndpoint<'Usage', 'getManyForSpace'> = (
   )
 }
 
+/**
+ * @deprecated Use {@link getAggregated} instead, calling it once per metric key
+ * (this endpoint accepted multiple metrics per call via `metric[in]`; {@link getAggregated}
+ * is scoped to a single `metricKey` per request). Sunset: 2026-12-31.
+ */
 export const getManyForOrganization: RestEndpoint<'Usage', 'getManyForOrganization'> = (
   http: AxiosInstance,
   params: { organizationId: string } & QueryParams,
@@ -24,6 +37,19 @@ export const getManyForOrganization: RestEndpoint<'Usage', 'getManyForOrganizati
   return raw.get<CollectionProp<UsageProps>>(
     http,
     `/organizations/${params.organizationId}/organization_periodic_usages`,
+    {
+      params: params.query,
+    },
+  )
+}
+
+export const getAggregated: RestEndpoint<'Usage', 'getAggregated'> = (
+  http: AxiosInstance,
+  params: { organizationId: string; metricKey: AggregatedUsageMetricKey } & QueryParams,
+) => {
+  return raw.get<AggregatedUsageCollectionProps>(
+    http,
+    `/organizations/${params.organizationId}/usages/${params.metricKey}`,
     {
       params: params.query,
     },

--- a/lib/adapters/REST/endpoints/usage.ts
+++ b/lib/adapters/REST/endpoints/usage.ts
@@ -3,6 +3,7 @@ import type { CollectionProp, QueryParams } from '../../../common-types'
 import type {
   AggregatedUsageCollectionProps,
   AggregatedUsageMetricKey,
+  AssetBandwidthUsageDetailedCollectionProps,
   UsageProps,
 } from '../../../entities/usage'
 import type { RestEndpoint } from '../types'
@@ -50,6 +51,19 @@ export const getAggregated: RestEndpoint<'Usage', 'getAggregated'> = (
   return raw.get<AggregatedUsageCollectionProps>(
     http,
     `/organizations/${params.organizationId}/usages/${params.metricKey}`,
+    {
+      params: params.query,
+    },
+  )
+}
+
+export const getAssetBandwidthUsageDetailed: RestEndpoint<
+  'Usage',
+  'getAssetBandwidthUsageDetailed'
+> = (http: AxiosInstance, params: { organizationId: string } & QueryParams) => {
+  return raw.get<AssetBandwidthUsageDetailedCollectionProps>(
+    http,
+    `/organizations/${params.organizationId}/usages-detailed/asset_bandwidth`,
     {
       params: params.query,
     },

--- a/lib/adapters/REST/endpoints/usage.ts
+++ b/lib/adapters/REST/endpoints/usage.ts
@@ -11,7 +11,7 @@ import * as raw from './raw'
 
 /**
  * @deprecated Use {@link getAggregated} instead, calling it once per metric key and
- * filtering by `filter[sys.dimensions.space.sys.id]` to scope to a space. Sunset: 2026-12-31.
+ * filtering by `filter[sys.dimensions.space.sys.id]` to scope to a space. Sunset: 2027-02-28.
  */
 export const getManyForSpace: RestEndpoint<'Usage', 'getManyForSpace'> = (
   http: AxiosInstance,
@@ -29,7 +29,7 @@ export const getManyForSpace: RestEndpoint<'Usage', 'getManyForSpace'> = (
 /**
  * @deprecated Use {@link getAggregated} instead, calling it once per metric key
  * (this endpoint accepted multiple metrics per call via `metric[in]`; {@link getAggregated}
- * is scoped to a single `metricKey` per request). Sunset: 2026-12-31.
+ * is scoped to a single `metricKey` per request). Sunset: 2027-02-28.
  */
 export const getManyForOrganization: RestEndpoint<'Usage', 'getManyForOrganization'> = (
   http: AxiosInstance,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -159,6 +159,7 @@ import type {
 import type {
   AggregatedUsageCollectionProps,
   AggregatedUsageMetricKey,
+  AssetBandwidthUsageDetailedCollectionProps,
   UsageProps,
 } from './entities/usage'
 import type { UserProps } from './entities/user'
@@ -1178,6 +1179,9 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Usage', 'getManyForSpace', UA>): MRReturn<'Usage', 'getManyForSpace'>
   (opts: MROpts<'Usage', 'getManyForOrganization', UA>): MRReturn<'Usage', 'getManyForOrganization'>
   (opts: MROpts<'Usage', 'getAggregated', UA>): MRReturn<'Usage', 'getAggregated'>
+  (
+    opts: MROpts<'Usage', 'getAssetBandwidthUsageDetailed', UA>,
+  ): MRReturn<'Usage', 'getAssetBandwidthUsageDetailed'>
   (opts: MROpts<'User', 'getManyForSpace', UA>): MRReturn<'User', 'getManyForSpace'>
   (opts: MROpts<'User', 'getForSpace', UA>): MRReturn<'User', 'getForSpace'>
   (opts: MROpts<'User', 'getCurrent', UA>): MRReturn<'User', 'getCurrent'>
@@ -3056,6 +3060,10 @@ export type MRActions = {
     getAggregated: {
       params: { organizationId: string; metricKey: AggregatedUsageMetricKey } & QueryParams
       return: AggregatedUsageCollectionProps
+    }
+    getAssetBandwidthUsageDetailed: {
+      params: { organizationId: string } & QueryParams
+      return: AssetBandwidthUsageDetailedCollectionProps
     }
   }
   User: {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -3042,7 +3042,7 @@ export type MRActions = {
   Usage: {
     /**
      * @deprecated Use `getAggregated` instead, calling it once per metric key and
-     * filtering by `filter[sys.dimensions.space.sys.id]` to scope to a space. Sunset: 2026-12-31.
+     * filtering by `filter[sys.dimensions.space.sys.id]` to scope to a space. Sunset: 2027-02-28.
      */
     getManyForSpace: {
       params: { organizationId: string } & QueryParams
@@ -3051,7 +3051,7 @@ export type MRActions = {
     /**
      * @deprecated Use `getAggregated` instead, calling it once per metric key
      * (this action accepted multiple metrics per call via `metric[in]`; `getAggregated`
-     * is scoped to a single `metricKey` per request). Sunset: 2026-12-31.
+     * is scoped to a single `metricKey` per request). Sunset: 2027-02-28.
      */
     getManyForOrganization: {
       params: { organizationId: string } & QueryParams

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -156,7 +156,11 @@ import type {
   CreateTeamSpaceMembershipProps,
   TeamSpaceMembershipProps,
 } from './entities/team-space-membership'
-import type { UsageProps } from './entities/usage'
+import type {
+  AggregatedUsageCollectionProps,
+  AggregatedUsageMetricKey,
+  UsageProps,
+} from './entities/usage'
 import type { UserProps } from './entities/user'
 import type {
   CreateWebhooksProps,
@@ -1173,7 +1177,7 @@ type MRInternal<UA extends boolean> = {
 
   (opts: MROpts<'Usage', 'getManyForSpace', UA>): MRReturn<'Usage', 'getManyForSpace'>
   (opts: MROpts<'Usage', 'getManyForOrganization', UA>): MRReturn<'Usage', 'getManyForOrganization'>
-
+  (opts: MROpts<'Usage', 'getAggregated', UA>): MRReturn<'Usage', 'getAggregated'>
   (opts: MROpts<'User', 'getManyForSpace', UA>): MRReturn<'User', 'getManyForSpace'>
   (opts: MROpts<'User', 'getForSpace', UA>): MRReturn<'User', 'getForSpace'>
   (opts: MROpts<'User', 'getCurrent', UA>): MRReturn<'User', 'getCurrent'>
@@ -3032,13 +3036,26 @@ export type MRActions = {
     }
   }
   Usage: {
+    /**
+     * @deprecated Use `getAggregated` instead, calling it once per metric key and
+     * filtering by `filter[sys.dimensions.space.sys.id]` to scope to a space. Sunset: 2026-12-31.
+     */
     getManyForSpace: {
       params: { organizationId: string } & QueryParams
       return: CollectionProp<UsageProps>
     }
+    /**
+     * @deprecated Use `getAggregated` instead, calling it once per metric key
+     * (this action accepted multiple metrics per call via `metric[in]`; `getAggregated`
+     * is scoped to a single `metricKey` per request). Sunset: 2026-12-31.
+     */
     getManyForOrganization: {
       params: { organizationId: string } & QueryParams
       return: CollectionProp<UsageProps>
+    }
+    getAggregated: {
+      params: { organizationId: string; metricKey: AggregatedUsageMetricKey } & QueryParams
+      return: AggregatedUsageCollectionProps
     }
   }
   User: {

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -138,7 +138,11 @@ import type {
   CreateTeamSpaceMembershipProps,
   TeamSpaceMembershipProps,
 } from './entities/team-space-membership'
-import type { UsageProps } from './entities/usage'
+import type {
+  AggregatedUsageCollectionProps,
+  AggregatedUsageMetricKey,
+  UsageProps,
+} from './entities/usage'
 import type { UserProps } from './entities/user'
 import type {
   CreateWebhooksProps,
@@ -1148,7 +1152,7 @@ type MRInternal<UA extends boolean> = {
 
   (opts: MROpts<'Usage', 'getManyForSpace', UA>): MRReturn<'Usage', 'getManyForSpace'>
   (opts: MROpts<'Usage', 'getManyForOrganization', UA>): MRReturn<'Usage', 'getManyForOrganization'>
-
+  (opts: MROpts<'Usage', 'getAggregated', UA>): MRReturn<'Usage', 'getAggregated'>
   (opts: MROpts<'User', 'getManyForSpace', UA>): MRReturn<'User', 'getManyForSpace'>
   (opts: MROpts<'User', 'getForSpace', UA>): MRReturn<'User', 'getForSpace'>
   (opts: MROpts<'User', 'getCurrent', UA>): MRReturn<'User', 'getCurrent'>
@@ -2960,13 +2964,26 @@ export type MRActions = {
     }
   }
   Usage: {
+    /**
+     * @deprecated Use `getAggregated` instead, calling it once per metric key and
+     * filtering by `filter[sys.dimensions.space.sys.id]` to scope to a space. Sunset: 2026-12-31.
+     */
     getManyForSpace: {
       params: { organizationId: string } & QueryParams
       return: CollectionProp<UsageProps>
     }
+    /**
+     * @deprecated Use `getAggregated` instead, calling it once per metric key
+     * (this action accepted multiple metrics per call via `metric[in]`; `getAggregated`
+     * is scoped to a single `metricKey` per request). Sunset: 2026-12-31.
+     */
     getManyForOrganization: {
       params: { organizationId: string } & QueryParams
       return: CollectionProp<UsageProps>
+    }
+    getAggregated: {
+      params: { organizationId: string; metricKey: AggregatedUsageMetricKey } & QueryParams
+      return: AggregatedUsageCollectionProps
     }
   }
   User: {

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -30,7 +30,7 @@ import {
 } from './entities/personal-access-token'
 import { wrapAccessToken, wrapAccessTokenCollection } from './entities/access-token'
 import { wrapOrganization, wrapOrganizationCollection } from './entities/organization'
-import { wrapUsageCollection } from './entities/usage'
+import { wrapAggregatedUsageCollection, wrapUsageCollection } from './entities/usage'
 import { wrapAppDefinition } from './entities/app-definition'
 import {
   wrapEnvironmentTemplate,
@@ -47,7 +47,7 @@ import type { Organization, OrganizationProps } from './entities/organization'
 import type { CreatePersonalAccessTokenProps } from './entities/personal-access-token'
 import type { Space, SpaceIncludeParam, SpaceProps } from './entities/space'
 import type { AppDefinition } from './entities/app-definition'
-import type { UsageQuery } from './entities/usage'
+import type { AggregatedUsageMetricKey, AggregatedUsageQuery, UsageQuery } from './entities/usage'
 import type { UserProps } from './entities/user'
 import type {
   CreateEnvironmentTemplateProps,
@@ -629,6 +629,9 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * @param organizationId - Id of an organization
      * @param query - Query parameters
      * @returns Promise of a collection of usages
+     * @deprecated Use {@link getUsageAggregated} instead, calling it once per metric key
+     * (this method accepted multiple metrics per call via `metric[in]`; {@link getUsageAggregated}
+     * is scoped to a single `metricKey` per request). Sunset: 2026-12-31.
      * @example ```javascript
      *
      * const contentful = require('contentful-management')
@@ -664,6 +667,8 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * @param organizationId - Id of an organization
      * @param query - Query parameters
      * @returns Promise of a collection of usages
+     * @deprecated Use {@link getUsageAggregated} instead, calling it once per metric key and
+     * filtering by `filter[sys.dimensions.space.sys.id]` to scope to a space. Sunset: 2026-12-31.
      * ```javascript
      * const contentful = require('contentful-management')
      *
@@ -692,6 +697,41 @@ export default function createClientApi(makeRequest: MakeRequest) {
           query,
         },
       }).then((data) => wrapUsageCollection(makeRequest, data))
+    },
+
+    /**
+     * Get aggregated usage for an organization metric.
+     *
+     * @param organizationId - Id of the organization
+     * @param metricKey - Key of the metric, e.g. `"functions_invocations"`, `"asset_bandwidth"`, `"api_call_cma"`, `"api_call_cpa"`, `"api_call_cda"`, `"api_call_graphql"`, `"ai_action_invocation"`, `"ai_action_word_count"`, `"ai_consumption_unit"`
+     * @param query - Query parameters (date range, granularity, grouping, pagination)
+     * @returns Promise of an aggregated usage collection
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getUsageAggregated('<organizationId>', 'functions_invocations', {
+     *   'date[gte]': '2025-01-01',
+     *   'date[lte]': '2025-01-31',
+     *   granularity: 'P1D',
+     * })
+     * .then(result => console.log(result.items))
+     * .catch(console.error)
+     * ```
+     */
+    getUsageAggregated: function getUsageAggregated(
+      organizationId: string,
+      metricKey: AggregatedUsageMetricKey,
+      query: AggregatedUsageQuery = {},
+    ) {
+      return makeRequest({
+        entityType: 'Usage',
+        action: 'getAggregated',
+        params: { organizationId, metricKey, query },
+      }).then((data) => wrapAggregatedUsageCollection(makeRequest, data))
     },
 
     /**

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -640,7 +640,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * @returns Promise of a collection of usages
      * @deprecated Use {@link getUsageAggregated} instead, calling it once per metric key
      * (this method accepted multiple metrics per call via `metric[in]`; {@link getUsageAggregated}
-     * is scoped to a single `metricKey` per request). Sunset: 2026-12-31.
+     * is scoped to a single `metricKey` per request). Sunset: 2027-02-28.
      * @example ```javascript
      *
      * const contentful = require('contentful-management')
@@ -677,7 +677,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      * @param query - Query parameters
      * @returns Promise of a collection of usages
      * @deprecated Use {@link getUsageAggregated} instead, calling it once per metric key and
-     * filtering by `filter[sys.dimensions.space.sys.id]` to scope to a space. Sunset: 2026-12-31.
+     * filtering by `filter[sys.dimensions.space.sys.id]` to scope to a space. Sunset: 2027-02-28.
      * ```javascript
      * const contentful = require('contentful-management')
      *

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -30,7 +30,11 @@ import {
 } from './entities/personal-access-token'
 import { wrapAccessToken, wrapAccessTokenCollection } from './entities/access-token'
 import { wrapOrganization, wrapOrganizationCollection } from './entities/organization'
-import { wrapAggregatedUsageCollection, wrapUsageCollection } from './entities/usage'
+import {
+  wrapAggregatedUsageCollection,
+  wrapAssetBandwidthUsageDetailedCollection,
+  wrapUsageCollection,
+} from './entities/usage'
 import { wrapAppDefinition } from './entities/app-definition'
 import {
   wrapEnvironmentTemplate,
@@ -47,7 +51,12 @@ import type { Organization, OrganizationProps } from './entities/organization'
 import type { CreatePersonalAccessTokenProps } from './entities/personal-access-token'
 import type { Space, SpaceIncludeParam, SpaceProps } from './entities/space'
 import type { AppDefinition } from './entities/app-definition'
-import type { AggregatedUsageMetricKey, AggregatedUsageQuery, UsageQuery } from './entities/usage'
+import type {
+  AggregatedUsageMetricKey,
+  AggregatedUsageQuery,
+  AssetBandwidthUsageDetailedQuery,
+  UsageQuery,
+} from './entities/usage'
 import type { UserProps } from './entities/user'
 import type {
   CreateEnvironmentTemplateProps,
@@ -732,6 +741,38 @@ export default function createClientApi(makeRequest: MakeRequest) {
         action: 'getAggregated',
         params: { organizationId, metricKey, query },
       }).then((data) => wrapAggregatedUsageCollection(makeRequest, data))
+    },
+
+    /**
+     * Get detailed asset-bandwidth usage for an organization.
+     *
+     * @param organizationId - Id of the organization
+     * @param query - Query parameters (date range only)
+     * @returns Promise of a detailed asset-bandwidth usage collection
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     *
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getUsageAssetBandwidthDetailed('<organizationId>', {
+     *   'date[gte]': '2025-01-01',
+     *   'date[lte]': '2025-01-31',
+     * })
+     * .then(result => console.log(result.items))
+     * .catch(console.error)
+     * ```
+     */
+    getUsageAssetBandwidthDetailed: function getUsageAssetBandwidthDetailed(
+      organizationId: string,
+      query: AssetBandwidthUsageDetailedQuery = {},
+    ) {
+      return makeRequest({
+        entityType: 'Usage',
+        action: 'getAssetBandwidthUsageDetailed',
+        params: { organizationId, query },
+      }).then((data) => wrapAssetBandwidthUsageDetailedCollection(makeRequest, data))
     },
 
     /**

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -734,7 +734,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
     getUsageAggregated: function getUsageAggregated(
       organizationId: string,
       metricKey: AggregatedUsageMetricKey,
-      query: AggregatedUsageQuery = {},
+      query: AggregatedUsageQuery,
     ) {
       return makeRequest({
         entityType: 'Usage',
@@ -766,7 +766,7 @@ export default function createClientApi(makeRequest: MakeRequest) {
      */
     getUsageAssetBandwidthDetailed: function getUsageAssetBandwidthDetailed(
       organizationId: string,
-      query: AssetBandwidthUsageDetailedQuery = {},
+      query: AssetBandwidthUsageDetailedQuery,
     ) {
       return makeRequest({
         entityType: 'Usage',

--- a/lib/entities/usage.ts
+++ b/lib/entities/usage.ts
@@ -1,6 +1,7 @@
 import { freezeSys, toPlainObject } from 'contentful-sdk-core'
 import copy from 'fast-copy'
 import type {
+  CollectionProp,
   DefaultElements,
   MakeRequest,
   MetaLinkProps,
@@ -18,6 +19,7 @@ export interface UsageQuery extends QueryOptions {
   'dateRange.endAt'?: string
 }
 
+/** @deprecated Use {@link AggregatedUsageQuery} with `usage.getAggregated()` instead. Sunset: 2026-12-31. */
 export type UsageProps = {
   /**
    * System metadata
@@ -57,6 +59,7 @@ export type UsageProps = {
   }
 }
 
+/** @deprecated Use `usage.getAggregated()` instead. Sunset: 2026-12-31. */
 export interface Usage extends UsageProps, DefaultElements<UsageProps> {}
 
 /**
@@ -64,6 +67,7 @@ export interface Usage extends UsageProps, DefaultElements<UsageProps> {}
  * @param makeRequest - function to make requests via an adapter
  * @param data - Raw data
  * @returns Normalized usage
+ * @deprecated
  */
 export function wrapUsage(_makeRequest: MakeRequest, data: UsageProps): Usage {
   const usage = toPlainObject(copy(data))
@@ -71,7 +75,84 @@ export function wrapUsage(_makeRequest: MakeRequest, data: UsageProps): Usage {
   return freezeSys(usageWithMethods)
 }
 
-/**
- * @internal
- */
+/** @internal @deprecated */
 export const wrapUsageCollection = wrapCollection(wrapUsage)
+
+// ─── New aggregated usage types ───────────────────────────────────────────────
+
+export type AggregatedUsageMetricKey =
+  | 'functions_invocations'
+  | 'asset_bandwidth'
+  | 'api_call_cma'
+  | 'api_call_cpa'
+  | 'api_call_cda'
+  | 'api_call_graphql'
+  | 'ai_action_invocation'
+  | 'ai_action_word_count'
+  | 'ai_consumption_unit'
+
+export interface AggregatedUsageQuery {
+  /** Start date (inclusive) in YYYY-MM-DD format */
+  'date[gte]'?: string
+  /** End date (inclusive) in YYYY-MM-DD format */
+  'date[lte]'?: string
+  /** Granularity in ISO-8601 duration format, e.g. "P1D" or "P1M" */
+  granularity?: string
+  /** Comma-separated dimension keys to group results by */
+  group?: string
+  /**
+   * Filter by a single dimension value, e.g. `filter[sys.dimensions.space.sys.id]=<id>`.
+   * Allowed dimension keys per metric are documented in `MetricDimensions` in the OpenAPI spec.
+   */
+  [filterKey: `filter[sys.dimensions.${string}.sys.${string}]`]: string | undefined
+  /**
+   * Filter by multiple dimension values using the `[in]` operator, e.g.
+   * `filter[sys.dimensions.space.sys.id][in]=id1,id2` (max 10 comma-separated values).
+   * Allowed dimension keys per metric are documented in `MetricDimensions` in the OpenAPI spec.
+   */
+  [filterInKey: `filter[sys.dimensions.${string}.sys.${string}][in]`]: string | undefined
+  /** Maximum number of items to return */
+  limit?: number
+  /** Number of items to skip */
+  skip?: number
+  /** Column to sort by with optional `-` prefix for descending, e.g. `"total_usage"` or `"-total_usage"` (descending).
+   *  For `api_call_*` metrics, `total_usage` sorts by the per-group sum across the requested date range. */
+  order?: string
+}
+
+type SysLink = {
+  sys: { type: 'Link'; linkType: string; id: string }
+}
+
+export type AggregatedUsageItemProps = {
+  sys: {
+    id: string
+    type: string
+    key: string
+    organization: { sys: { type: 'Link'; linkType: 'Organization'; id: string } }
+    unitOfMeasurement: string
+    dimensions: Record<string, SysLink>
+    accumulation: string
+  }
+  dateRange: { start: string; end: string }
+  granularity?: string
+  data: number[]
+}
+
+export type AggregatedUsageCollectionProps = CollectionProp<AggregatedUsageItemProps>
+
+export interface AggregatedUsage
+  extends AggregatedUsageItemProps,
+    DefaultElements<AggregatedUsageItemProps> {}
+
+/** @internal */
+export function wrapAggregatedUsage(
+  _makeRequest: MakeRequest,
+  data: AggregatedUsageItemProps,
+): AggregatedUsage {
+  const item = toPlainObject(copy(data))
+  return freezeSys(enhanceWithMethods(item, {}))
+}
+
+/** @internal */
+export const wrapAggregatedUsageCollection = wrapCollection(wrapAggregatedUsage)

--- a/lib/entities/usage.ts
+++ b/lib/entities/usage.ts
@@ -67,7 +67,7 @@ export interface Usage extends UsageProps, DefaultElements<UsageProps> {}
  * @param makeRequest - function to make requests via an adapter
  * @param data - Raw data
  * @returns Normalized usage
- * @deprecated
+ * @deprecated Use {@link wrapAggregatedUsage} / `usage.getAggregated()` instead. Sunset: 2026-12-31.
  */
 export function wrapUsage(_makeRequest: MakeRequest, data: UsageProps): Usage {
   const usage = toPlainObject(copy(data))
@@ -92,12 +92,12 @@ export type AggregatedUsageMetricKey =
   | 'ai_consumption_unit'
 
 export interface AggregatedUsageQuery {
-  /** Start date (inclusive) in YYYY-MM-DD format */
-  'date[gte]'?: string
-  /** End date (inclusive) in YYYY-MM-DD format */
-  'date[lte]'?: string
-  /** Granularity in ISO-8601 duration format, e.g. "P1D" or "P1M" */
-  granularity?: string
+  /** Start date (inclusive) in YYYY-MM-DD format. Required. */
+  'date[gte]': string
+  /** End date (inclusive) in YYYY-MM-DD format. Required. */
+  'date[lte]': string
+  /** ISO-8601 granularity. Defaults to `"P1D"` server-side when omitted. `"P1D"` is limited to a 31-day range; `"P1M"` to 12 calendar months (including the current one). */
+  granularity?: 'P1D' | 'P1M'
   /** Comma-separated dimension keys to group results by */
   group?: string
   /**
@@ -174,10 +174,10 @@ export const wrapAggregatedUsageCollection = wrapCollection(wrapAggregatedUsage)
 // ─── Detailed asset-bandwidth usage types ─────────────────────────────────────
 
 export interface AssetBandwidthUsageDetailedQuery {
-  /** Start date (inclusive) in YYYY-MM-DD format */
-  'date[gte]'?: string
-  /** End date (inclusive) in YYYY-MM-DD format */
-  'date[lte]'?: string
+  /** Start date (inclusive) in YYYY-MM-DD format. Required. */
+  'date[gte]': string
+  /** End date (inclusive) in YYYY-MM-DD format. Required. */
+  'date[lte]': string
 }
 
 export type AssetBandwidthUsageItemProps = {

--- a/lib/entities/usage.ts
+++ b/lib/entities/usage.ts
@@ -115,7 +115,9 @@ export interface AggregatedUsageQuery {
   limit?: number
   /** Number of items to skip */
   skip?: number
-  /** Column to sort by with optional `-` prefix for descending, e.g. `"total_usage"` or `"-total_usage"` (descending).
+  /** Comma-separated columns in `sys.dimensions.<name>.sys.<suffix>` form (matching the `group` and `filter` grammar),
+   *  optionally prefixed with `-` for descending, e.g. `"total_usage"` or `"-total_usage"` (descending).
+   *  The synthetic aggregate `total_usage` is a bare-token passthrough (`"total_usage"`, `"-total_usage"`).
    *  For `api_call_*` metrics, `total_usage` sorts by the per-group sum across the requested date range. */
   order?: string
 }
@@ -124,6 +126,18 @@ type SysLink = {
   sys: { type: 'Link'; linkType: string; id: string }
 }
 
+type EmbeddedDimensionEntity = {
+  sys: { type: string } & { [suffix: string]: string }
+}
+
+/**
+ * A response value under `dimensions`. Id-only families (`space`, `app`, `function`, `ai_action`, `asset`)
+ * render as classic Contentful Links. Families like `model` render as an embedded-entity block whose
+ * `sys.type` names the entity (e.g. `"Model"`) and carries the grouped suffixes alongside (`sys.id`,
+ * `sys.provider`, …). Narrow with `dim.sys.type === 'Link'` vs a specific entity type.
+ */
+export type AggregatedUsageDimension = SysLink | EmbeddedDimensionEntity
+
 export type AggregatedUsageItemProps = {
   sys: {
     id: string
@@ -131,7 +145,7 @@ export type AggregatedUsageItemProps = {
     key: string
     organization: { sys: { type: 'Link'; linkType: 'Organization'; id: string } }
     unitOfMeasurement: string
-    dimensions: Record<string, SysLink>
+    dimensions: Record<string, AggregatedUsageDimension>
     accumulation: string
   }
   dateRange: { start: string; end: string }

--- a/lib/entities/usage.ts
+++ b/lib/entities/usage.ts
@@ -7,6 +7,7 @@ import type {
   MetaLinkProps,
   MetaSysProps,
   QueryOptions,
+  SysLink,
 } from '../common-types'
 import { wrapCollection } from '../common-utils'
 import enhanceWithMethods from '../enhance-with-methods'
@@ -102,13 +103,13 @@ export interface AggregatedUsageQuery {
   group?: string
   /**
    * Filter by a single dimension value, e.g. `filter[sys.dimensions.space.sys.id]=<id>`.
-   * Allowed dimension keys per metric are documented in `MetricDimensions` in the OpenAPI spec.
+   * Allowed dimension keys per metric are documented in `MetricDimensions` in the Usage API reference docs.
    */
   [filterKey: `filter[sys.dimensions.${string}.sys.${string}]`]: string | undefined
   /**
    * Filter by multiple dimension values using the `[in]` operator, e.g.
    * `filter[sys.dimensions.space.sys.id][in]=id1,id2` (max 10 comma-separated values).
-   * Allowed dimension keys per metric are documented in `MetricDimensions` in the OpenAPI spec.
+   * Allowed dimension keys per metric are documented in `MetricDimensions` in the Usage API reference docs.
    */
   [filterInKey: `filter[sys.dimensions.${string}.sys.${string}][in]`]: string | undefined
   /** Maximum number of items to return */
@@ -122,7 +123,7 @@ export interface AggregatedUsageQuery {
   order?: string
 }
 
-type SysLink = {
+type LinkDimension = {
   sys: { type: 'Link'; linkType: string; id: string }
 }
 
@@ -136,7 +137,7 @@ type EmbeddedDimensionEntity = {
  * `sys.type` names the entity (e.g. `"Model"`) and carries the grouped suffixes alongside (`sys.id`,
  * `sys.provider`, …). Narrow with `dim.sys.type === 'Link'` vs a specific entity type.
  */
-export type AggregatedUsageDimension = SysLink | EmbeddedDimensionEntity
+export type AggregatedUsageDimension = LinkDimension | EmbeddedDimensionEntity
 
 export type AggregatedUsageItemProps = {
   sys: {

--- a/lib/entities/usage.ts
+++ b/lib/entities/usage.ts
@@ -170,3 +170,59 @@ export function wrapAggregatedUsage(
 
 /** @internal */
 export const wrapAggregatedUsageCollection = wrapCollection(wrapAggregatedUsage)
+
+// ─── Detailed asset-bandwidth usage types ─────────────────────────────────────
+
+export interface AssetBandwidthUsageDetailedQuery {
+  /** Start date (inclusive) in YYYY-MM-DD format */
+  'date[gte]'?: string
+  /** End date (inclusive) in YYYY-MM-DD format */
+  'date[lte]'?: string
+}
+
+export type AssetBandwidthUsageItemProps = {
+  sys: {
+    id: string
+    type: string
+    asset: SysLink
+    space: SysLink
+  }
+  usedBandwidth: number
+}
+
+export type AssetBandwidthUsageDetailedCollectionProps = {
+  sys: { type: 'Array' }
+  limit: number
+  items: AssetBandwidthUsageItemProps[]
+}
+
+export interface AssetBandwidthUsage
+  extends AssetBandwidthUsageItemProps,
+    DefaultElements<AssetBandwidthUsageItemProps> {}
+
+export interface AssetBandwidthUsageDetailedCollection
+  extends DefaultElements<AssetBandwidthUsageDetailedCollectionProps> {
+  sys: { type: 'Array' }
+  limit: number
+  items: AssetBandwidthUsage[]
+}
+
+/** @internal */
+export function wrapAssetBandwidthUsage(
+  _makeRequest: MakeRequest,
+  data: AssetBandwidthUsageItemProps,
+): AssetBandwidthUsage {
+  const item = toPlainObject(copy(data))
+  return freezeSys(enhanceWithMethods(item, {}))
+}
+
+/** @internal */
+export function wrapAssetBandwidthUsageDetailedCollection(
+  makeRequest: MakeRequest,
+  data: AssetBandwidthUsageDetailedCollectionProps,
+): AssetBandwidthUsageDetailedCollection {
+  const collectionData = toPlainObject(copy(data))
+  collectionData.items = collectionData.items.map((item) => wrapAssetBandwidthUsage(makeRequest, item))
+  // @ts-expect-error items is reassigned above from AssetBandwidthUsageItemProps[] to AssetBandwidthUsage[]
+  return collectionData
+}

--- a/lib/entities/usage.ts
+++ b/lib/entities/usage.ts
@@ -19,7 +19,7 @@ export interface UsageQuery extends QueryOptions {
   'dateRange.endAt'?: string
 }
 
-/** @deprecated Use {@link AggregatedUsageQuery} with `usage.getAggregated()` instead. Sunset: 2026-12-31. */
+/** @deprecated Use {@link AggregatedUsageQuery} with `usage.getAggregated()` instead. Sunset: 2027-02-28. */
 export type UsageProps = {
   /**
    * System metadata
@@ -59,7 +59,7 @@ export type UsageProps = {
   }
 }
 
-/** @deprecated Use `usage.getAggregated()` instead. Sunset: 2026-12-31. */
+/** @deprecated Use `usage.getAggregated()` instead. Sunset: 2027-02-28. */
 export interface Usage extends UsageProps, DefaultElements<UsageProps> {}
 
 /**
@@ -67,7 +67,7 @@ export interface Usage extends UsageProps, DefaultElements<UsageProps> {}
  * @param makeRequest - function to make requests via an adapter
  * @param data - Raw data
  * @returns Normalized usage
- * @deprecated Use {@link wrapAggregatedUsage} / `usage.getAggregated()` instead. Sunset: 2026-12-31.
+ * @deprecated Use {@link wrapAggregatedUsage} / `usage.getAggregated()` instead. Sunset: 2027-02-28.
  */
 export function wrapUsage(_makeRequest: MakeRequest, data: UsageProps): Usage {
   const usage = toPlainObject(copy(data))

--- a/lib/entities/usage.ts
+++ b/lib/entities/usage.ts
@@ -222,7 +222,9 @@ export function wrapAssetBandwidthUsageDetailedCollection(
   data: AssetBandwidthUsageDetailedCollectionProps,
 ): AssetBandwidthUsageDetailedCollection {
   const collectionData = toPlainObject(copy(data))
-  collectionData.items = collectionData.items.map((item) => wrapAssetBandwidthUsage(makeRequest, item))
+  collectionData.items = collectionData.items.map((item) =>
+    wrapAssetBandwidthUsage(makeRequest, item),
+  )
   // @ts-expect-error items is reassigned above from AssetBandwidthUsageItemProps[] to AssetBandwidthUsage[]
   return collectionData
 }

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -273,7 +273,15 @@ export type {
 export type { UIConfig, UIConfigProps } from './entities/ui-config'
 export type { Upload, UploadProps } from './entities/upload'
 export type { UploadCredential, UploadCredentialProps } from './entities/upload-credential'
-export type { Usage, UsageProps } from './entities/usage'
+export type {
+  Usage,
+  UsageProps,
+  AggregatedUsage,
+  AggregatedUsageItemProps,
+  AggregatedUsageCollectionProps,
+  AggregatedUsageMetricKey,
+  AggregatedUsageQuery,
+} from './entities/usage'
 export type { User, UserProps } from './entities/user'
 export type { UserUIConfig, UserUIConfigProps } from './entities/user-ui-config'
 export type {

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -281,6 +281,10 @@ export type {
   AggregatedUsageCollectionProps,
   AggregatedUsageMetricKey,
   AggregatedUsageQuery,
+  AssetBandwidthUsage,
+  AssetBandwidthUsageItemProps,
+  AssetBandwidthUsageDetailedCollectionProps,
+  AssetBandwidthUsageDetailedQuery,
 } from './entities/usage'
 export type { User, UserProps } from './entities/user'
 export type { UserUIConfig, UserUIConfigProps } from './entities/user-ui-config'

--- a/lib/plain/entities/usage.ts
+++ b/lib/plain/entities/usage.ts
@@ -1,50 +1,46 @@
 import type { CollectionProp, QueryParams } from '../../common-types'
-import type { UsageProps } from '../../entities/usage'
+import type {
+  AggregatedUsageCollectionProps,
+  AggregatedUsageMetricKey,
+  UsageProps,
+} from '../../entities/usage'
 import type { OptionalDefaults } from '../wrappers/wrap'
 
 export type UsagePlainClientAPI = {
-  /** Fetches all of an organization's usage data by space
-   *
-   * @param params organization ID and query parameters
-   * @returns a collection of an organization's usage data
-   * @throws if the request fails or the usage data is not found
-   * @example
-   * ```javascript
-   * const usage = await client.usage.getManyForSpace({
-   *   organizationId: '<organization_id>',
-   *   {
-   *        skip: 0,
-   *        limit: 10,
-   *        'metric[in]': 'cda,gql',
-   *        'dateRange.startAt': '2020-01-05',
-   *        'dateRange.endAt': '2020-01-20'
-   *    }
-   * });
-   * ```
+  /**
+   * @deprecated Use {@link getAggregated} instead, calling it once per `metricKey` and
+   * passing `'filter[sys.dimensions.space.sys.id]': spaceId` in the query to scope to a space.
+   * Note: {@link getAggregated} is scoped to a single metric key per request, whereas this method
+   * accepted multiple metrics via `metric[in]`. Sunset: 2026-12-31.
    */
   getManyForSpace(
     params: OptionalDefaults<{ organizationId: string } & QueryParams>,
   ): Promise<CollectionProp<UsageProps>>
-  /** Fetches all an organization's usage data by organization
-   *
-   * @param params organization ID and query parameters
-   * @returns a collection of an organization's usage data
-   * @throws if the request fails or the usage data is not found
-   * @example
-   * ```javascript
-   * const usage = await client.usage.getManyForOrganization({
-   *   organizationId: '<organization_id>',
-   *   {
-   *        skip: 0,
-   *        limit: 10,
-   *        'metric[in]': 'cda,gql',
-   *        'dateRange.startAt': '2020-01-05',
-   *        'dateRange.endAt': '2020-01-20'
-   *    }
-   * });
-   * ```
+  /**
+   * @deprecated Use {@link getAggregated} instead, calling it once per metric key
+   * (this method accepted multiple metrics per call via `metric[in]`; {@link getAggregated}
+   * is scoped to a single `metricKey` per request). Sunset: 2026-12-31.
    */
   getManyForOrganization(
     params: OptionalDefaults<{ organizationId: string } & QueryParams>,
   ): Promise<CollectionProp<UsageProps>>
+  /** Fetches aggregated usage for an organization metric.
+   *
+   * @param params organization ID, metric key, and query parameters
+   * @returns a collection of aggregated usage items
+   * @throws if the request fails or the metric is not found
+   * @example
+   * ```javascript
+   * const usage = await client.usage.getAggregated({
+   *   organizationId: '<organization_id>',
+   *   metricKey: 'api_call_cma',
+   *   query: { 'date[gte]': '2025-01-01', 'date[lte]': '2025-01-31', granularity: 'P1D' },
+   * });
+   * ```
+   */
+  getAggregated(
+    params: OptionalDefaults<
+      { organizationId: string; metricKey: AggregatedUsageMetricKey } & QueryParams
+    >,
+  ): Promise<AggregatedUsageCollectionProps>
 }

--- a/lib/plain/entities/usage.ts
+++ b/lib/plain/entities/usage.ts
@@ -2,6 +2,7 @@ import type { CollectionProp, QueryParams } from '../../common-types'
 import type {
   AggregatedUsageCollectionProps,
   AggregatedUsageMetricKey,
+  AssetBandwidthUsageDetailedCollectionProps,
   UsageProps,
 } from '../../entities/usage'
 import type { OptionalDefaults } from '../wrappers/wrap'
@@ -43,4 +44,21 @@ export type UsagePlainClientAPI = {
       { organizationId: string; metricKey: AggregatedUsageMetricKey } & QueryParams
     >,
   ): Promise<AggregatedUsageCollectionProps>
+  /**
+   * Fetches detailed asset-bandwidth usage for an organization.
+   *
+   * @param params organization ID and query parameters
+   * @returns a collection of detailed asset-bandwidth usage items
+   * @throws if the request fails
+   * @example
+   * ```javascript
+   * const usage = await client.usage.getAssetBandwidthUsageDetailed({
+   *   organizationId: '<organization_id>',
+   *   query: { 'date[gte]': '2025-01-01', 'date[lte]': '2025-01-31' },
+   * });
+   * ```
+   */
+  getAssetBandwidthUsageDetailed(
+    params: OptionalDefaults<{ organizationId: string } & QueryParams>,
+  ): Promise<AssetBandwidthUsageDetailedCollectionProps>
 }

--- a/lib/plain/entities/usage.ts
+++ b/lib/plain/entities/usage.ts
@@ -12,7 +12,7 @@ export type UsagePlainClientAPI = {
    * @deprecated Use {@link getAggregated} instead, calling it once per `metricKey` and
    * passing `'filter[sys.dimensions.space.sys.id]': spaceId` in the query to scope to a space.
    * Note: {@link getAggregated} is scoped to a single metric key per request, whereas this method
-   * accepted multiple metrics via `metric[in]`. Sunset: 2026-12-31.
+   * accepted multiple metrics via `metric[in]`. Sunset: 2027-02-28.
    */
   getManyForSpace(
     params: OptionalDefaults<{ organizationId: string } & QueryParams>,
@@ -20,7 +20,7 @@ export type UsagePlainClientAPI = {
   /**
    * @deprecated Use {@link getAggregated} instead, calling it once per metric key
    * (this method accepted multiple metrics per call via `metric[in]`; {@link getAggregated}
-   * is scoped to a single `metricKey` per request). Sunset: 2026-12-31.
+   * is scoped to a single `metricKey` per request). Sunset: 2027-02-28.
    */
   getManyForOrganization(
     params: OptionalDefaults<{ organizationId: string } & QueryParams>,

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -402,6 +402,7 @@ export const createPlainClient = (
     usage: {
       getManyForSpace: wrap(wrapParams, 'Usage', 'getManyForSpace'),
       getManyForOrganization: wrap(wrapParams, 'Usage', 'getManyForOrganization'),
+      getAggregated: wrap(wrapParams, 'Usage', 'getAggregated'),
     },
     release: {
       asset: {

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -411,6 +411,7 @@ export const createPlainClient = (
     usage: {
       getManyForSpace: wrap(wrapParams, 'Usage', 'getManyForSpace'),
       getManyForOrganization: wrap(wrapParams, 'Usage', 'getManyForOrganization'),
+      getAggregated: wrap(wrapParams, 'Usage', 'getAggregated'),
     },
     release: {
       asset: {

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -412,6 +412,7 @@ export const createPlainClient = (
       getManyForSpace: wrap(wrapParams, 'Usage', 'getManyForSpace'),
       getManyForOrganization: wrap(wrapParams, 'Usage', 'getManyForOrganization'),
       getAggregated: wrap(wrapParams, 'Usage', 'getAggregated'),
+      getAssetBandwidthUsageDetailed: wrap(wrapParams, 'Usage', 'getAssetBandwidthUsageDetailed'),
     },
     release: {
       asset: {

--- a/test/integration/usage-integration.test.ts
+++ b/test/integration/usage-integration.test.ts
@@ -1,0 +1,124 @@
+import { describe, test, expect, afterAll } from 'vitest'
+import {
+  defaultClient,
+  getTestOrganizationId,
+  initPlainClient,
+  timeoutToCalmRateLimiting,
+} from '../helpers'
+
+function lastMonthRange() {
+  const now = new Date()
+  const start = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+  const end = new Date(now.getFullYear(), now.getMonth(), 0)
+  const fmt = (d: Date) => d.toISOString().slice(0, 10)
+  return { gte: fmt(start), lte: fmt(end) }
+}
+
+describe('Usage API', async function () {
+  afterAll(timeoutToCalmRateLimiting)
+
+  const orgId = getTestOrganizationId()
+  const { gte, lte } = lastMonthRange()
+  describe('Contentful client (legacy)', () => {
+    describe('getUsageAggregated', () => {
+      test('returns a collection with sys.type Array', async () => {
+        const result = await defaultClient.getUsageAggregated(orgId, 'api_call_cma', {
+          'date[gte]': gte,
+          'date[lte]': lte,
+          granularity: 'P1D',
+        })
+        expect(result.sys.type).toBe('Array')
+        expect(typeof result.total).toBe('number')
+        expect(typeof result.limit).toBe('number')
+        expect(typeof result.skip).toBe('number')
+        expect(Array.isArray(result.items)).toBe(true)
+      })
+
+      test('each item has the expected shape', async () => {
+        const result = await defaultClient.getUsageAggregated(orgId, 'api_call_cma', {
+          'date[gte]': gte,
+          'date[lte]': lte,
+        })
+        for (const item of result.items) {
+          expect(item.sys.key).toBe('api_call_cma')
+          expect(item.sys.organization.sys.id).toBe(orgId)
+          expect(Array.isArray(item.data)).toBe(true)
+          expect(item.dateRange.start).toBeDefined()
+          expect(item.dateRange.end).toBeDefined()
+        }
+      })
+
+      test('respects limit and skip query params', async () => {
+        const result = await defaultClient.getUsageAggregated(orgId, 'api_call_cma', {
+          'date[gte]': gte,
+          'date[lte]': lte,
+          limit: 1,
+          skip: 0,
+        })
+        expect(result.items.length).toBeLessThanOrEqual(1)
+      })
+    })
+
+    describe('getOrganizationUsage (deprecated)', () => {
+      test('still returns a collection', async () => {
+        const result = await defaultClient.getOrganizationUsage(orgId, {
+          'metric[in]': 'cma',
+          'dateRange.startAt': '2019-10-01',
+          'dateRange.endAt': '2019-10-31',
+        })
+        expect(result.sys.type).toBe('Array')
+        expect(Array.isArray(result.items)).toBe(true)
+      })
+    })
+  })
+
+  describe('PlainClient', () => {
+    const plainClient = initPlainClient()
+
+    describe('usage.getAggregated', () => {
+      test('returns a collection with sys.type Array', async () => {
+        const result = await plainClient.usage.getAggregated({
+          organizationId: orgId,
+          metricKey: 'api_call_cma',
+          query: {
+            'date[gte]': '2026-06-01',
+            'date[lte]': '2026-06-30',
+            granularity: 'P1D',
+          },
+        })
+        expect(result.sys.type).toBe('Array')
+        expect(typeof result.total).toBe('number')
+        expect(Array.isArray(result.items)).toBe(true)
+      })
+
+      test('each item has key matching the requested metricKey', async () => {
+        const result = await plainClient.usage.getAggregated({
+          organizationId: orgId,
+          metricKey: 'api_call_cma',
+          query: {
+            'date[gte]': '2026-06-01',
+            'date[lte]': '2026-06-30',
+          },
+        })
+        for (const item of result.items) {
+          expect(item.sys.key).toBe('api_call_cma')
+        }
+      })
+    })
+
+    describe('usage.getManyForOrganization (deprecated)', () => {
+      test('still returns a collection', async () => {
+        const result = await plainClient.usage.getManyForOrganization({
+          organizationId: orgId,
+          query: {
+            'metric[in]': 'cma',
+            'dateRange.startAt': '2019-10-01',
+            'dateRange.endAt': '2019-10-31',
+          },
+        })
+        expect(result.sys.type).toBe('Array')
+        expect(Array.isArray(result.items)).toBe(true)
+      })
+    })
+  })
+})

--- a/test/integration/usage-integration.test.ts
+++ b/test/integration/usage-integration.test.ts
@@ -59,6 +59,30 @@ describe('Usage API', async function () {
       })
     })
 
+    describe('getUsageAssetBandwidthDetailed', () => {
+      test('returns a collection with sys.type Array', async () => {
+        const result = await defaultClient.getUsageAssetBandwidthDetailed(orgId, {
+          'date[gte]': gte,
+          'date[lte]': lte,
+        })
+        expect(result.sys.type).toBe('Array')
+        expect(typeof result.limit).toBe('number')
+        expect(Array.isArray(result.items)).toBe(true)
+      })
+
+      test('each item has the expected shape', async () => {
+        const result = await defaultClient.getUsageAssetBandwidthDetailed(orgId, {
+          'date[gte]': gte,
+          'date[lte]': lte,
+        })
+        for (const item of result.items) {
+          expect(item.sys.asset.sys.linkType).toBe('Asset')
+          expect(item.sys.space.sys.linkType).toBe('Space')
+          expect(typeof item.usedBandwidth).toBe('number')
+        }
+      })
+    })
+
     describe('getOrganizationUsage (deprecated)', () => {
       test('still returns a collection', async () => {
         const result = await defaultClient.getOrganizationUsage(orgId, {
@@ -102,6 +126,36 @@ describe('Usage API', async function () {
         })
         for (const item of result.items) {
           expect(item.sys.key).toBe('api_call_cma')
+        }
+      })
+    })
+
+    describe('usage.getAssetBandwidthUsageDetailed', () => {
+      test('returns a collection with sys.type Array', async () => {
+        const result = await plainClient.usage.getAssetBandwidthUsageDetailed({
+          organizationId: orgId,
+          query: {
+            'date[gte]': gte,
+            'date[lte]': lte,
+          },
+        })
+        expect(result.sys.type).toBe('Array')
+        expect(typeof result.limit).toBe('number')
+        expect(Array.isArray(result.items)).toBe(true)
+      })
+
+      test('each item has the expected shape', async () => {
+        const result = await plainClient.usage.getAssetBandwidthUsageDetailed({
+          organizationId: orgId,
+          query: {
+            'date[gte]': gte,
+            'date[lte]': lte,
+          },
+        })
+        for (const item of result.items) {
+          expect(item.sys.asset.sys.linkType).toBe('Asset')
+          expect(item.sys.space.sys.linkType).toBe('Space')
+          expect(typeof item.usedBandwidth).toBe('number')
         }
       })
     })

--- a/test/integration/usage-integration.test.ts
+++ b/test/integration/usage-integration.test.ts
@@ -59,8 +59,7 @@ describe('Usage API', async function () {
       })
     })
 
-    // Skipped: /usages-detailed/asset_bandwidth is not exposed publicly yet, causing a 404. [MOI-7207]
-    describe.skip('getUsageAssetBandwidthDetailed', () => {
+    describe('getUsageAssetBandwidthDetailed', () => {
       test('returns a collection with sys.type Array', async () => {
         const result = await defaultClient.getUsageAssetBandwidthDetailed(orgId, {
           'date[gte]': gte,
@@ -131,8 +130,7 @@ describe('Usage API', async function () {
       })
     })
 
-    // Skipped: /usages-detailed/asset_bandwidth is not exposed publicly yet, causing a 404. [MOI-7207]
-    describe.skip('usage.getAssetBandwidthUsageDetailed', () => {
+    describe('usage.getAssetBandwidthUsageDetailed', () => {
       test('returns a collection with sys.type Array', async () => {
         const result = await plainClient.usage.getAssetBandwidthUsageDetailed({
           organizationId: orgId,

--- a/test/integration/usage-integration.test.ts
+++ b/test/integration/usage-integration.test.ts
@@ -59,7 +59,8 @@ describe('Usage API', async function () {
       })
     })
 
-    describe('getUsageAssetBandwidthDetailed', () => {
+    // Skipped: /usages-detailed/asset_bandwidth is not exposed publicly yet, causing a 404. [MOI-7207]
+    describe.skip('getUsageAssetBandwidthDetailed', () => {
       test('returns a collection with sys.type Array', async () => {
         const result = await defaultClient.getUsageAssetBandwidthDetailed(orgId, {
           'date[gte]': gte,
@@ -130,7 +131,8 @@ describe('Usage API', async function () {
       })
     })
 
-    describe('usage.getAssetBandwidthUsageDetailed', () => {
+    // Skipped: /usages-detailed/asset_bandwidth is not exposed publicly yet, causing a 404. [MOI-7207]
+    describe.skip('usage.getAssetBandwidthUsageDetailed', () => {
       test('returns a collection with sys.type Array', async () => {
         const result = await plainClient.usage.getAssetBandwidthUsageDetailed({
           organizationId: orgId,

--- a/test/unit/adapters/REST/endpoints/usage.test.ts
+++ b/test/unit/adapters/REST/endpoints/usage.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect } from 'vitest'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+
+const collectionMockResponse = {
+  sys: { type: 'Array' },
+  total: 1,
+  skip: 0,
+  limit: 100,
+  items: [
+    {
+      sys: {
+        id: 'mock-metric-id',
+        type: 'FunctionInvocation',
+        key: 'api_call_cma',
+        organization: { sys: { type: 'Link', linkType: 'Organization', id: 'org-id' } },
+        unitOfMeasurement: 'Invocation',
+        dimensions: {},
+        accumulation: 'integrate',
+      },
+      dateRange: { start: '2026-06-01', end: '2026-06-30' },
+      granularity: 'P1D',
+      data: [1, 2, 3],
+    },
+  ],
+}
+
+describe('Rest Usage', { concurrent: true }, () => {
+  describe('getAggregated', () => {
+    test('fetches correct URL', async () => {
+      const { httpMock, adapterMock } = setupRestAdapter(
+        Promise.resolve({ data: collectionMockResponse }),
+      )
+
+      await adapterMock.makeRequest({
+        entityType: 'Usage',
+        action: 'getAggregated',
+        userAgent: 'mocked',
+        params: {
+          organizationId: 'org-id',
+          metricKey: 'api_call_cma',
+          query: { 'date[gte]': '2026-06-01', 'date[lte]': '2026-06-30' },
+        },
+      })
+
+      expect(httpMock.get.mock.calls[0][0]).to.eql('/organizations/org-id/usages/api_call_cma')
+    })
+
+    test('passes single-value filter as query param', async () => {
+      const { httpMock, adapterMock } = setupRestAdapter(
+        Promise.resolve({ data: collectionMockResponse }),
+      )
+
+      await adapterMock.makeRequest({
+        entityType: 'Usage',
+        action: 'getAggregated',
+        userAgent: 'mocked',
+        params: {
+          organizationId: 'org-id',
+          metricKey: 'api_call_cma',
+          query: {
+            'date[gte]': '2026-06-01',
+            'date[lte]': '2026-06-30',
+            'filter[sys.dimensions.space.sys.id]': 'space-id-1',
+          },
+        },
+      })
+
+      expect(httpMock.get.mock.calls[0][1].params).to.include({
+        'filter[sys.dimensions.space.sys.id]': 'space-id-1',
+      })
+    })
+
+    test('passes [in] multi-value filter as comma-separated string query param', async () => {
+      const { httpMock, adapterMock } = setupRestAdapter(
+        Promise.resolve({ data: collectionMockResponse }),
+      )
+
+      await adapterMock.makeRequest({
+        entityType: 'Usage',
+        action: 'getAggregated',
+        userAgent: 'mocked',
+        params: {
+          organizationId: 'org-id',
+          metricKey: 'api_call_cma',
+          query: {
+            'date[gte]': '2026-06-01',
+            'date[lte]': '2026-06-30',
+            'filter[sys.dimensions.space.sys.id][in]': 'id1,id2,id3',
+          },
+        },
+      })
+
+      expect(httpMock.get.mock.calls[0][1].params).to.include({
+        'filter[sys.dimensions.space.sys.id][in]': 'id1,id2,id3',
+      })
+    })
+
+    test('passes non-space dimension filter as query param', async () => {
+      const { httpMock, adapterMock } = setupRestAdapter(
+        Promise.resolve({ data: collectionMockResponse }),
+      )
+
+      await adapterMock.makeRequest({
+        entityType: 'Usage',
+        action: 'getAggregated',
+        userAgent: 'mocked',
+        params: {
+          organizationId: 'org-id',
+          metricKey: 'functions_invocations',
+          query: {
+            'date[gte]': '2026-06-01',
+            'date[lte]': '2026-06-30',
+            'filter[sys.dimensions.function.sys.id]': 'fn-id-1',
+          },
+        },
+      })
+
+      expect(httpMock.get.mock.calls[0][1].params).to.include({
+        'filter[sys.dimensions.function.sys.id]': 'fn-id-1',
+      })
+    })
+  })
+})

--- a/test/unit/adapters/REST/endpoints/usage.test.ts
+++ b/test/unit/adapters/REST/endpoints/usage.test.ts
@@ -120,4 +120,63 @@ describe('Rest Usage', { concurrent: true }, () => {
       })
     })
   })
+
+  describe('getAssetBandwidthUsageDetailed', () => {
+    const assetBandwidthMockResponse = {
+      sys: { type: 'Array' },
+      limit: 100,
+      items: [
+        {
+          sys: {
+            id: 'mock-asset-bandwidth-id',
+            type: 'AssetBandwidthUsage',
+            asset: { sys: { type: 'Link', linkType: 'Asset', id: 'asset-id' } },
+            space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
+          },
+          usedBandwidth: 1024,
+        },
+      ],
+    }
+
+    test('fetches correct URL', async () => {
+      const { httpMock, adapterMock } = setupRestAdapter(
+        Promise.resolve({ data: assetBandwidthMockResponse }),
+      )
+
+      await adapterMock.makeRequest({
+        entityType: 'Usage',
+        action: 'getAssetBandwidthUsageDetailed',
+        userAgent: 'mocked',
+        params: {
+          organizationId: 'org-id',
+          query: { 'date[gte]': '2026-06-01', 'date[lte]': '2026-06-30' },
+        },
+      })
+
+      expect(httpMock.get.mock.calls[0][0]).to.eql(
+        '/organizations/org-id/usages-detailed/asset_bandwidth',
+      )
+    })
+
+    test('passes date range as query params', async () => {
+      const { httpMock, adapterMock } = setupRestAdapter(
+        Promise.resolve({ data: assetBandwidthMockResponse }),
+      )
+
+      await adapterMock.makeRequest({
+        entityType: 'Usage',
+        action: 'getAssetBandwidthUsageDetailed',
+        userAgent: 'mocked',
+        params: {
+          organizationId: 'org-id',
+          query: { 'date[gte]': '2026-06-01', 'date[lte]': '2026-06-30' },
+        },
+      })
+
+      expect(httpMock.get.mock.calls[0][1].params).to.include({
+        'date[gte]': '2026-06-01',
+        'date[lte]': '2026-06-30',
+      })
+    })
+  })
 })

--- a/test/unit/entities/aggregated-usage.test.ts
+++ b/test/unit/entities/aggregated-usage.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from 'vitest'
+import { cloneMock, mockCollection } from '../mocks/entities'
+import setupMakeRequest from '../mocks/makeRequest'
+import { wrapAggregatedUsage, wrapAggregatedUsageCollection } from '../../../lib/entities/usage'
+
+function setupAggregated() {
+  const makeRequest = setupMakeRequest(Promise.resolve())
+  return { makeRequest, entityMock: cloneMock('aggregatedUsage') }
+}
+
+describe('Entity AggregatedUsage', () => {
+  test('wrapAggregatedUsage returns an object with toPlainObject', () => {
+    const { makeRequest, entityMock } = setupAggregated()
+    const wrapped = wrapAggregatedUsage(makeRequest, entityMock)
+    expect(wrapped.toPlainObject()).toEqual(entityMock)
+  })
+
+  test('wrapAggregatedUsageCollection wraps each item', () => {
+    const { makeRequest, entityMock } = setupAggregated()
+    const collection = mockCollection(entityMock)
+    const wrapped = wrapAggregatedUsageCollection(makeRequest, collection)
+    expect(wrapped.items).toHaveLength(1)
+    expect(wrapped.items[0].toPlainObject()).toEqual(entityMock)
+  })
+
+  test('wrapAggregatedUsageCollection preserves collection metadata', () => {
+    const { makeRequest, entityMock } = setupAggregated()
+    const collection = mockCollection(entityMock)
+    const wrapped = wrapAggregatedUsageCollection(makeRequest, collection)
+    expect(wrapped.total).toBe(1)
+    expect(wrapped.limit).toBe(100)
+    expect(wrapped.skip).toBe(0)
+    expect(wrapped.sys.type).toBe('Array')
+  })
+})

--- a/test/unit/entities/asset-bandwidth-usage.test.ts
+++ b/test/unit/entities/asset-bandwidth-usage.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from 'vitest'
+import { cloneMock } from '../mocks/entities'
+import setupMakeRequest from '../mocks/makeRequest'
+import {
+  wrapAssetBandwidthUsage,
+  wrapAssetBandwidthUsageDetailedCollection,
+} from '../../../lib/entities/usage'
+import type {
+  AssetBandwidthUsageDetailedCollectionProps,
+  AssetBandwidthUsageItemProps,
+} from '../../../lib/entities/usage'
+
+function setupAssetBandwidthUsage() {
+  const makeRequest = setupMakeRequest(Promise.resolve())
+  return { makeRequest, entityMock: cloneMock('assetBandwidthUsageDetailed') }
+}
+
+function mockAssetBandwidthCollection(
+  entityMock: AssetBandwidthUsageItemProps,
+): AssetBandwidthUsageDetailedCollectionProps {
+  return {
+    sys: { type: 'Array' },
+    limit: 30,
+    items: [entityMock],
+  }
+}
+
+describe('Entity AssetBandwidthUsage', () => {
+  test('wrapAssetBandwidthUsage returns an object with toPlainObject', () => {
+    const { makeRequest, entityMock } = setupAssetBandwidthUsage()
+    const wrapped = wrapAssetBandwidthUsage(makeRequest, entityMock)
+    expect(wrapped.toPlainObject()).toEqual(entityMock)
+  })
+
+  test('wrapAssetBandwidthUsageDetailedCollection wraps each item', () => {
+    const { makeRequest, entityMock } = setupAssetBandwidthUsage()
+    const collection = mockAssetBandwidthCollection(entityMock)
+    const wrapped = wrapAssetBandwidthUsageDetailedCollection(makeRequest, collection)
+    expect(wrapped.items).toHaveLength(1)
+    expect(wrapped.items[0].toPlainObject()).toEqual(entityMock)
+  })
+
+  test('wrapAssetBandwidthUsageDetailedCollection preserves collection metadata', () => {
+    const { makeRequest, entityMock } = setupAssetBandwidthUsage()
+    const collection = mockAssetBandwidthCollection(entityMock)
+    const wrapped = wrapAssetBandwidthUsageDetailedCollection(makeRequest, collection)
+    expect(wrapped.limit).toBe(30)
+    expect(wrapped.sys.type).toBe('Array')
+  })
+})

--- a/test/unit/mocks/entities.ts
+++ b/test/unit/mocks/entities.ts
@@ -64,7 +64,7 @@ import type { ReleaseProps } from '../../../lib/entities/release'
 import type { ReleaseActionProps } from '../../../lib/entities/release-action'
 import type { ApiKey, ApiKeyProps } from '../../../lib/entities/api-key'
 import type { OrganizationProps } from '../../../lib/entities/organization'
-import type { UsageProps } from '../../../lib/entities/usage'
+import type { AggregatedUsageItemProps, UsageProps } from '../../../lib/entities/usage'
 import type { ExtensionProps } from '../../../lib/entities/extension'
 import type { AppInstallationProps } from '../../../lib/entities/app-installation'
 import type { EnvironmentAliasProps } from '../../../lib/entities/environment-alias'
@@ -1106,6 +1106,21 @@ const usageMock: UsageProps = {
   usagePerDay: {},
 }
 
+const aggregatedUsageMock: AggregatedUsageItemProps = {
+  sys: {
+    id: 'mock-metric-id',
+    type: 'FunctionInvocation',
+    key: 'functions_invocations',
+    organization: { sys: { type: 'Link', linkType: 'Organization', id: 'mock-org-id' } },
+    unitOfMeasurement: 'Invocation',
+    dimensions: {},
+    accumulation: 'integrate',
+  },
+  dateRange: { start: '2025-01-01', end: '2025-01-31' },
+  granularity: 'P1D',
+  data: [10, 20, 30],
+}
+
 const extensionMock: ExtensionProps = {
   sys: Object.assign(cloneDeep(sysMock), {
     type: 'Extension',
@@ -1723,6 +1738,7 @@ const mocks = {
   upload: uploadMock,
   uploadCredential: uploadCredentialMock,
   usage: usageMock,
+  aggregatedUsage: aggregatedUsageMock,
   uiConfig: uiConfigMock,
   user: userMock,
   userUIConfig: userUIConfigMock,
@@ -2097,6 +2113,7 @@ export {
   accessTokenMock,
   environmentMock,
   usageMock,
+  aggregatedUsageMock,
   environmentAliasMock,
   environmentTemplateMock,
   environmentTemplateInstallationMock,

--- a/test/unit/mocks/entities.ts
+++ b/test/unit/mocks/entities.ts
@@ -64,7 +64,11 @@ import type { ReleaseProps } from '../../../lib/entities/release'
 import type { ReleaseActionProps } from '../../../lib/entities/release-action'
 import type { ApiKey, ApiKeyProps } from '../../../lib/entities/api-key'
 import type { OrganizationProps } from '../../../lib/entities/organization'
-import type { AggregatedUsageItemProps, UsageProps } from '../../../lib/entities/usage'
+import type {
+  AggregatedUsageItemProps,
+  AssetBandwidthUsageItemProps,
+  UsageProps,
+} from '../../../lib/entities/usage'
 import type { ExtensionProps } from '../../../lib/entities/extension'
 import type { AppInstallationProps } from '../../../lib/entities/app-installation'
 import type { EnvironmentAliasProps } from '../../../lib/entities/environment-alias'
@@ -1124,6 +1128,16 @@ const aggregatedUsageMock: AggregatedUsageItemProps = {
   data: [10, 20, 30],
 }
 
+const assetBandwidthUsageDetailedMock: AssetBandwidthUsageItemProps = {
+  sys: {
+    id: 'mock-asset-bandwidth-id',
+    type: 'AssetBandwidthUsage',
+    asset: { sys: { type: 'Link', linkType: 'Asset', id: 'mock-asset-id' } },
+    space: { sys: { type: 'Link', linkType: 'Space', id: 'mock-space-id' } },
+  },
+  usedBandwidth: 1024,
+}
+
 const extensionMock: ExtensionProps = {
   sys: Object.assign(cloneDeep(sysMock), {
     type: 'Extension',
@@ -1742,6 +1756,7 @@ const mocks = {
   uploadCredential: uploadCredentialMock,
   usage: usageMock,
   aggregatedUsage: aggregatedUsageMock,
+  assetBandwidthUsageDetailed: assetBandwidthUsageDetailedMock,
   uiConfig: uiConfigMock,
   user: userMock,
   userUIConfig: userUIConfigMock,

--- a/test/unit/mocks/entities.ts
+++ b/test/unit/mocks/entities.ts
@@ -1113,7 +1113,10 @@ const aggregatedUsageMock: AggregatedUsageItemProps = {
     key: 'functions_invocations',
     organization: { sys: { type: 'Link', linkType: 'Organization', id: 'mock-org-id' } },
     unitOfMeasurement: 'Invocation',
-    dimensions: {},
+    dimensions: {
+      space: { sys: { type: 'Link', linkType: 'Space', id: 'mock-space-id' } },
+      model: { sys: { type: 'Model', id: 'gpt-4', provider: 'openai' } },
+    },
     accumulation: 'integrate',
   },
   dateRange: { start: '2025-01-01', end: '2025-01-31' },


### PR DESCRIPTION
## Summary

Adds `usage.getAggregated` to the SDK and deprecates the legacy periodic-usage methods, per [RFC-0011](https://contentful.atlassian.net/wiki/spaces/PROD/pages/6598033459/RFC-0011+Usage+API+Public+Release).

Also adds `usage.getAssetBandwidthUsageDetailed` for the `/usages-detailed/asset_bandwidth` endpoint (MOI-7207). It was initially descoped pending public availability, but the endpoint is now public — the alpha-header gate was removed in [usage-api#1109](https://github.com/contentful/usage-api/pull/1109) (MOI-7208) and deployed to production.

## New method

### `client.getUsageAggregated` / `client.usage.getAggregated`

Fetches aggregated usage for a single metric key across an organization.

**Legacy client**

```js
const result = await client.getUsageAggregated('my-org-id', 'api_call_cma', {
  'date[gte]': '2026-06-01',
  'date[lte]': '2026-06-30',
  granularity: 'P1D',
})
```

**Plain client**

```js
const result = await client.usage.getAggregated({
  organizationId: 'my-org-id',
  metricKey: 'api_call_cma',
  query: {
    'date[gte]': '2026-06-01',
    'date[lte]': '2026-06-30',
    granularity: 'P1D',
  },
})
```

**Sample response**

```json
{
  "sys": { "type": "Array" },
  "total": 1,
  "skip": 0,
  "limit": 100,
  "items": [
    {
      "sys": {
        "type": "AggregatedUsage",
        "key": "api_call_cma",
        "organization": {
          "sys": { "type": "Link", "linkType": "Organization", "id": "my-org-id" }
        },
        "unitOfMeasurement": "requests",
        "dimensions": {},
        "accumulation": "integrate"
      },
      "dateRange": { "start": "2026-06-01", "end": "2026-06-30" },
      "granularity": "P1D",
      "data": [1200, 980, 1430]
    }
  ]
}
```

**Supported `metricKey` values**

`api_call_cma` · `api_call_cpa` · `api_call_cda` · `api_call_graphql` · `asset_bandwidth` · `functions_invocations` · `ai_action_invocation` · `ai_action_word_count` · `ai_consumption_unit`

> Not all metric keys are available for every organization — availability depends on the products enabled for the org.

### `client.getUsageAssetBandwidthDetailed` / `client.usage.getAssetBandwidthUsageDetailed`

Fetches per-asset bandwidth usage for an organization.

**Legacy client**

```js
const result = await client.getUsageAssetBandwidthDetailed('my-org-id', {
  'date[gte]': '2026-06-01',
  'date[lte]': '2026-06-30',
})
```

**Plain client**

```js
const result = await client.usage.getAssetBandwidthUsageDetailed({
  organizationId: 'my-org-id',
  query: {
    'date[gte]': '2026-06-01',
    'date[lte]': '2026-06-30',
  },
})
```

## Deprecated methods (sunset: 2027-02-28)

| Deprecated | Replacement |
|---|---|
| `client.getOrganizationUsage(orgId, query)` | `client.getUsageAggregated(orgId, metricKey, query)` |
| `client.getSpaceUsage(orgId, query)` | `client.getUsageAggregated(orgId, metricKey, { 'filter[sys.dimensions.space.sys.id]': spaceId })` |
| `client.usage.getManyForOrganization(...)` | `client.usage.getAggregated(...)` |
| `client.usage.getManyForSpace(...)` | `client.usage.getAggregated(...)` with space filter |

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes

[MOI-6817]: https://contentful.atlassian.net/browse/MOI-6817 
 

[MOI-6817]: https://contentful.atlassian.net/browse/MOI-6817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOI-6817]: https://contentful.atlassian.net/browse/MOI-6817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR refactors the type definitions in `lib/entities/usage.ts` to import the shared `SysLink` type from `common-types` for use in `AssetBandwidthUsageItemProps`, while renaming the local private type to `LinkDimension` to prevent naming conflicts. The change ensures consistency with other entity types in the SDK.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Imports `SysLink` type from `../common-types` in `usage.ts` for compatibility with `AssetBandwidthUsageItemProps` interface</li>

<li>Renames local private type `SysLink` to `LinkDimension` to avoid shadowing the newly imported type</li>

<li>Updates `AggregatedUsageDimension` discriminated union to reference `LinkDimension` instead of `SysLink`</li>

<li>Updates JSDoc comments to reference "Usage API reference docs" instead of "OpenAPI spec" for accuracy</li>

</ul>
</details>

</div>
