### PR TITLE
feat: getSpaceAddOns from Organization [HEJO-9275]

### DIFF
--- a/lib/adapters/REST/endpoints/space-add-on.ts
+++ b/lib/adapters/REST/endpoints/space-add-on.ts
@@ -1,8 +1,14 @@
 import type { RawAxiosRequestHeaders } from 'axios'
 import type { AxiosInstance } from 'contentful-sdk-core'
-import type { CollectionProp, GetSpaceParams, QueryParams } from '../../../common-types'
+import type {
+  CollectionProp,
+  GetOrganizationParams,
+  GetSpaceParams,
+  QueryParams,
+} from '../../../common-types'
 import type {
   SpaceAddOnProps,
+  SpaceAddOnOrganizationProps,
   UpdateSpaceAddOnAllocationProps,
 } from '../../../entities/space-add-on'
 import type { RestEndpoint } from '../types'
@@ -16,6 +22,19 @@ export const getMany: RestEndpoint<'SpaceAddOn', 'getMany'> = (
   return raw.get<CollectionProp<SpaceAddOnProps>>(http, `/spaces/${params.spaceId}/space_add_ons`, {
     params: normalizeSelect(params.query),
   })
+}
+
+export const getManyForOrganization: RestEndpoint<'SpaceAddOn', 'getManyForOrganization'> = (
+  http: AxiosInstance,
+  params: GetOrganizationParams & QueryParams,
+) => {
+  return raw.get<CollectionProp<SpaceAddOnOrganizationProps>>(
+    http,
+    `/organizations/${params.organizationId}/space_add_ons`,
+    {
+      params: normalizeSelect(params.query),
+    },
+  )
 }
 
 export const updateAllocations: RestEndpoint<'SpaceAddOn', 'updateAllocations'> = (

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -100,7 +100,11 @@ import type { CreateRoleProps, RoleProps } from './entities/role'
 import type { ScheduledActionProps } from './entities/scheduled-action'
 import type { SnapshotProps } from './entities/snapshot'
 import type { SpaceProps, SpaceIncludes, SpaceIncludeParam, UnarchiveProps } from './entities/space'
-import type { SpaceAddOnProps, UpdateSpaceAddOnAllocationProps } from './entities/space-add-on'
+import type {
+  SpaceAddOnProps,
+  SpaceAddOnOrganizationProps,
+  UpdateSpaceAddOnAllocationProps,
+} from './entities/space-add-on'
 import type { SpaceMemberProps } from './entities/space-member'
 import type { CreateSpaceMembershipProps, SpaceMembershipProps } from './entities/space-membership'
 import type { CreateTagProps, DeleteTagParams, TagProps, UpdateTagProps } from './entities/tag'
@@ -856,6 +860,9 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'SpaceMembership', 'delete', UA>): MRReturn<'SpaceMembership', 'delete'>
 
   (opts: MROpts<'SpaceAddOn', 'getMany', UA>): MRReturn<'SpaceAddOn', 'getMany'>
+  (
+    opts: MROpts<'SpaceAddOn', 'getManyForOrganization', UA>,
+  ): MRReturn<'SpaceAddOn', 'getManyForOrganization'>
   (opts: MROpts<'SpaceAddOn', 'updateAllocations', UA>): MRReturn<'SpaceAddOn', 'updateAllocations'>
 
   (opts: MROpts<'Tag', 'get', UA>): MRReturn<'Tag', 'get'>
@@ -2428,6 +2435,10 @@ export type MRActions = {
     getMany: {
       params: GetSpaceParams & QueryParams
       return: CollectionProp<SpaceAddOnProps>
+    }
+    getManyForOrganization: {
+      params: GetOrganizationParams & QueryParams
+      return: CollectionProp<SpaceAddOnOrganizationProps>
     }
     updateAllocations: {
       params: GetSpaceParams

--- a/lib/create-organization-api.ts
+++ b/lib/create-organization-api.ts
@@ -40,6 +40,7 @@ import { wrapAppKey, wrapAppKeyCollection } from './entities/app-key'
 import { wrapAppDetails } from './entities/app-details'
 import { wrapAppAction, wrapAppActionCollection } from './entities/app-action'
 import { wrapAvailableLicenseCollection } from './entities/available-license'
+import { wrapSpaceAddOnOrganizationCollection } from './entities/space-add-on'
 import { wrapFunction, wrapFunctionCollection } from './entities/function'
 import { wrapRoleCollection } from './entities/role'
 import { wrapSpaceCollection } from './entities/space'
@@ -503,6 +504,33 @@ export default function createOrganizationApi(makeRequest: MakeRequest) {
           query: createRequestConfig({ query }).params,
         },
       }).then((data) => wrapAvailableLicenseCollection(makeRequest, data))
