### PR TITLE
fix: export ExO nested types from barrel []

### DIFF
--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -370,6 +370,14 @@ export type {
   ComponentTypeProps,
   CreateComponentTypeProps,
   UpsertComponentTypeProps,
+  ComponentTypeViewport,
+  ComponentTypeContentProperty,
+  ComponentTypeDesignProperty,
+  ComponentTypeSlotDefinition,
+  TreeNode,
+  ComponentNode,
+  FragmentNode,
+  SlotNode,
 } from './entities/component-type'
 export type {
   TemplateCollection,
@@ -385,6 +393,8 @@ export type {
   ReleaseExperience,
   ReleaseExperienceCollection,
   ReleaseExperienceSys,
+  ExperienceContentBindings,
+  InlineFragmentNode,
 } from './entities/experience'
 export type {
   FragmentCollection,


### PR DESCRIPTION
## Summary

- Adds `ComponentTypeViewport`, `ComponentTypeContentProperty`, `ComponentTypeDesignProperty`, `ComponentTypeSlotDefinition`, `TreeNode`, `ComponentNode`, `FragmentNode`, `SlotNode` to the `export type { ... }` block for `entities/component-type` in `export-types.ts`
- Adds `ExperienceContentBindings`, `InlineFragmentNode` to the `export type { ... }` block for `entities/experience`

## Motivation

These types are defined and exported from their entity source files but were not included in the `export-types.ts` barrel, making them unreachable from the package root under `moduleResolution: bundler` (which respects the `exports` map). Consumers needing to use these types as explicit type constraints (e.g. `satisfies z.ZodType<ComponentTypeViewport>`) currently have to work around the missing exports.

Unblocks removing structural workarounds in contentful/contentful-mcp-server#433.

## Test plan

- [x] `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Adds 10 previously private nested types (8 from component-type entity and 2 from experience entity) to the public export-types.ts barrel, making them accessible from the package root under moduleResolution: bundler.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Exports 8 nested types from entities/component-type: ComponentTypeViewport, ComponentTypeContentProperty, ComponentTypeDesignProperty, ComponentTypeSlotDefinition, TreeNode, ComponentNode, FragmentNode, and SlotNode</li>

<li>Exports 2 nested types from entities/experience: ExperienceContentBindings and InlineFragmentNode</li>

<li>Enables consumers using moduleResolution: bundler to access these types for explicit type constraints without workarounds</li>

</ul>
</details>

</div>