### PR TITLE
fix: typing on getMany spaces [HEJO-9060]

### DIFF
--- a/lib/plain/entities/space.test-d.ts
+++ b/lib/plain/entities/space.test-d.ts
@@ -62,8 +62,17 @@ describe('SpacePlainClientAPI.getMany overloads', () => {
     })
   })
 
-  it('Parameters<>[0] is optional (empty object assignable)', () => {
-    type FirstParam = Parameters<GetMany>[0]
-    expectTypeOf<Record<string, never>>().toMatchTypeOf<FirstParam>()
+  it('Parameters<>[0] is optional (undefined is assignable)', () => {
+    void ((getMany: GetMany) => {
+      const param: Parameters<GetMany>[0] = undefined
+      expectTypeOf(getMany(param)).resolves.toEqualTypeOf<OffsetReturn>()
+    })
+  })
+
+  it('rejects passing both pageNext and pagePrev in the same query', () => {
+    void ((getMany: GetMany) => {
+      // @ts-expect-error — cursor overload is XOR: pageNext and pagePrev are mutually exclusive
+      getMany({ query: { pageNext: 'a', pagePrev: 'b' } })
+    })
   })
 })

--- a/lib/plain/entities/space.test-d.ts
+++ b/lib/plain/entities/space.test-d.ts
@@ -1,0 +1,69 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type { CollectionProp, CursorPaginatedCollectionProp } from '../../common-types'
+import type { SpaceIncludes, SpaceProps } from '../../entities/space'
+import type { SpacePlainClientAPI } from './space'
+
+type GetMany = SpacePlainClientAPI['getMany']
+type OffsetReturn = CollectionProp<SpaceProps> & { includes?: SpaceIncludes }
+type CursorReturn = CursorPaginatedCollectionProp<SpaceProps> & {
+  includes?: SpaceIncludes
+}
+
+describe('SpacePlainClientAPI.getMany overloads', () => {
+  it('resolves to the offset overload when called with no arguments', () => {
+    void ((getMany: GetMany) => {
+      expectTypeOf(getMany()).resolves.toEqualTypeOf<OffsetReturn>()
+    })
+  })
+
+  it('resolves to the offset overload for an empty params object', () => {
+    void ((getMany: GetMany) => {
+      expectTypeOf(getMany({})).resolves.toEqualTypeOf<OffsetReturn>()
+    })
+  })
+
+  it('resolves to the offset overload for { query: { limit } }', () => {
+    void ((getMany: GetMany) => {
+      expectTypeOf(getMany({ query: { limit: 10 } })).resolves.toEqualTypeOf<OffsetReturn>()
+    })
+  })
+
+  it('resolves to the offset overload when organizationId and include are passed', () => {
+    void ((getMany: GetMany) => {
+      expectTypeOf(
+        getMany({ organizationId: 'org-id', include: 'sys.license' }),
+      ).resolves.toEqualTypeOf<OffsetReturn>()
+    })
+  })
+
+  it('resolves to the cursor overload when query has pageNext', () => {
+    void ((getMany: GetMany) => {
+      expectTypeOf(getMany({ query: { pageNext: 'tok' } })).resolves.toEqualTypeOf<CursorReturn>()
+    })
+  })
+
+  it('resolves to the cursor overload when query has pagePrev', () => {
+    void ((getMany: GetMany) => {
+      expectTypeOf(getMany({ query: { pagePrev: 'tok' } })).resolves.toEqualTypeOf<CursorReturn>()
+    })
+  })
+
+  it('resolves to the cursor overload when pageNext is string | undefined', () => {
+    void ((getMany: GetMany, token: string | undefined) => {
+      expectTypeOf(getMany({ query: { pageNext: token } })).resolves.toEqualTypeOf<CursorReturn>()
+    })
+  })
+
+  it('resolves to the cursor overload when query has pageNext + limit', () => {
+    void ((getMany: GetMany) => {
+      expectTypeOf(
+        getMany({ query: { pageNext: 'tok', limit: 10 } }),
+      ).resolves.toEqualTypeOf<CursorReturn>()
+    })
+  })
+
+  it('Parameters<>[0] is optional (empty object assignable)', () => {
+    type FirstParam = Parameters<GetMany>[0]
+    expectTypeOf<Record<string, never>>().toMatchTypeOf<FirstParam>()
+  })
+})