+    },
+    /**
+     * Gets a collection of space add-ons across all spaces in the organization
+     * @param query - Object with search parameters
+     * @returns Promise for a collection of SpaceAddOnsOrganization
+     * @example ```javascript
+     * const contentful = require('contentful-management')
+     * const client = contentful.createClient({
+     *   accessToken: '<content_management_api_key>'
+     * })
+     *
+     * client.getOrganization('<organization_id>')
+     * .then((organization) => organization.getSpaceAddOns())
+     * .then((addOns) => console.log(addOns))
+     * .catch(console.error)
+     * ```
+     */
+    getSpaceAddOns(query: QueryOptions = {}) {
+      const raw = this.toPlainObject() as OrganizationProps
+      return makeRequest({
+        entityType: 'SpaceAddOn',
+        action: 'getManyForOrganization',
+        params: {
+          organizationId: raw.sys.id,
+          query: createRequestConfig({ query }).params,
+        },
+      }).then((data) => wrapSpaceAddOnOrganizationCollection(makeRequest, data))
     },
     /**
      * Gets an Invitation in Organization

--- a/lib/entities/space-add-on.ts
+++ b/lib/entities/space-add-on.ts
@@ -16,12 +16,25 @@ export type SpaceAddOnProps = {
   allocated: number
 }
 
+export type SpaceAddOnOrganizationProps = {
+  sys: BasicMetaSysProps & {
+    organization: SysLink
+  }
+  name: string
+  used: number
+  allocated: number
+}
+
 export type UpdateSpaceAddOnAllocationProps = {
   add_on: SpaceAddOnType
   allocation: number
 }
 
 export interface SpaceAddOn extends SpaceAddOnProps, DefaultElements<SpaceAddOnProps> {}
+
+export interface SpaceAddOnOrganization
+  extends SpaceAddOnOrganizationProps,
+    DefaultElements<SpaceAddOnOrganizationProps> {}
 
 /**
  * @internal
@@ -39,3 +52,20 @@ export function wrapSpaceAddOn(makeRequest: MakeRequest, data: SpaceAddOnProps):
  * @internal
  */
 export const wrapSpaceAddOnCollection = wrapCollection(wrapSpaceAddOn)
+
+/**
+ * @internal
+ */
+export function wrapSpaceAddOnOrganization(
+  makeRequest: MakeRequest,
+  data: SpaceAddOnOrganizationProps,
+): SpaceAddOnOrganization {
+  const orgAddOn = toPlainObject(copy(data))
+  const orgAddOnWithMethods = enhanceWithMethods(orgAddOn, {})
+  return freezeSys(orgAddOnWithMethods)
+}
+
+/**
+ * @internal
+ */
+export const wrapSpaceAddOnOrganizationCollection = wrapCollection(wrapSpaceAddOnOrganization)

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -238,7 +238,9 @@ export type { Snapshot, SnapshotProps } from './entities/snapshot'
 export type { Space, SpaceProps } from './entities/space'
 export type {
   SpaceAddOn,
+  SpaceAddOnOrganization,
   SpaceAddOnProps,
+  SpaceAddOnOrganizationProps,
   SpaceAddOnType,
   UpdateSpaceAddOnAllocationProps,
 } from './entities/space-add-on'

--- a/test/unit/create-organization-api.test.ts
+++ b/test/unit/create-organization-api.test.ts
@@ -23,7 +23,9 @@ import {
   contentSemanticsIndexMock,
   contentSemanticsIndexCollectionMock,
   availableLicenseMock,
+  spaceAddOnOrganizationMock,
 } from './mocks/entities'
+
 import {
   makeGetEntityTest,
   makeGetCollectionTest,
@@ -972,5 +974,33 @@ describe('A createOrganizationApi', () => {
     return makeEntityMethodFailingTest(setup, {
       methodToTest: 'getAvailableLicenses',
     })
+  })
+
+  test('API call getSpaceAddOns (organization)', async () => {
+    const responseData = {
+      total: 1,
+      skip: 0,
+      limit: 10,
+      items: [spaceAddOnOrganizationMock],
+    }
+    const { api, makeRequest, entitiesMock } = setup(Promise.resolve(responseData))
+    entitiesMock.spaceAddOn.wrapSpaceAddOnOrganizationCollection.mockReturnValue(responseData)
+
+    await api.getSpaceAddOns().then((r) => {
+      expect(r).toEqual(responseData)
+      expect(makeRequest.mock.calls[0][0].entityType).toBe('SpaceAddOn')
+      expect(makeRequest.mock.calls[0][0].action).toBe('getManyForOrganization')
+    })
+  })
+
+  test('API call getSpaceAddOns (organization) fails', async () => {
+    const error = cloneMock('error')
+    const { api } = setup(Promise.reject(error))
+
+    try {
+      await api.getSpaceAddOns()
+    } catch (e) {
+      expect(e).toEqual(error)
+    }
   })
 })

