### PR TITLE
feat: add experiences DesignToken entity support [AIS-352]

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ In addition, there may be some experimental features in the main build of this S
 ### Current experimental features
 
 - **AI Agents**: The Agent and Agent Run APIs (`getAgent`, `getAgents`, `getAgentRun`, `getAgentRuns`, `generateWithAgent`, `resumeAgentRun`) are experimental and subject to breaking changes without notice.
-- **Experiences**: The Experiences APIs (`componentType`, `template`, `fragment`, `experience`, `dataAssembly`) are experimental and subject to breaking changes without notice.
+- **Experiences**: The Experiences APIs (`componentType`, `template`, `fragment`, `experience`, `dataAssembly`, `designToken`) are experimental and subject to breaking changes without notice.
 
 ## Support Policy
 

--- a/lib/adapters/REST/endpoints/design-token.ts
+++ b/lib/adapters/REST/endpoints/design-token.ts
@@ -1,0 +1,60 @@
+import type { RawAxiosRequestHeaders } from 'axios'
+import type { AxiosInstance } from 'contentful-sdk-core'
+import copy from 'fast-copy'
+import type { GetDesignTokenParams, GetSpaceEnvironmentParams } from '../../../common-types'
+import type {
+  DesignTokenCollection,
+  DesignTokenProps,
+  DesignTokenQueryOptions,
+  UpsertDesignTokenProps,
+} from '../../../entities/design-token'
+import type { RestEndpoint } from '../types'
+import * as raw from './raw'
+
+const getBaseUrl = (params: GetSpaceEnvironmentParams) =>
+  `/spaces/${params.spaceId}/environments/${params.environmentId}/design_tokens`
+
+export const getMany: RestEndpoint<'DesignToken', 'getMany'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams & { query: DesignTokenQueryOptions },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.get<DesignTokenCollection>(http, getBaseUrl(params), {
+    params: params.query,
+    headers,
+  })
+}
+
+export const get: RestEndpoint<'DesignToken', 'get'> = (
+  http: AxiosInstance,
+  params: GetDesignTokenParams,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.get<DesignTokenProps>(http, getBaseUrl(params) + `/${params.designTokenId}`, {
+    headers,
+  })
+}
+
+export const upsert: RestEndpoint<'DesignToken', 'upsert'> = (
+  http: AxiosInstance,
+  params: GetDesignTokenParams,
+  rawData: UpsertDesignTokenProps,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  const { sys, ...body } = copy(rawData)
+  return raw.put<DesignTokenProps>(http, getBaseUrl(params) + `/${params.designTokenId}`, body, {
+    headers: {
+      ...(sys.version !== undefined && {
+        'X-Contentful-Version': sys.version,
+      }),
+      ...headers,
+    },
+  })
+}
+
+export const del: RestEndpoint<'DesignToken', 'delete'> = (
+  http: AxiosInstance,
+  params: GetDesignTokenParams,
+) => {
+  return raw.del(http, getBaseUrl(params) + `/${params.designTokenId}`)
+}

--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -28,6 +28,7 @@ import * as Concept from './concept'
 import * as ConceptScheme from './concept-scheme'
 import * as ContentType from './content-type'
 import * as DataAssembly from './data-assembly'
+import * as DesignToken from './design-token'
 import * as EditorInterface from './editor-interface'
 import * as EligibleLicense from './eligible-license'
 import * as Entry from './entry'
@@ -115,6 +116,7 @@ export default {
   ConceptScheme,
   ContentType,
   DataAssembly,
+  DesignToken,
   EditorInterface,
   EligibleLicense,
   Entry,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -178,6 +178,12 @@ import type {
   DataAssemblyCollection,
 } from './entities/data-assembly'
 import type {
+  DesignTokenCollection,
+  DesignTokenProps,
+  DesignTokenQueryOptions,
+  UpsertDesignTokenProps,
+} from './entities/design-token'
+import type {
   CreateEnvironmentTemplateProps,
   EnvironmentTemplateProps,
 } from './entities/environment-template'
@@ -839,6 +845,11 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'DataAssembly', 'delete', UA>): MRReturn<'DataAssembly', 'delete'>
   (opts: MROpts<'DataAssembly', 'publish', UA>): MRReturn<'DataAssembly', 'publish'>
   (opts: MROpts<'DataAssembly', 'unpublish', UA>): MRReturn<'DataAssembly', 'unpublish'>