--- a/lib/plain/entities/space.ts
+++ b/lib/plain/entities/space.ts
@@ -26,6 +26,27 @@ export type SpacePlainClientAPI = {
     params: OptionalDefaults<GetSpaceParams & SpaceIncludeParam>,
   ): Promise<SpaceProps & { includes?: SpaceIncludes }>
   /**
+   * Fetches a cursor-paginated page of spaces the user has access to.
+   * Pass `pageNext` or `pagePrev` (typically `string | undefined` from a previous response) in `query`.
+   * @param params cursor pagination query parameters plus optional org filter and includes
+   * @returns a cursor-paginated collection of spaces
+   * @throws if the request fails, or the query parameters are malformed
+   * @example ```javascript
+   * const page = await client.space.getMany({
+   *   query: { pageNext: previousResponse.pages?.next, limit: 10 },
+   * });
+   * ```
+   */
+  getMany(
+    params: OptionalDefaults<
+      {
+        query: BasicCursorPaginationOptions &
+          ({ pageNext: string | undefined } | { pagePrev: string | undefined })
+        organizationId?: string
+      } & SpaceIncludeParam
+    >,
+  ): Promise<CursorPaginatedCollectionProp<SpaceProps> & { includes?: SpaceIncludes }>
+  /**
    * Fetches all the spaces that the logged in user has access to
    * @param params (optional) filter and pagination query parameters
    * @returns a collection of spaces
@@ -39,15 +60,13 @@ export type SpacePlainClientAPI = {
    * ```
    */
   getMany(
-    params: OptionalDefaults<
-      { query?: QueryParams['query']; organizationId?: string } & SpaceIncludeParam
+    params?: OptionalDefaults<
+      {
+        query?: QueryParams['query'] & { pageNext?: never; pagePrev?: never }
+        organizationId?: string
+      } & SpaceIncludeParam
     >,
   ): Promise<CollectionProp<SpaceProps> & { includes?: SpaceIncludes }>
-  getMany(
-    params: OptionalDefaults<
-      { query: BasicCursorPaginationOptions; organizationId?: string } & SpaceIncludeParam
-    >,
-  ): Promise<CursorPaginatedCollectionProp<SpaceProps> & { includes?: SpaceIncludes }>
   /**
    * Fetches all the spaces in the given organization
    * @param params the organization ID and query parameters

--- a/lib/plain/entities/space.ts
+++ b/lib/plain/entities/space.ts
@@ -41,7 +41,10 @@ export type SpacePlainClientAPI = {
     params: OptionalDefaults<
       {
         query: BasicCursorPaginationOptions &
-          ({ pageNext: string | undefined } | { pagePrev: string | undefined })
+          (
+            | { pageNext: string | undefined; pagePrev?: never }
+            | { pageNext?: never; pagePrev: string | undefined }
+          )
         organizationId?: string
       } & SpaceIncludeParam
     >,


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.
-->

https://contentful.atlassian.net/browse/HEJO-9060

## Summary

Fixes a TypeScript regression in `SpacePlainClientAPI.getMany` overloads that caused 6 `tsc` errors in downstream consumers of `contentful-management`.

## Why

The overloads introduced in `9467834ef` (HEJO-8559, cursor pagination) and refined in `12c9e30c6` (HEJO-8659, license include) discriminated cursor vs. offset pagination on **"is `query` present"** — cursor overload had `query: BasicCursorPaginationOptions` required, offset overload had `query?` optional. This broke in two ways:

1. **`Parameters<typeof space.getMany>[0]` inference lands on the last overload**, which was the cursor overload with required `query` + `organizationId`. Any react-query wrapper deriving its params via `Parameters<>` (a very common pattern) inherited a shape where `query` and `organizationId` looked required, even though they were declared optional on the offset overload.
2. **`BasicCursorPaginationOptions` inherits `[key: string]: any`** from `BasicQueryOptions`, so `{ query: { limit: 10 } }` structurally satisfied both overloads. TS could resolve either way depending on context, and the return type surfaced as the union `CollectionProp | CursorPaginatedCollectionProp` at consumer sites — breaking `.filter`, `.length`, and `SpaceProps[]` assignments.

### Reported failure

CircleCI job [1523283](https://app.circleci.com/pipelines/github/contentful/user_interface/162140/workflows/09ec87ea-59d0-47d3-8903-fee3b6d2c959/jobs/1523283) on downstream PR [contentful/user_interface#32167](https://github.com/contentful/user_interface/pull/32167) failed `tsc` with 6 errors across 5 files, all downstream of `space.getMany`:

```
src/javascripts/core/react-query/cma/space/useGetAllSpacesForUserInOrg.ts:25:41
TS2345: Argument of type '{}' is not assignable to parameter of type
'WithHeaders<{ query: BasicCursorPaginationOptions; include?: "sys.license"; organizationId: string; }>'.

src/javascripts/features/content-model-templates/core/hooks/useAllActiveSpaces.ts:6:5
TS2345: Property 'organizationId' is missing in type '{ query: { limit: number; }; }'
but required in type '{ query: BasicCursorPaginationOptions; include?: "sys.license"; organizationId: string; }'.

src/javascripts/features/content-model-templates/core/components/ContentTypeTable/ContentTypeRow.tsx:67
TS2345: Argument of type 'never[] | (CursorPaginatedCollectionProp<SpaceProps> & { includes?: SpaceIncludes; })'
is not assignable to parameter of type 'readonly never[]'.

src/javascripts/features/content-model-templates/core/components/ContentTypeTable/ContentTypeRow.tsx:68
TS2339: Property 'name' does not exist on type 'never'.

src/javascripts/features/content-model-templates/features/template-editor/EnvironmentSelector/EnvironmentSelector.tsx:150
TS2339: Property 'filter' does not exist on type 'never[] | (CursorPaginatedCollectionProp<SpaceProps> & …)'.

src/javascripts/features/content-model-templates/features/template-editor/TemplateViewer/TemplateViewer.tsx:97
TS2345: Argument of type 'never[] | (CursorPaginatedCollectionProp<SpaceProps> & …)'
is not assignable to parameter of type 'SpaceProps[]'.

Found 6 errors in 5 files.
```

## Changes

- **`lib/plain/entities/space.ts`** — rewrite the two `getMany` overloads:
  - **Cursor overload (first, strictest):** `query` must include `pageNext` or `pagePrev` (typed as `string | undefined` to accommodate React callsites where the token comes from `usePageToken()` or a previous response's `pages?.next`). Returns `CursorPaginatedCollectionProp<SpaceProps> & { includes?: SpaceIncludes }`.
  - **Offset overload (last, permissive):** all params optional; `query.pageNext?: never` and `query.pagePrev?: never` explicitly forbid the cursor shape from silently matching. Returns `CollectionProp<SpaceProps> & { includes?: SpaceIncludes }`. `Parameters<>[0]` now resolves to this shape.
  - Each overload gets its own JSDoc block so IDE hover shows the correct example for the branch the caller matched.
- **`lib/plain/entities/space.test-d.ts`** — new type-test file with 9 assertions pinning overload resolution for `{}`, no args, `{ query: { limit } }`, `{ organizationId, include }`, `{ query: { pageNext } }`, `{ query: { pagePrev } }`, `{ query: { pageNext, limit } }`, `{ query: { pageNext: string | undefined } }`, and `Parameters<>[0]` optionality.

## Why this discriminator

Runtime cursor detection at [`lib/common-utils.ts:54-61`](lib/common-utils.ts) already keys on `pageNext`/`pagePrev` presence. This PR aligns typing with the actual runtime contract instead of the fragile "is `query` present" heuristic. The exclusive-shape pattern already exists in [`lib/common-types.ts:415-428`](lib/common-types.ts) (`CursorPaginationPageNext | PagePrev | None`), so this is codebase-consistent.

## What is intentionally unchanged

- `MRActions['Space']['getMany']` return type in `lib/common-types.ts` — kept as the internal union; the plain-client cast at `lib/plain/plain-client.ts:187` remains the enforcement boundary.
- `lib/adapters/REST/endpoints/space.ts` — runtime is a single HTTP call for both branches; no change needed.
- `lib/create-contentful-api.ts` `getSpaces` — already has a well-formed discriminated overload via a `cursor: boolean` flag; independent of the plain-client fix.

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Fixes a TypeScript regression in SpacePlainClientAPI.getMany overloads that caused 6 tsc errors in downstream consumers. The fix enforces mutual exclusivity between pageNext and pagePrev pagination tokens in the cursor overload signature using XOR-pattern never-type constraints, ensuring correct return type inference for consumers using type derivation patterns like Parameters<>.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates cursor pagination overload in space.ts to enforce XOR pattern: pageNext requires pagePrev?: never, pagePrev requires pageNext?: never, preventing dual-token objects from matching and causing union type ambiguity.</li>

<li>Adds type test in space.test-d.ts asserting that passing both pageNext and pagePrev together produces a TypeScript error via @ts-expect-error.</li>

<li>Modifies Parameters<>[0] optionality test in space.test-d.ts to verify undefined is assignable and correctly resolves to the offset overload returning CollectionProp<SpaceProps>.</li>

</ul>
</details>

</div>