--- a/test/unit/mocks/entities.ts
+++ b/test/unit/mocks/entities.ts
@@ -13,7 +13,10 @@ import type {
 } from '../../../lib/common-types'
 import type { AppEventSubscriptionProps } from '../../../lib/entities/app-event-subscription'
 import type { SpaceProps } from '../../../lib/entities/space'
-import type { SpaceAddOnProps } from '../../../lib/entities/space-add-on'
+import type {
+  SpaceAddOnOrganizationProps,
+  SpaceAddOnProps,
+} from '../../../lib/entities/space-add-on'
 import type { EnvironmentProps } from '../../../lib/entities/environment'
 import type { EnvironmentTemplateProps } from '../../../lib/entities/environment-template'
 import type {
@@ -134,6 +137,17 @@ const spaceAddOnMock: SpaceAddOnProps = {
     id: 'contentTypes',
     organization: makeLink('Organization', 'mock-organization-id'),
     space: makeLink('Space', 'mock-space-id'),
+  }),
+  name: 'ContentTypes',
+  used: 2,
+  allocated: 5,
+}
+
+const spaceAddOnOrganizationMock: SpaceAddOnOrganizationProps = {
+  sys: Object.assign(cloneDeep(sysMock), {
+    type: 'SpaceAddOn',
+    id: 'contentTypes',
+    organization: makeLink('Organization', 'mock-organization-id'),
   }),
   name: 'ContentTypes',
   used: 2,
@@ -1697,6 +1711,7 @@ const mocks = {
   semanticSearch: semanticSearchMock,
   snapshot: snapShotMock,
   spaceAddOn: spaceAddOnMock,
+  spaceAddOnOrganization: spaceAddOnOrganizationMock,
   spaceMember: spaceMemberMock,
   spaceMembership: spaceMembershipMock,
   sys: sysMock,
@@ -1885,6 +1900,7 @@ function setupEntitiesMock() {
     spaceAddOn: {
       wrapSpaceAddOn: vi.fn(),
       wrapSpaceAddOnCollection: vi.fn(),
+      wrapSpaceAddOnOrganizationCollection: vi.fn(),
     },
     release: {
       wrapRelease: vi.fn(),
@@ -2037,6 +2053,7 @@ export {
   sysMock,
   spaceMock,
   spaceAddOnMock,
+  spaceAddOnOrganizationMock,
   bulkActionMock,
   bulkActionPublishMock,
   commentMock,


### PR DESCRIPTION
## Summary

Adds `getSpaceAddOns()` to the `Organization` entity, mirroring the existing method on `Space` but aggregated across all spaces in the organization via `GET /organizations/{organizationId}/space_add_ons`.

## Description

The space-level `getSpaceAddOns()` returns items with a `sys.space` link since each result belongs to a specific space. The org-level aggregation response omits that link, so a separate type is introduced rather than reusing `SpaceAddOnProps`.

**Changes:**

- **`lib/entities/space-add-on.ts`** — New `SpaceAddOnOrganizationProps` type (no `space` link in `sys`), `SpaceAddOnOrganization` interface, and `wrapSpaceAddOnOrganization` / `wrapSpaceAddOnOrganizationCollection` wrappers.
- **`lib/adapters/REST/endpoints/space-add-on.ts`** — New `getManyForOrganization` REST handler hitting `GET /organizations/{organizationId}/space_add_ons`.
- **`lib/common-types.ts`** — `getManyForOrganization` action added to the `SpaceAddOn` action map, with the corresponding `MROpts`/`MRReturn` overload.
- **`lib/create-organization-api.ts`** — `getSpaceAddOns(query?)` method added to the `Organization` API.
- **`lib/export-types.ts`** — `SpaceAddOnOrganization` and `SpaceAddOnOrganizationProps` exported publicly.
- **`test/unit/mocks/entities.ts`** — `spaceAddOnOrganizationMock` fixture and `wrapSpaceAddOnOrganizationCollection` mock added.
- **`test/unit/create-organization-api.test.ts`** — Unit tests for the happy path and failure path of the new method.

## Motivation and Context

We needed the same add-on aggregation available at the space level to also be available at the organization level, returning the sum across all spaces in the org.

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes