### PR TITLE
chore: exclude package-lock.json from Bito reviews

### DIFF
--- a/.bito.yaml
+++ b/.bito.yaml
@@ -1,0 +1,9 @@
+suggestion_mode: comprehensive
+post_description: true
+post_changelist: true
+exclude_files: 'package-lock.json'
+exclude_draft_pr: false
+secret_scanner_feedback: true
+linters_feedback: true
+repo_level_guidelines_enabled: true
+sequence_diagram_enabled: true


### PR DESCRIPTION
## Summary

- Add `.bito.yaml` with `exclude_files: 'package-lock.json'` so Bito skips the lockfile during PR review
- Aligns with sibling npm SDK repos (e.g. `contentful.js`) and the internal guidance that `.bitoignore` alone does not stop review — only `exclude_files` (or the dashboard) does

## Description

Bito is already reviewing PRs in this repo (dashboard defaults), but master had no `.bito.yaml`. Lockfile noise is a known review-time sink; excluding it is the standard speed win across Contentful npm repos.

This is intentionally scoped to the review-speed fix only (no Golden Context guidelines yet).

## Motivation and Context

Internal guidance (Slack / Glean): files in `.bitoignore` are removed from Bito's knowledge graph only. To stop Bito from reviewing them — and to get the ~40m → ~10m style speedup people have seen — they need to be listed in `.bito.yaml` `exclude_files`.

Related: #3023 (`docs: seed Golden Context [DX-1029]`) already includes this same `exclude_files` line as part of a larger docs dump, but that PR has been idle since May. Landing this focused config now unblocks the speed win; #3023 can rebase/merge guidelines on top later.

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes

## Test plan

- [ ] Confirm `.bito.yaml` parses / shows up on the branch
- [ ] On a follow-up PR that touches `package-lock.json` only (or includes a large lockfile delta), confirm Bito skips reviewing the lockfile / completes faster than comparable pre-change reviews
- [ ] Confirm normal source-only PRs still get Bito auto-review


Made with [Cursor](https://cursor.com)

[DX-1029]: https://contentful.atlassian.net/browse/DX-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