### PR TITLE
feat: add experience-toolbar to App Definition LocationType [AIS-314]

### DIFF
--- a/lib/entities/app-definition.ts
+++ b/lib/entities/app-definition.ts
@@ -40,6 +40,7 @@ type LocationType =
   | 'dialog'
   | 'page'
   | 'home'
+  | 'experience-toolbar'
   | InternalLocationType
 
 export interface SimpleLocation {


### PR DESCRIPTION
## Summary
- Adds `experience-toolbar` to the public App Definition `LocationType` union so App Definition locations can be typed as `{ location: 'experience-toolbar' }`.
- Aligns CMA types with the published App SDK / widget location constant used by Experience canvas toolbar apps.

## Test plan
- [x] `npm run test:types` passes
- [x] Confirm `LocationType` includes `experience-toolbar` and `agent` remains internal-only


Made with [Cursor](https://cursor.com) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR introduces 'experience-toolbar' as a public location type in the App Definition types, enabling developers to properly type App Definition locations as `{ location: 'experience-toolbar' }`. The change aligns the Contentful Management API types with the Experience canvas toolbar app location constant published in the App SDK.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds 'experience-toolbar' to the public LocationType union in app-definition.ts, allowing typed location declarations for Experience canvas toolbar apps.</li>

<li>Maintains 'agent' location in InternalLocationType, keeping it restricted to internal Contentful apps only with documentation linking to Contentful Support.</li>

</ul>
</details>

</div>