+
+  (opts: MROpts<'DesignToken', 'getMany', UA>): MRReturn<'DesignToken', 'getMany'>
+  (opts: MROpts<'DesignToken', 'get', UA>): MRReturn<'DesignToken', 'get'>
+  (opts: MROpts<'DesignToken', 'upsert', UA>): MRReturn<'DesignToken', 'upsert'>
+  (opts: MROpts<'DesignToken', 'delete', UA>): MRReturn<'DesignToken', 'delete'>
 
   (opts: MROpts<'EditorInterface', 'get', UA>): MRReturn<'EditorInterface', 'get'>
   (opts: MROpts<'EditorInterface', 'getMany', UA>): MRReturn<'EditorInterface', 'getMany'>
@@ -2020,6 +2031,25 @@ export type MRActions = {
       return: DataAssemblyProps
     }
   }
+  DesignToken: {
+    getMany: {
+      params: GetSpaceEnvironmentParams & { query: DesignTokenQueryOptions }
+      return: DesignTokenCollection
+    }
+    get: {
+      params: GetDesignTokenParams
+      return: DesignTokenProps
+    }
+    upsert: {
+      params: GetDesignTokenParams
+      payload: UpsertDesignTokenProps
+      return: DesignTokenProps
+    }
+    delete: {
+      params: GetDesignTokenParams
+      return: void
+    }
+  }
   EditorInterface: {
     get: { params: GetEditorInterfaceParams; return: EditorInterfaceProps }
     getMany: {
@@ -3199,6 +3229,8 @@ export type GetComponentTypeParams = GetSpaceEnvironmentParams & { componentType
 export type GetExperienceParams = GetSpaceEnvironmentParams & { experienceId: string }
 /** @internal */
 export type GetDataAssemblyParams = GetSpaceEnvironmentParams & { dataAssemblyId: string }
+/** @internal */
+export type GetDesignTokenParams = GetSpaceEnvironmentParams & { designTokenId: string }
 /** @internal */
 export type GetFragmentParams = GetSpaceEnvironmentParams & { fragmentId: string }
 /** @internal */

--- a/lib/entities/design-token.ts
+++ b/lib/entities/design-token.ts
@@ -1,0 +1,52 @@
+import type { Except } from 'type-fest'
+import type {
+  CursorPaginationParams,
+  ExoCursorPaginatedCollectionProp,
+  ExoMetadataProps,
+  ExoQueryFilters,
+  Link,
+  ResourceLink,
+} from '../common-types'
+import type { DTCGDesignPropertyType } from './component-type'
+
+export type DesignTokenType = DTCGDesignPropertyType
+
+// DesignToken sys properties (management API shape)
+export type DesignTokenSys = {
+  id: string
+  type: 'DesignToken'
+  version: number
+  space: Link<'Space'>
+  environment: Link<'Environment'>
+  createdAt: string
+  updatedAt: string
+  createdBy: Link<'User'> | Link<'App'>
+  updatedBy: Link<'User'> | Link<'App'>
+  designSystemSource?: ResourceLink<'Contentful:DesignSystemSource'>
+}
+
+// Main DesignToken props
+export type DesignTokenProps = {
+  sys: DesignTokenSys
+  name: string
+  type: DesignTokenType
+  metadata?: ExoMetadataProps
+}
+
+export type UpsertDesignTokenProps = Except<DesignTokenProps, 'sys'> & {
+  sys: {
+    id: string
+    type: 'DesignToken'
+    version?: number
+  }
+}
+
+// Query options for getMany - cursor-based pagination with typed filter fields
+export type DesignTokenQueryOptions = CursorPaginationParams &
+  ExoQueryFilters & {
+    type?: string
+    'type[in]'?: string
+    'type[nin]'?: string
+  }
+
+export type DesignTokenCollection = ExoCursorPaginatedCollectionProp<DesignTokenProps>

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -399,3 +399,8 @@ export type {
   CreateDataAssemblyProps,
   UpdateDataAssemblyProps,
 } from './entities/data-assembly'
+export type {
+  DesignTokenCollection,
+  DesignTokenProps,
+  UpsertDesignTokenProps,
+} from './entities/design-token'

--- a/lib/plain/entities/design-token.ts
+++ b/lib/plain/entities/design-token.ts
@@ -58,6 +58,8 @@ export type DesignTokenPlainClientAPI = {
    * @param rawData the design token data to upsert (include sys.version for updates, omit for creates)
    * @returns the upserted design token
    * @throws if the request fails
+   * @remarks Unlike ComponentType/Fragment, DesignToken has no separate publish step — every
+   * upsert auto-publishes server-side, which bumps `sys.version` by 2 (not 1) per call.
    * @internal - Experimental endpoint, subject to breaking changes without notice
    * @example
    * ```javascript

--- a/lib/plain/entities/design-token.ts
+++ b/lib/plain/entities/design-token.ts
@@ -1,0 +1,96 @@
+import type {
+  GetSpaceEnvironmentParams,
+  GetDesignTokenParams,
+  ExoCursorPaginatedCollectionProp,
+} from '../../common-types'
+import type {
+  DesignTokenQueryOptions,
+  DesignTokenProps,
+  UpsertDesignTokenProps,
+} from '../../entities/design-token'
+import type { OptionalDefaults } from '../wrappers/wrap'
+
+export type DesignTokenPlainClientAPI = {
+  /**
+   * Fetches all design tokens for a space and environment
+   * @param params the space and environment IDs and query parameters
+   * @param params.query.limit the maximum number of design tokens to return
+   * @param params.query.pageNext cursor token for the next page
+   * @param params.query.pagePrev cursor token for the previous page
+   * @returns a collection of design tokens
+   * @throws if the request fails, or the space or environment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const designTokens = await client.designToken.getMany({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   query: {
+   *     limit: 10,
+   *   },
+   * });
+   * ```
+   */
+  getMany(
+    params: OptionalDefaults<GetSpaceEnvironmentParams & { query: DesignTokenQueryOptions }>,
+  ): Promise<ExoCursorPaginatedCollectionProp<DesignTokenProps>>
+
+  /**
+   * Fetches a single design token by ID
+   * @param params the space, environment, and design token IDs
+   * @returns the design token
+   * @throws if the request fails, or the space, environment, or design token is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const designToken = await client.designToken.get({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   designTokenId: '<design_token_id>',
+   * });
+   * ```
+   */
+  get(params: OptionalDefaults<GetDesignTokenParams>): Promise<DesignTokenProps>
+
+  /**
+   * Upserts a design token (creates or updates via PUT)
+   * @param params the space, environment, and design token IDs
+   * @param rawData the design token data to upsert (include sys.version for updates, omit for creates)
+   * @returns the upserted design token
+   * @throws if the request fails
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const current = await client.designToken.get({ designTokenId: '<design_token_id>' });
+   * const updated = await client.designToken.upsert({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   designTokenId: '<design_token_id>',
+   * }, {
+   *   sys: { id: current.sys.id, type: 'DesignToken', version: current.sys.version },
+   *   name: 'Updated Design Token',
+   *   type: 'DTCG.Color',
+   * });
+   * ```
+   */
+  upsert(
+    params: OptionalDefaults<GetDesignTokenParams>,
+    rawData: UpsertDesignTokenProps,
+  ): Promise<DesignTokenProps>
+
+  /**
+   * Deletes a single design token
+   * @param params the space, environment, and design token IDs
+   * @throws if the request fails, or the design token is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * await client.designToken.delete({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   designTokenId: '<design_token_id>',
+   * });
+   * ```
+   */
+  delete(params: OptionalDefaults<GetDesignTokenParams>): Promise<void>
+}

--- a/lib/plain/plain-client-types.ts
+++ b/lib/plain/plain-client-types.ts
@@ -154,6 +154,7 @@ import type { SemanticSettingsPlainClientAPI } from './entities/semantic-setting
 import type { ContentSemanticsIndexPlainClientAPI } from './entities/content-semantics-index'
 import type { ComponentTypePlainClientAPI } from './entities/component-type'
 import type { DataAssemblyPlainClientAPI } from './entities/data-assembly'
+import type { DesignTokenPlainClientAPI } from './entities/design-token'
 import type { ExperiencePlainClientAPI } from './entities/experience'
 
 export type PlainClientAPI = {
@@ -289,6 +290,7 @@ export type PlainClientAPI = {
   comment: CommentPlainClientAPI
   componentType: ComponentTypePlainClientAPI
   dataAssembly: DataAssemblyPlainClientAPI
+  designToken: DesignTokenPlainClientAPI
   concept: ConceptPlainClientAPI
   conceptScheme: ConceptSchemePlainClientAPI
   contentType: {

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -275,6 +275,12 @@ export const createPlainClient = (
       publish: wrap(wrapParams, 'DataAssembly', 'publish'),
       unpublish: wrap(wrapParams, 'DataAssembly', 'unpublish'),
     },
+    designToken: {
+      getMany: wrap(wrapParams, 'DesignToken', 'getMany'),
+      get: wrap(wrapParams, 'DesignToken', 'get'),
+      upsert: wrap(wrapParams, 'DesignToken', 'upsert'),
+      delete: wrap(wrapParams, 'DesignToken', 'delete'),
+    },
     user: {
       getManyForSpace: wrap(wrapParams, 'User', 'getManyForSpace'),
       getForSpace: wrap(wrapParams, 'User', 'getForSpace'),

--- a/test/integration/design-token-integration.test.ts
+++ b/test/integration/design-token-integration.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import { initPlainClient, timeoutToCalmRateLimiting, generateRandomId } from '../helpers'
+import { TestDefaults } from '../defaults'
+import { testName, sweepStaleExoEntities } from './utils/exo.utils'
+
+describe('DesignToken Integration', { sequential: true }, () => {
+  const client = initPlainClient({
+    spaceId: TestDefaults.spaceId,
+    environmentId: TestDefaults.environmentId,
+  })
+
+  const createdIds: string[] = []
+  let designTokenId: string
+
+  beforeAll(async () => {
+    await sweepStaleExoEntities(client)
+
+    designTokenId = generateRandomId('token')
+    const created = await client.designToken.upsert(
+      { designTokenId },
+      {
+        sys: { id: designTokenId, type: 'DesignToken' },
+        name: testName('Token'),
+        type: 'DTCG.Color',
+      },
+    )
+    designTokenId = created.sys.id
+    createdIds.push(designTokenId)
+  })
+
+  afterAll(async () => {
+    for (const id of createdIds) {
+      try {
+        await client.designToken.delete({ designTokenId: id })
+      } catch {
+        // entity already deleted or not found
+      }
+    }
+
+    await timeoutToCalmRateLimiting()
+  })
+
+  it('has correct sys fields after creation', async () => {
+    const token = await client.designToken.get({ designTokenId })
+
+    expect(token.sys.id).toBeDefined()
+    expect(token.sys.type).toBe('DesignToken')
+    expect(token.sys.version).toBeGreaterThanOrEqual(1)
+    expect(token.sys.createdAt).toBeDefined()
+    expect(token.sys.updatedAt).toBeDefined()
+    expect(token.sys.createdBy).toBeDefined()
+    expect(token.name).toBe(testName('Token'))
+    expect(token.type).toBe('DTCG.Color')
+  })
+
+  it('gets a design token by ID', async () => {
+    const fetched = await client.designToken.get({ designTokenId })
+
+    expect(fetched.sys.id).toBe(designTokenId)
+    expect(fetched.sys.type).toBe('DesignToken')
+    expect(fetched.type).toBe('DTCG.Color')
+  })
+
+  it('upserts (updates) a design token', async () => {
+    const current = await client.designToken.get({ designTokenId })
+
+    const updated = await client.designToken.upsert(
+      { designTokenId },
+      {
+        sys: { id: current.sys.id, type: 'DesignToken', version: current.sys.version },
+        name: testName('Token Updated'),
+        type: current.type,
+      },
+    )
+
+    expect(updated.name).toBe(testName('Token Updated'))
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+  })
+
+  it('lists design tokens with cursor pagination', async () => {
+    const collection = await client.designToken.getMany({ query: { limit: 10 } })
+
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
+    expect(collection.pages).toBeDefined()
+
+    const found = collection.items.find((item) => item.sys.id === designTokenId)
+    expect(found).toBeDefined()
+  })
+
+  it('deletes a design token', async () => {
+    await client.designToken.delete({ designTokenId })
+
+    await expect(client.designToken.get({ designTokenId })).rejects.toThrow()
+
+    const idx = createdIds.indexOf(designTokenId)
+    if (idx !== -1) createdIds.splice(idx, 1)
+  })
+})

--- a/test/integration/design-token-integration.test.ts
+++ b/test/integration/design-token-integration.test.ts
@@ -45,7 +45,9 @@ describe('DesignToken Integration', { sequential: true }, () => {
 
     expect(token.sys.id).toBeDefined()
     expect(token.sys.type).toBe('DesignToken')
-    expect(token.sys.version).toBeGreaterThanOrEqual(1)
+    // DesignToken auto-publishes on every upsert (set + publish in one transaction upstream),
+    // so a fresh create lands at version 2, not version 1 like ComponentType/Fragment.
+    expect(token.sys.version).toBe(2)
     expect(token.sys.createdAt).toBeDefined()
     expect(token.sys.updatedAt).toBeDefined()
     expect(token.sys.createdBy).toBeDefined()
@@ -74,7 +76,8 @@ describe('DesignToken Integration', { sequential: true }, () => {
     )
 
     expect(updated.name).toBe(testName('Token Updated'))
-    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+    // Each upsert bumps version by 2 (set + auto-publish), not 1 as with ComponentType/Fragment.
+    expect(updated.sys.version).toBe(current.sys.version + 2)
   })
 
   it('lists design tokens with cursor pagination', async () => {

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -168,8 +168,30 @@ export async function sweepStaleExoEntities(
     }
   }
 
+  const sweepDesignTokens = async () => {
+    try {
+      const { items } = await client.designToken.getMany({ query: { limit: 100 } })
+      for (const item of items) {
+        if (item.name.startsWith(TEST_PREFIX) && new Date(item.sys.createdAt) < cutoff) {
+          try {
+            await client.designToken.delete({ designTokenId: item.sys.id })
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    } catch {
+      // ignore if listing fails
+    }
+  }
+
   // Sweep dependents first, then parents
-  await Promise.all([sweepExperiences(), sweepFragments(), sweepDataAssemblies()])
+  await Promise.all([
+    sweepExperiences(),
+    sweepFragments(),
+    sweepDataAssemblies(),
+    sweepDesignTokens(),
+  ])
   await sweepTemplates()
   await sweepComponentTypes()
 }

--- a/test/unit/adapters/REST/endpoints/design-token.test.ts
+++ b/test/unit/adapters/REST/endpoints/design-token.test.ts
@@ -1,0 +1,226 @@
+import { describe, test, expect } from 'vitest'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+
+describe('Rest DesignToken', { concurrent: true }, () => {
+  test('getMany calls correct URL', async () => {
+    const mockResponse = {
+      sys: { type: 'Array' },
+      limit: 100,
+      items: [],
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'DesignToken',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          query: {},
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/design_tokens',
+        )
+        expect(httpMock.get.mock.calls[0][1].params).to.eql({})
+      })
+  })
+
+  test('getMany passes pagination query parameters', async () => {
+    const mockResponse = {
+      sys: { type: 'Array' },
+      limit: 20,
+      items: [],
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'DesignToken',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          query: {
+            limit: 20,
+            pageNext: 'next-page-token',
+          },
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/design_tokens',
+        )
+        expect(httpMock.get.mock.calls[0][1].params).to.eql({
+          limit: 20,
+          pageNext: 'next-page-token',
+        })
+      })
+  })
+
+  test('getMany passes filter query parameters', async () => {
+    const mockResponse = {
+      sys: { type: 'Array' },
+      limit: 100,
+      items: [],
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'DesignToken',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          query: {
+            'sys.id[in]': 'id1,id2,id3',
+            'type[in]': 'DTCG.Color,DTCG.Dimension',
+            'metadata.tags.sys.id[in]': 'tag1,tag2',
+          },
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/design_tokens',
+        )
+        expect(httpMock.get.mock.calls[0][1].params).to.eql({
+          'sys.id[in]': 'id1,id2,id3',
+          'type[in]': 'DTCG.Color,DTCG.Dimension',
+          'metadata.tags.sys.id[in]': 'tag1,tag2',
+        })
+      })
+  })
+
+  test('get calls correct URL', async () => {
+    const mockResponse = {
+      sys: { id: 'token123', type: 'DesignToken' },
+      name: 'Test Token',
+      type: 'DTCG.Color',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'DesignToken',
+        action: 'get',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          designTokenId: 'token123',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/design_tokens/token123',
+        )
+      })
+  })
+
+  test('upsert calls correct URL with version header from sys', async () => {
+    const mockResponse = {
+      sys: { id: 'token123', type: 'DesignToken', version: 2 },
+      name: 'Updated Token',
+      type: 'DTCG.Color',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'DesignToken',
+        action: 'upsert',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          designTokenId: 'token123',
+        },
+        payload: {
+          sys: { id: 'token123', type: 'DesignToken', version: 1 },
+          name: 'Updated Token',
+          type: 'DTCG.Color',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/design_tokens/token123',
+        )
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
+        const body = httpMock.put.mock.calls[0][1]
+        expect(body.sys).to.be.undefined
+      })
+  })
+
+  test('upsert omits version header when version is not provided', async () => {
+    const mockResponse = {
+      sys: { id: 'newtoken123', type: 'DesignToken', version: 1 },
+      name: 'New Token via Upsert',
+      type: 'DTCG.Color',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'DesignToken',
+        action: 'upsert',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          designTokenId: 'newtoken123',
+        },
+        payload: {
+          sys: { id: 'newtoken123', type: 'DesignToken' },
+          name: 'New Token via Upsert',
+          type: 'DTCG.Color',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/design_tokens/newtoken123',
+        )
+        expect(httpMock.put.mock.calls[0][2].headers).to.not.have.property('X-Contentful-Version')
+        const body = httpMock.put.mock.calls[0][1]
+        expect(body.sys).to.be.undefined
+      })
+  })
+
+  test('delete calls correct URL', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: '' }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'DesignToken',
+        action: 'delete',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          designTokenId: 'token123',
+        },
+      })
+      .then(() => {
+        expect(httpMock.delete.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/design_tokens/token123',
+        )
+      })
+  })
+})


