### PR TITLE
fix: re-couple integration tests to release gate [DX-1160]

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,7 +33,7 @@ jobs:
 
   release:
     if: github.event_name == 'push' && (contains(fromJSON('["refs/heads/master", "refs/heads/beta", "refs/heads/canary", "refs/heads/dev"]'), github.ref) || endsWith(github.ref, '.x'))
-    needs: [build, check, test-demo-projects]
+    needs: [build, check, test-demo-projects, test-integration]
     permissions:
       contents: write
       id-token: write

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ In addition, there may be some experimental features in the main build of this S
 ### Current experimental features
 
 - **AI Agents**: The Agent and Agent Run APIs (`getAgent`, `getAgents`, `getAgentRun`, `getAgentRuns`, `generateWithAgent`, `resumeAgentRun`) are experimental and subject to breaking changes without notice.
-- **Component Types**: The Component Type `getMany` endpoint (`componentType.getMany`) is experimental and subject to breaking changes without notice.
+- **Experiences**: The Experiences APIs (`componentType`, `template`, `fragment`, `experience`, `dataAssembly`) are experimental and subject to breaking changes without notice.
 
 ## Support Policy
 


### PR DESCRIPTION
[DX-1160](https://contentful.atlassian.net/browse/DX-1160)

## Summary
- Re-couples `test-integration` to the `release` job's `needs` list in `.github/workflows/main.yaml`, now that the CI test org license issue is resolved. This must land before `feat/exo` merges to `master`.
- Broadens the README's "Current experimental features" note from the single `componentType.getMany` callout to cover all Experiences entity APIs (`componentType`, `template`, `fragment`, `experience`, `dataAssembly`).

## Test plan
- [ ] CI passes on this branch with `test-integration` gating `release`
- [ ] Confirm integration tests pass (not skipped) given the resolved CI test org license
- [ ] Review README rendering for the updated experimental features bullet

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1160]: https://contentful.atlassian.net/browse/DX-1160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