### PR DESCRIPTION
[AIS-352](https://contentful.atlassian.net/browse/AIS-352)

## Summary
- Adds `getMany`, `get`, `upsert`, and `delete` methods for the ExO `DesignToken` entity to `contentful-management`, mirroring the existing `ComponentType`/`Fragment` pattern (entity types -> REST endpoint -> common-types wiring -> plain-client wrapper -> public exports).
- No `create`, `publish`, or `unpublish` methods. Unlike `ComponentType`/`Fragment`, `DesignToken` has no separate draft/published state exposed to API consumers -- the upstream repository (`assemblies`) auto-publishes on every `upsert` and auto-unpublishes as part of `delete`, all within the same server-side transaction. There is no `POST` create endpoint either; `upsert` (PUT) covers both create and update.
- **Auto-publish quirk**: because every `upsert` does `set` + `publish` in one transaction, `sys.version` jumps by **2 per upsert call**, not 1 as with `ComponentType`/`Fragment`. A fresh create lands at version 2, not version 1. Confirmed live against staging and documented in the `upsert` JSDoc; integration test assertions check the exact delta rather than a loose `>` comparison, so a future change to this behavior would fail loudly.
- Adds unit tests for the new REST endpoint and an integration test suite (create/read/list/update/delete), plus a `sweepDesignTokens` cleanup helper in the shared ExO integration test utils.

## Test plan
- [x] `tsc --noEmit` passes with no type errors
- [x] New unit test file passes (7/7 tests)
- [x] Full unit suite passes with no regressions (892/892 tests)
- [x] ESLint and Prettier clean on all touched files
- [x] Verified end-to-end against a live staging space via a local test harness (getMany/get/upsert/delete, 17/17 tests passed, including version-conflict handling, exact version-delta behavior, and type filtering)

Generated with Claude Code

[AIS-352]: https://contentful.atlassian.net/browse/AIS-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds DesignToken entity support to the contentful-management.js SDK, exposing getMany, get, upsert, and delete methods for managing design tokens in a space/environment. The implementation follows the established ExO entity pattern (ComponentType/Fragment) with full type system integration, wiring through the REST endpoint layer, common types, plain client, and public exports. Unlike other ExO entities, DesignToken has no separate publish/unpublish operations — every upsert auto-publishes server-side in one transaction.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds lib/adapters/REST/endpoints/design-token.ts implementing getMany, get, upsert, and del methods against the /spaces/{spaceId}/environments/{environmentId}/design_tokens endpoint, with X-Contentful-Version header support on upsert.</li>

<li>Adds lib/entities/design-token.ts with TypeScript types including DesignTokenProps, DesignTokenSys (with optional designSystemSource link), UpsertDesignTokenProps, and DesignTokenQueryOptions supporting cursor pagination and type filtering.</li>

<li>Adds lib/plain/entities/design-token.ts exposing DesignTokenPlainClientAPI with JSDoc documenting the auto-publish quirk — each upsert bumps sys.version by 2 (set + publish in one upstream transaction), unlike ComponentType/Fragment which increment by 1.</li>

<li>Wires DesignToken into lib/common-types.ts MRActions (getMany/get/upsert/delete) and GetDesignTokenParams, with public exports via lib/export-types.ts.</li>

<li>Adds comprehensive test coverage: 7 unit tests for REST endpoint behavior and an integration test suite covering create/read/update/delete lifecycle with exact version-delta assertions validated against live staging.</li>

</ul>
</details>

</div>