### PR TITLE
feat(experience): align experiences API with renamed assemblies contract; add experienceFragment endpoint

### DIFF
--- a/lib/adapters/REST/endpoints/component.ts
+++ b/lib/adapters/REST/endpoints/component.ts
@@ -1,0 +1,97 @@
+import type { RawAxiosRequestHeaders } from 'axios'
+import type { AxiosInstance } from 'contentful-sdk-core'
+import copy from 'fast-copy'
+import type { GetComponentParams, GetSpaceEnvironmentParams } from '../../../common-types'
+import type {
+  ComponentCollection,
+  ComponentProps,
+  ComponentQueryOptions,
+  CreateComponentProps,
+  UpsertComponentProps,
+} from '../../../entities/component'
+import type { RestEndpoint } from '../types'
+import * as raw from './raw'
+
+const getBaseUrl = (params: GetSpaceEnvironmentParams) =>
+  `/spaces/${params.spaceId}/environments/${params.environmentId}/components`
+
+export const getMany: RestEndpoint<'Component', 'getMany'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams & { query: ComponentQueryOptions },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.get<ComponentCollection>(http, getBaseUrl(params), {
+    params: params.query,
+    headers,
+  })
+}
+
+export const get: RestEndpoint<'Component', 'get'> = (
+  http: AxiosInstance,
+  params: GetComponentParams,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.get<ComponentProps>(http, getBaseUrl(params) + `/${params.componentId}`, {
+    headers,
+  })
+}
+
+export const create: RestEndpoint<'Component', 'create'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams,
+  rawData: CreateComponentProps,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  const data = copy(rawData)
+  return raw.post<ComponentProps>(http, getBaseUrl(params), data, { headers })
+}
+
+export const upsert: RestEndpoint<'Component', 'upsert'> = (
+  http: AxiosInstance,
+  params: GetComponentParams,
+  rawData: UpsertComponentProps,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  const { sys, ...body } = copy(rawData)
+  return raw.put<ComponentProps>(http, getBaseUrl(params) + `/${params.componentId}`, body, {
+    headers: {
+      ...(sys.version !== undefined && {
+        'X-Contentful-Version': sys.version,
+      }),
+      ...headers,
+    },
+  })
+}
+
+export const del: RestEndpoint<'Component', 'delete'> = (
+  http: AxiosInstance,
+  params: GetComponentParams,
+) => {
+  return raw.del(http, getBaseUrl(params) + `/${params.componentId}`)
+}
+
+export const publish: RestEndpoint<'Component', 'publish'> = (
+  http: AxiosInstance,
+  params: GetComponentParams & { version: number },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.put(http, `${getBaseUrl(params)}/${params.componentId}/published`, null, {
+    headers: {
+      'X-Contentful-Version': params.version,
+      ...headers,
+    },
+  })
+}
+
+export const unpublish: RestEndpoint<'Component', 'unpublish'> = (
+  http: AxiosInstance,
+  params: GetComponentParams & { version: number },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.del(http, `${getBaseUrl(params)}/${params.componentId}/published`, {
+    headers: {
+      'X-Contentful-Version': params.version,
+      ...headers,
+    },
+  })
+}

--- a/lib/adapters/REST/endpoints/experience-fragment.ts
+++ b/lib/adapters/REST/endpoints/experience-fragment.ts
@@ -1,0 +1,140 @@
+import type { RawAxiosRequestHeaders } from 'axios'
+import type { AxiosInstance } from 'contentful-sdk-core'
+import copy from 'fast-copy'
+import type { GetExperienceFragmentParams, GetSpaceEnvironmentParams } from '../../../common-types'
+import type {
+  CreateExperienceFragmentProps,
+  ExperienceFragmentProps,
+  ExperienceFragmentQueryOptions,
+  UpsertExperienceFragmentProps,
+  ExperienceFragmentCollection,
+} from '../../../entities/experience-fragment'
+import type { RestEndpoint } from '../types'
+import * as raw from './raw'
+
+const getBaseUrl = (params: GetSpaceEnvironmentParams) =>
+  `/spaces/${params.spaceId}/environments/${params.environmentId}/experienceFragments`
+
+// Opts into the renamed ("new ExO entity types") ExperienceFragment shape: sys.component
+// instead of sys.componentType, and ExperienceFragment slot nodes. The renamed family is
+// discriminated server-side on this header.
+const ExperienceFragmentAlphaHeaders = {
+  'x-contentful-enable-alpha-feature': 'new-exo-entity-types',
+}
+
+export const getMany: RestEndpoint<'ExperienceFragment', 'getMany'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams & { query: ExperienceFragmentQueryOptions },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.get<ExperienceFragmentCollection>(http, getBaseUrl(params), {
+    params: params.query,
+    headers: {
+      ...ExperienceFragmentAlphaHeaders,
+      ...headers,
+    },
+  })
+}
+
+export const get: RestEndpoint<'ExperienceFragment', 'get'> = (
+  http: AxiosInstance,
+  params: GetExperienceFragmentParams,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.get<ExperienceFragmentProps>(
+    http,
+    getBaseUrl(params) + `/${params.experienceFragmentId}`,
+    {
+      headers: {
+        ...ExperienceFragmentAlphaHeaders,
+        ...headers,
+      },
+    },
+  )
+}
+
+export const create: RestEndpoint<'ExperienceFragment', 'create'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams,
+  rawData: CreateExperienceFragmentProps,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  const data = copy(rawData)
+  return raw.post<ExperienceFragmentProps>(http, getBaseUrl(params), data, {
+    headers: {
+      ...ExperienceFragmentAlphaHeaders,
+      ...headers,
+    },
+  })
+}
+
+export const upsert: RestEndpoint<'ExperienceFragment', 'upsert'> = (
+  http: AxiosInstance,
+  params: GetExperienceFragmentParams,
+  rawData: UpsertExperienceFragmentProps,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  const { sys, ...body } = copy(rawData)
+  return raw.put<ExperienceFragmentProps>(
+    http,
+    getBaseUrl(params) + `/${params.experienceFragmentId}`,
+    body,
+    {
+      headers: {
+        ...ExperienceFragmentAlphaHeaders,
+        ...(sys?.version !== undefined && {
+          'X-Contentful-Version': sys.version,
+        }),
+        ...headers,
+      },
+    },
+  )
+}
+
+export const del: RestEndpoint<'ExperienceFragment', 'delete'> = (
+  http: AxiosInstance,
+  params: GetExperienceFragmentParams,
+) => {
+  return raw.del(http, getBaseUrl(params) + `/${params.experienceFragmentId}`, {
+    headers: {
+      ...ExperienceFragmentAlphaHeaders,
+    },
+  })
+}
+
+export const publish: RestEndpoint<'ExperienceFragment', 'publish'> = (
+  http: AxiosInstance,
+  params: GetExperienceFragmentParams & { version: number },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.put<ExperienceFragmentProps>(
+    http,
+    getBaseUrl(params) + `/${params.experienceFragmentId}/published`,
+    null,
+    {
+      headers: {
+        ...ExperienceFragmentAlphaHeaders,
+        'X-Contentful-Version': params.version,
+        ...headers,
+      },
+    },
+  )
+}
+
+export const unpublish: RestEndpoint<'ExperienceFragment', 'unpublish'> = (
+  http: AxiosInstance,
+  params: GetExperienceFragmentParams & { version: number },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.del<ExperienceFragmentProps>(
+    http,
+    getBaseUrl(params) + `/${params.experienceFragmentId}/published`,
+    {
+      headers: {
+        ...ExperienceFragmentAlphaHeaders,
+        'X-Contentful-Version': params.version,
+        ...headers,
+      },
+    },
+  )
+}

--- a/lib/adapters/REST/endpoints/experience-fragment.ts
+++ b/lib/adapters/REST/endpoints/experience-fragment.ts
@@ -13,14 +13,7 @@ import type { RestEndpoint } from '../types'
 import * as raw from './raw'
 
 const getBaseUrl = (params: GetSpaceEnvironmentParams) =>
-  `/spaces/${params.spaceId}/environments/${params.environmentId}/experienceFragments`
-
-// Opts into the renamed ("new ExO entity types") ExperienceFragment shape: sys.component
-// instead of sys.componentType, and ExperienceFragment slot nodes. The renamed family is
-// discriminated server-side on this header.
-const ExperienceFragmentAlphaHeaders = {
-  'x-contentful-enable-alpha-feature': 'new-exo-entity-types',
-}
+  `/spaces/${params.spaceId}/environments/${params.environmentId}/experience_fragments`
 
 export const getMany: RestEndpoint<'ExperienceFragment', 'getMany'> = (
   http: AxiosInstance,
@@ -29,10 +22,7 @@ export const getMany: RestEndpoint<'ExperienceFragment', 'getMany'> = (
 ) => {
   return raw.get<ExperienceFragmentCollection>(http, getBaseUrl(params), {
     params: params.query,
-    headers: {
-      ...ExperienceFragmentAlphaHeaders,
-      ...headers,
-    },
+    headers,
   })
 }
 
@@ -44,12 +34,7 @@ export const get: RestEndpoint<'ExperienceFragment', 'get'> = (
   return raw.get<ExperienceFragmentProps>(
     http,
     getBaseUrl(params) + `/${params.experienceFragmentId}`,
-    {
-      headers: {
-        ...ExperienceFragmentAlphaHeaders,
-        ...headers,
-      },
-    },
+    { headers },
   )
 }
 
@@ -60,12 +45,7 @@ export const create: RestEndpoint<'ExperienceFragment', 'create'> = (
   headers?: RawAxiosRequestHeaders,
 ) => {
   const data = copy(rawData)
-  return raw.post<ExperienceFragmentProps>(http, getBaseUrl(params), data, {
-    headers: {
-      ...ExperienceFragmentAlphaHeaders,
-      ...headers,
-    },
-  })
+  return raw.post<ExperienceFragmentProps>(http, getBaseUrl(params), data, { headers })
 }
 
 export const upsert: RestEndpoint<'ExperienceFragment', 'upsert'> = (
@@ -81,7 +61,6 @@ export const upsert: RestEndpoint<'ExperienceFragment', 'upsert'> = (
     body,
     {
       headers: {
-        ...ExperienceFragmentAlphaHeaders,
         ...(sys?.version !== undefined && {
           'X-Contentful-Version': sys.version,
         }),
@@ -95,11 +74,7 @@ export const del: RestEndpoint<'ExperienceFragment', 'delete'> = (
   http: AxiosInstance,
   params: GetExperienceFragmentParams,
 ) => {
-  return raw.del(http, getBaseUrl(params) + `/${params.experienceFragmentId}`, {
-    headers: {
-      ...ExperienceFragmentAlphaHeaders,
-    },
-  })
+  return raw.del(http, getBaseUrl(params) + `/${params.experienceFragmentId}`)
 }
 
 export const publish: RestEndpoint<'ExperienceFragment', 'publish'> = (
@@ -113,7 +88,6 @@ export const publish: RestEndpoint<'ExperienceFragment', 'publish'> = (
     null,
     {
       headers: {
-        ...ExperienceFragmentAlphaHeaders,
         'X-Contentful-Version': params.version,
         ...headers,
       },
@@ -131,7 +105,6 @@ export const unpublish: RestEndpoint<'ExperienceFragment', 'unpublish'> = (
     getBaseUrl(params) + `/${params.experienceFragmentId}/published`,
     {
       headers: {
-        ...ExperienceFragmentAlphaHeaders,
         'X-Contentful-Version': params.version,
         ...headers,
       },

--- a/lib/adapters/REST/endpoints/experience-template.ts
+++ b/lib/adapters/REST/endpoints/experience-template.ts
@@ -1,0 +1,113 @@
+import type { RawAxiosRequestHeaders } from 'axios'
+import type { AxiosInstance } from 'contentful-sdk-core'
+import copy from 'fast-copy'
+import type { GetExperienceTemplateParams, GetSpaceEnvironmentParams } from '../../../common-types'
+import type {
+  CreateExperienceTemplateProps,
+  ExperienceTemplateProps,
+  ExperienceTemplateQueryOptions,
+  UpsertExperienceTemplateProps,
+  ExperienceTemplateCollection,
+} from '../../../entities/experience-template'
+import type { RestEndpoint } from '../types'
+import * as raw from './raw'
+
+const getBaseUrl = (params: GetSpaceEnvironmentParams) =>
+  `/spaces/${params.spaceId}/environments/${params.environmentId}/experience_templates`
+
+export const getMany: RestEndpoint<'ExperienceTemplate', 'getMany'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams & { query: ExperienceTemplateQueryOptions },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.get<ExperienceTemplateCollection>(http, getBaseUrl(params), {
+    params: params.query,
+    headers,
+  })
+}
+
+export const get: RestEndpoint<'ExperienceTemplate', 'get'> = (
+  http: AxiosInstance,
+  params: GetExperienceTemplateParams,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.get<ExperienceTemplateProps>(
+    http,
+    getBaseUrl(params) + `/${params.experienceTemplateId}`,
+    { headers },
+  )
+}
+
+export const create: RestEndpoint<'ExperienceTemplate', 'create'> = (
+  http: AxiosInstance,
+  params: GetSpaceEnvironmentParams,
+  rawData: CreateExperienceTemplateProps,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  const data = copy(rawData)
+  return raw.post<ExperienceTemplateProps>(http, getBaseUrl(params), data, { headers })
+}
+
+export const upsert: RestEndpoint<'ExperienceTemplate', 'upsert'> = (
+  http: AxiosInstance,
+  params: GetExperienceTemplateParams,
+  rawData: UpsertExperienceTemplateProps,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  const { sys, ...body } = copy(rawData)
+  return raw.put<ExperienceTemplateProps>(
+    http,
+    getBaseUrl(params) + `/${params.experienceTemplateId}`,
+    body,
+    {
+      headers: {
+        ...(sys.version !== undefined && {
+          'X-Contentful-Version': sys.version,
+        }),
+        ...headers,
+      },
+    },
+  )
+}
+
+export const del: RestEndpoint<'ExperienceTemplate', 'delete'> = (
+  http: AxiosInstance,
+  params: GetExperienceTemplateParams,
+) => {
+  return raw.del(http, getBaseUrl(params) + `/${params.experienceTemplateId}`)
+}
+
+export const publish: RestEndpoint<'ExperienceTemplate', 'publish'> = (
+  http: AxiosInstance,
+  params: GetExperienceTemplateParams & { version: number },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.put<ExperienceTemplateProps>(
+    http,
+    getBaseUrl(params) + `/${params.experienceTemplateId}/published`,
+    null,
+    {
+      headers: {
+        'X-Contentful-Version': params.version,
+        ...headers,
+      },
+    },
+  )
+}
+
+export const unpublish: RestEndpoint<'ExperienceTemplate', 'unpublish'> = (
+  http: AxiosInstance,
+  params: GetExperienceTemplateParams & { version: number },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.del<ExperienceTemplateProps>(
+    http,
+    getBaseUrl(params) + `/${params.experienceTemplateId}/published`,
+    {
+      headers: {
+        'X-Contentful-Version': params.version,
+        ...headers,
+      },
+    },
+  )
+}

--- a/lib/adapters/REST/endpoints/experience.ts
+++ b/lib/adapters/REST/endpoints/experience.ts
@@ -16,6 +16,13 @@ import * as raw from './raw'
 const getBaseUrl = (params: GetSpaceEnvironmentParams) =>
   `/spaces/${params.spaceId}/environments/${params.environmentId}/experiences`
 
+// Opts into the renamed ("new ExO entity types") Experience shape: sys.experienceTemplate
+// instead of sys.template, and ExperienceFragment slot nodes. The renamed family shares the
+// `/experiences` URLs with the legacy routes and is discriminated server-side on this header.
+const ExperienceAlphaHeaders = {
+  'x-contentful-enable-alpha-feature': 'new-exo-entity-types',
+}
+
 export const getMany: RestEndpoint<'Experience', 'getMany'> = (
   http: AxiosInstance,
   params: GetSpaceEnvironmentParams & { query: ExperienceQueryOptions },
@@ -23,7 +30,10 @@ export const getMany: RestEndpoint<'Experience', 'getMany'> = (
 ) => {
   return raw.get<ExperienceCollection>(http, getBaseUrl(params), {
     params: params.query,
-    headers,
+    headers: {
+      ...ExperienceAlphaHeaders,
+      ...headers,
+    },
   })
 }
 
@@ -33,7 +43,10 @@ export const get: RestEndpoint<'Experience', 'get'> = (
   headers?: RawAxiosRequestHeaders,
 ) => {
   return raw.get<ExperienceProps>(http, getBaseUrl(params) + `/${params.experienceId}`, {
-    headers,
+    headers: {
+      ...ExperienceAlphaHeaders,
+      ...headers,
+    },
   })
 }
 
@@ -44,7 +57,12 @@ export const create: RestEndpoint<'Experience', 'create'> = (
   headers?: RawAxiosRequestHeaders,
 ) => {
   const data = copy(rawData)
-  return raw.post<ExperienceProps>(http, getBaseUrl(params), data, { headers })
+  return raw.post<ExperienceProps>(http, getBaseUrl(params), data, {
+    headers: {
+      ...ExperienceAlphaHeaders,
+      ...headers,
+    },
+  })
 }
 
 export const upsert: RestEndpoint<'Experience', 'upsert'> = (
@@ -56,6 +74,7 @@ export const upsert: RestEndpoint<'Experience', 'upsert'> = (
   const { sys, ...body } = copy(rawData)
   return raw.put<ExperienceProps>(http, getBaseUrl(params) + `/${params.experienceId}`, body, {
     headers: {
+      ...ExperienceAlphaHeaders,
       ...(sys.version !== undefined && {
         'X-Contentful-Version': sys.version,
       }),
@@ -68,7 +87,11 @@ export const del: RestEndpoint<'Experience', 'delete'> = (
   http: AxiosInstance,
   params: GetExperienceParams,
 ) => {
-  return raw.del(http, getBaseUrl(params) + `/${params.experienceId}`)
+  return raw.del(http, getBaseUrl(params) + `/${params.experienceId}`, {
+    headers: {
+      ...ExperienceAlphaHeaders,
+    },
+  })
 }
 
 export const publish: RestEndpoint<'Experience', 'publish'> = (
@@ -79,6 +102,7 @@ export const publish: RestEndpoint<'Experience', 'publish'> = (
 ) => {
   return raw.put(http, getBaseUrl(params) + `/${params.experienceId}/published`, payload ?? null, {
     headers: {
+      ...ExperienceAlphaHeaders,
       'X-Contentful-Version': params.version,
       ...headers,
     },
@@ -92,6 +116,7 @@ export const unpublish: RestEndpoint<'Experience', 'unpublish'> = (
 ) => {
   return raw.del(http, getBaseUrl(params) + `/${params.experienceId}/published`, {
     headers: {
+      ...ExperienceAlphaHeaders,
       'X-Contentful-Version': params.version,
       ...headers,
     },

--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -23,6 +23,7 @@ import * as AssetKey from './asset-key'
 import * as AvailableLicense from './available-license'
 import * as BulkAction from './bulk-action'
 import * as Comment from './comment'
+import * as Component from './component'
 import * as ComponentType from './component-type'
 import * as Concept from './concept'
 import * as ConceptScheme from './concept-scheme'
@@ -112,6 +113,7 @@ export default {
   AvailableLicense,
   BulkAction,
   Comment,
+  Component,
   ComponentType,
   Concept,
   ConceptScheme,

--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -76,6 +76,7 @@ import * as Template from './template'
 import * as UIConfig from './ui-config'
 import * as Upload from './upload'
 import * as Experience from './experience'
+import * as ExperienceFragment from './experience-fragment'
 import * as UploadCredential from './upload-credentials'
 import * as Usage from './usage'
 import * as User from './user'
@@ -165,6 +166,7 @@ export default {
   Upload,
   UploadCredential,
   Experience,
+  ExperienceFragment,
   Usage,
   User,
   UserUIConfig,

--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -77,6 +77,7 @@ import * as UIConfig from './ui-config'
 import * as Upload from './upload'
 import * as Experience from './experience'
 import * as ExperienceFragment from './experience-fragment'
+import * as ExperienceTemplate from './experience-template'
 import * as UploadCredential from './upload-credentials'
 import * as Usage from './usage'
 import * as User from './user'
@@ -167,6 +168,7 @@ export default {
   UploadCredential,
   Experience,
   ExperienceFragment,
+  ExperienceTemplate,
   Usage,
   User,
   UserUIConfig,

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -68,6 +68,12 @@ import type {
   UpsertComponentTypeProps,
 } from './entities/component-type'
 import type {
+  ComponentProps,
+  ComponentQueryOptions,
+  CreateComponentProps,
+  UpsertComponentProps,
+} from './entities/component'
+import type {
   CreateFragmentProps,
   FragmentProps,
   FragmentQueryOptions,
@@ -808,6 +814,13 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'ComponentType', 'delete', UA>): MRReturn<'ComponentType', 'delete'>
   (opts: MROpts<'ComponentType', 'publish', UA>): MRReturn<'ComponentType', 'publish'>
   (opts: MROpts<'ComponentType', 'unpublish', UA>): MRReturn<'ComponentType', 'unpublish'>
+  (opts: MROpts<'Component', 'getMany', UA>): MRReturn<'Component', 'getMany'>
+  (opts: MROpts<'Component', 'get', UA>): MRReturn<'Component', 'get'>
+  (opts: MROpts<'Component', 'create', UA>): MRReturn<'Component', 'create'>
+  (opts: MROpts<'Component', 'upsert', UA>): MRReturn<'Component', 'upsert'>
+  (opts: MROpts<'Component', 'delete', UA>): MRReturn<'Component', 'delete'>
+  (opts: MROpts<'Component', 'publish', UA>): MRReturn<'Component', 'publish'>
+  (opts: MROpts<'Component', 'unpublish', UA>): MRReturn<'Component', 'unpublish'>
 
   (opts: MROpts<'Concept', 'get', UA>): MRReturn<'Concept', 'get'>
   (opts: MROpts<'Concept', 'getMany', UA>): MRReturn<'Concept', 'getMany'>
@@ -1889,6 +1902,38 @@ export type MRActions = {
     unpublish: {
       params: GetComponentTypeParams & { version: number }
       return: ComponentTypeProps
+    }
+  }
+  Component: {
+    getMany: {
+      params: GetSpaceEnvironmentParams & { query: ComponentQueryOptions }
+      return: ExoCursorPaginatedCollectionProp<ComponentProps>
+    }
+    get: {
+      params: GetComponentParams
+      return: ComponentProps
+    }
+    create: {
+      params: GetSpaceEnvironmentParams
+      payload: CreateComponentProps
+      return: ComponentProps
+    }
+    upsert: {
+      params: GetComponentParams
+      payload: UpsertComponentProps
+      return: ComponentProps
+    }
+    delete: {
+      params: GetComponentParams
+      return: void
+    }
+    publish: {
+      params: GetComponentParams & { version: number }
+      return: ComponentProps
+    }
+    unpublish: {
+      params: GetComponentParams & { version: number }
+      return: ComponentProps
     }
   }
   Concept: {
@@ -3286,6 +3331,8 @@ export type GetCommentParams = (GetEntryParams | GetCommentParentEntityParams) &
 }
 /** @internal */
 export type GetComponentTypeParams = GetSpaceEnvironmentParams & { componentTypeId: string }
+/** @internal */
+export type GetComponentParams = GetSpaceEnvironmentParams & { componentId: string }
 /** @internal */
 export type GetExperienceParams = GetSpaceEnvironmentParams & { experienceId: string }
 /** @internal */

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -92,6 +92,12 @@ import type {
   ExperienceFragmentQueryOptions,
   UpsertExperienceFragmentProps,
 } from './entities/experience-fragment'
+import type {
+  CreateExperienceTemplateProps,
+  ExperienceTemplateProps,
+  ExperienceTemplateQueryOptions,
+  UpsertExperienceTemplateProps,
+} from './entities/experience-template'
 import type { ContentTypeProps, CreateContentTypeProps } from './entities/content-type'
 import type { EditorInterfaceProps } from './entities/editor-interface'
 import type { EligibleLicenseProps } from './entities/eligible-license'
@@ -1185,6 +1191,13 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'ExperienceFragment', 'delete', UA>): MRReturn<'ExperienceFragment', 'delete'>
   (opts: MROpts<'ExperienceFragment', 'publish', UA>): MRReturn<'ExperienceFragment', 'publish'>
   (opts: MROpts<'ExperienceFragment', 'unpublish', UA>): MRReturn<'ExperienceFragment', 'unpublish'>
+  (opts: MROpts<'ExperienceTemplate', 'getMany', UA>): MRReturn<'ExperienceTemplate', 'getMany'>
+  (opts: MROpts<'ExperienceTemplate', 'get', UA>): MRReturn<'ExperienceTemplate', 'get'>
+  (opts: MROpts<'ExperienceTemplate', 'create', UA>): MRReturn<'ExperienceTemplate', 'create'>
+  (opts: MROpts<'ExperienceTemplate', 'upsert', UA>): MRReturn<'ExperienceTemplate', 'upsert'>
+  (opts: MROpts<'ExperienceTemplate', 'delete', UA>): MRReturn<'ExperienceTemplate', 'delete'>
+  (opts: MROpts<'ExperienceTemplate', 'publish', UA>): MRReturn<'ExperienceTemplate', 'publish'>
+  (opts: MROpts<'ExperienceTemplate', 'unpublish', UA>): MRReturn<'ExperienceTemplate', 'unpublish'>
 
   (opts: MROpts<'Webhook', 'get', UA>): MRReturn<'Webhook', 'get'>
   (opts: MROpts<'Webhook', 'getMany', UA>): MRReturn<'Webhook', 'getMany'>
@@ -3032,6 +3045,38 @@ export type MRActions = {
       return: ExperienceFragmentProps
     }
   }
+  ExperienceTemplate: {
+    getMany: {
+      params: GetSpaceEnvironmentParams & { query: ExperienceTemplateQueryOptions }
+      return: ExoCursorPaginatedCollectionProp<ExperienceTemplateProps>
+    }
+    get: {
+      params: GetExperienceTemplateParams
+      return: ExperienceTemplateProps
+    }
+    create: {
+      params: GetSpaceEnvironmentParams
+      payload: CreateExperienceTemplateProps
+      return: ExperienceTemplateProps
+    }
+    upsert: {
+      params: GetExperienceTemplateParams
+      payload: UpsertExperienceTemplateProps
+      return: ExperienceTemplateProps
+    }
+    delete: {
+      params: GetExperienceTemplateParams
+      return: void
+    }
+    publish: {
+      params: GetExperienceTemplateParams & { version: number }
+      return: ExperienceTemplateProps
+    }
+    unpublish: {
+      params: GetExperienceTemplateParams & { version: number }
+      return: ExperienceTemplateProps
+    }
+  }
   Webhook: {
     get: { params: GetWebhookParams; return: WebhookProps }
     getMany: { params: GetSpaceParams & QueryParams; return: CollectionProp<WebhookProps> }
@@ -3253,6 +3298,10 @@ export type GetDataAssemblyParams = GetSpaceEnvironmentParams & { dataAssemblyId
 export type GetFragmentParams = GetSpaceEnvironmentParams & { fragmentId: string }
 /** @internal */
 export type GetTemplateParams = GetSpaceEnvironmentParams & { templateId: string }
+/** @internal */
+export type GetExperienceTemplateParams = GetSpaceEnvironmentParams & {
+  experienceTemplateId: string
+}
 /** @internal */
 export type GetContentTypeParams = GetSpaceEnvironmentParams & { contentTypeId: string }
 /** @internal */

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -86,6 +86,12 @@ import type {
   ExperienceProps,
   ExperienceQueryOptions,
 } from './entities/experience'
+import type {
+  CreateExperienceFragmentProps,
+  ExperienceFragmentProps,
+  ExperienceFragmentQueryOptions,
+  UpsertExperienceFragmentProps,
+} from './entities/experience-fragment'
 import type { ContentTypeProps, CreateContentTypeProps } from './entities/content-type'
 import type { EditorInterfaceProps } from './entities/editor-interface'
 import type { EligibleLicenseProps } from './entities/eligible-license'
@@ -1171,6 +1177,14 @@ type MRInternal<UA extends boolean> = {
   (opts: MROpts<'Experience', 'delete', UA>): MRReturn<'Experience', 'delete'>
   (opts: MROpts<'Experience', 'publish', UA>): MRReturn<'Experience', 'publish'>
   (opts: MROpts<'Experience', 'unpublish', UA>): MRReturn<'Experience', 'unpublish'>
+
+  (opts: MROpts<'ExperienceFragment', 'getMany', UA>): MRReturn<'ExperienceFragment', 'getMany'>
+  (opts: MROpts<'ExperienceFragment', 'get', UA>): MRReturn<'ExperienceFragment', 'get'>
+  (opts: MROpts<'ExperienceFragment', 'create', UA>): MRReturn<'ExperienceFragment', 'create'>
+  (opts: MROpts<'ExperienceFragment', 'upsert', UA>): MRReturn<'ExperienceFragment', 'upsert'>
+  (opts: MROpts<'ExperienceFragment', 'delete', UA>): MRReturn<'ExperienceFragment', 'delete'>
+  (opts: MROpts<'ExperienceFragment', 'publish', UA>): MRReturn<'ExperienceFragment', 'publish'>
+  (opts: MROpts<'ExperienceFragment', 'unpublish', UA>): MRReturn<'ExperienceFragment', 'unpublish'>
 
   (opts: MROpts<'Webhook', 'get', UA>): MRReturn<'Webhook', 'get'>
   (opts: MROpts<'Webhook', 'getMany', UA>): MRReturn<'Webhook', 'getMany'>
@@ -2986,6 +3000,38 @@ export type MRActions = {
       return: ExperienceProps
     }
   }
+  ExperienceFragment: {
+    getMany: {
+      params: GetSpaceEnvironmentParams & { query: ExperienceFragmentQueryOptions }
+      return: ExoCursorPaginatedCollectionProp<ExperienceFragmentProps>
+    }
+    get: {
+      params: GetExperienceFragmentParams
+      return: ExperienceFragmentProps
+    }
+    create: {
+      params: GetSpaceEnvironmentParams
+      payload: CreateExperienceFragmentProps
+      return: ExperienceFragmentProps
+    }
+    upsert: {
+      params: GetExperienceFragmentParams
+      payload: UpsertExperienceFragmentProps
+      return: ExperienceFragmentProps
+    }
+    delete: {
+      params: GetExperienceFragmentParams
+      return: void
+    }
+    publish: {
+      params: GetExperienceFragmentParams & { version: number }
+      return: ExperienceFragmentProps
+    }
+    unpublish: {
+      params: GetExperienceFragmentParams & { version: number }
+      return: ExperienceFragmentProps
+    }
+  }
   Webhook: {
     get: { params: GetWebhookParams; return: WebhookProps }
     getMany: { params: GetSpaceParams & QueryParams; return: CollectionProp<WebhookProps> }
@@ -3197,6 +3243,10 @@ export type GetCommentParams = (GetEntryParams | GetCommentParentEntityParams) &
 export type GetComponentTypeParams = GetSpaceEnvironmentParams & { componentTypeId: string }
 /** @internal */
 export type GetExperienceParams = GetSpaceEnvironmentParams & { experienceId: string }
+/** @internal */
+export type GetExperienceFragmentParams = GetSpaceEnvironmentParams & {
+  experienceFragmentId: string
+}
 /** @internal */
 export type GetDataAssemblyParams = GetSpaceEnvironmentParams & { dataAssemblyId: string }
 /** @internal */

--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -138,6 +138,14 @@ export type FragmentNode = {
   fragment: ResourceLink<'Contentful:Fragment'>
 }
 
+// Renamed form of FragmentNode used in Experience slot trees (post-migration).
+export type ExperienceFragmentNode = {
+  id: string
+  name?: string
+  nodeType: 'ExperienceFragment'
+  experienceFragment: ResourceLink<'Contentful:ExperienceFragment'>
+}
+
 export type SlotNode = {
   id: string
   nodeType: 'Slot'

--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -183,7 +183,7 @@ export type TreeNode = ComponentNode | FragmentNode | SlotNode
 
 /**
  * Renamed form of TreeNode used in ExperienceTemplate component trees (post-migration).
- * 
+ *
  * This will be renamed to TreeNode in the future, but during the migration, we need to support both.
  */
 export type TreeNodeV2 = ComponentNodeV2 | ExperienceFragmentNode | SlotNode

--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -121,6 +121,10 @@ export type ComponentTreeDesignPropertyValue =
   | DimensionedDesignPropertyValue
 
 // Tree node types for component tree
+/**
+ * @deprecated Use `ComponentNodeV2` instead. `ComponentNodeV2` uses the renamed
+ * `component` link (`Contentful:Component`) in place of `componentType`.
+ */
 export type ComponentNode = {
   id: string
   name?: string
@@ -131,6 +135,10 @@ export type ComponentNode = {
   slots: Record<string, TreeNode[]>
 }
 
+/**
+ * @deprecated Use `ExperienceFragmentNode` instead. `ExperienceFragmentNode` uses the
+ * renamed `experienceFragment` link (`Contentful:ExperienceFragment`).
+ */
 export type FragmentNode = {
   id: string
   name?: string
@@ -154,20 +162,27 @@ export type SlotNode = {
 
 // Renamed form of ComponentNode used in ExperienceTemplate component trees (post-migration).
 // `component` replaces `componentType`, and slots recurse over the renamed tree nodes.
-export type ExperienceComponentNode = {
+export type ComponentNodeV2 = {
   id: string
   name?: string
   nodeType: 'Component'
   component: ResourceLink<'Contentful:Component'>
   contentProperties: Record<string, ContentPropertyPointerValue | unknown> | string
   designProperties: Record<string, ComponentTreeDesignPropertyValue>
-  slots: Record<string, ExperienceTreeNode[]>
+  slots: Record<string, TreeNodeV2[]>
 }
 
+/**
+ * @deprecated Use TreeNodeV2 instead.
+ */
 export type TreeNode = ComponentNode | FragmentNode | SlotNode
 
-// Renamed form of TreeNode used in ExperienceTemplate component trees (post-migration).
-export type ExperienceTreeNode = ExperienceComponentNode | ExperienceFragmentNode | SlotNode
+/**
+ * Renamed form of TreeNode used in ExperienceTemplate component trees (post-migration).
+ * 
+ * This will be renamed to TreeNode in the future, but during the migration, we need to support both.
+ */
+export type TreeNodeV2 = ComponentNodeV2 | ExperienceFragmentNode | SlotNode
 
 // DataAssembly link type
 export type DataAssemblyLink = ResourceLink<'Contentful:DataAssembly'>

--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -10,6 +10,10 @@ import type {
 } from '../common-types'
 
 // Query options for getMany - cursor-based pagination with typed filter fields
+/**
+ * @deprecated Use `ComponentQueryOptions` (see `./component`) instead.
+ * The ComponentType entity is superseded by the Component entity.
+ */
 export type ComponentTypeQueryOptions = CursorPaginationParams &
   ExoQueryFilters & {
     order?: string
@@ -191,6 +195,10 @@ export const COMPONENT_TYPE_ALLOWED_RESOURCE_SOURCE =
   'crn:contentful:::experience:spaces/$self/environments/$self' as const
 
 // Slot definition
+/**
+ * @deprecated Use `ComponentSlotDefinition` instead. `ComponentSlotDefinition` uses the
+ * renamed `allowedResources[].type` value (`Contentful:Component`).
+ */
 export type ComponentTypeSlotDefinition = {
   id: string
   name: string
@@ -203,7 +211,25 @@ export type ComponentTypeSlotDefinition = {
   }>
 }
 
+// Renamed form of ComponentTypeSlotDefinition used in Component / ExperienceTemplate
+// slot definitions (post-migration). `allowedResources[].type` is `Contentful:Component`.
+export type ComponentSlotDefinition = {
+  id: string
+  name: string
+  required: boolean
+  validations: Array<{ size?: { min?: number; max?: number } }>
+  allowedResources?: Array<{
+    type: 'Contentful:Component'
+    source: typeof COMPONENT_TYPE_ALLOWED_RESOURCE_SOURCE
+    allowedTypes: string[]
+  }>
+}
+
 // ComponentType sys properties (management API shape)
+/**
+ * @deprecated Use the Component entity (see `./component`) instead.
+ * The ComponentType endpoint is superseded by the Component endpoint.
+ */
 export type ComponentTypeSys = {
   id: string
   type: 'ComponentType'
@@ -226,6 +252,10 @@ export type ComponentTypeSys = {
 }
 
 // Main ComponentType props
+/**
+ * @deprecated Use `ComponentProps` (see `./component`) instead.
+ * The ComponentType entity is superseded by the Component entity.
+ */
 export type ComponentTypeProps = {
   sys: ComponentTypeSys
   name: string
@@ -240,10 +270,18 @@ export type ComponentTypeProps = {
   source?: ResourceLink<'Contentful:DesignSystemSource'>
 }
 
+/**
+ * @deprecated Use `CreateComponentProps` (see `./component`) instead.
+ * The ComponentType entity is superseded by the Component entity.
+ */
 export type CreateComponentTypeProps = Except<ComponentTypeProps, 'sys' | 'source'> & {
   source?: ResourceLink<'Contentful:DesignSystemSource'> | null
 }
 
+/**
+ * @deprecated Use `UpsertComponentProps` (see `./component`) instead.
+ * The ComponentType entity is superseded by the Component entity.
+ */
 export type UpsertComponentTypeProps = Except<ComponentTypeProps, 'sys' | 'source'> & {
   sys: {
     id: string
@@ -253,4 +291,8 @@ export type UpsertComponentTypeProps = Except<ComponentTypeProps, 'sys' | 'sourc
   source?: ResourceLink<'Contentful:DesignSystemSource'> | null
 }
 
+/**
+ * @deprecated Use `ComponentCollection` (see `./component`) instead.
+ * The ComponentType entity is superseded by the Component entity.
+ */
 export type ComponentTypeCollection = ExoCursorPaginatedCollectionProp<ComponentTypeProps>

--- a/lib/entities/component-type.ts
+++ b/lib/entities/component-type.ts
@@ -152,7 +152,22 @@ export type SlotNode = {
   slotId: string
 }
 
+// Renamed form of ComponentNode used in ExperienceTemplate component trees (post-migration).
+// `component` replaces `componentType`, and slots recurse over the renamed tree nodes.
+export type ExperienceComponentNode = {
+  id: string
+  name?: string
+  nodeType: 'Component'
+  component: ResourceLink<'Contentful:Component'>
+  contentProperties: Record<string, ContentPropertyPointerValue | unknown> | string
+  designProperties: Record<string, ComponentTreeDesignPropertyValue>
+  slots: Record<string, ExperienceTreeNode[]>
+}
+
 export type TreeNode = ComponentNode | FragmentNode | SlotNode
+
+// Renamed form of TreeNode used in ExperienceTemplate component trees (post-migration).
+export type ExperienceTreeNode = ExperienceComponentNode | ExperienceFragmentNode | SlotNode
 
 // DataAssembly link type
 export type DataAssemblyLink = ResourceLink<'Contentful:DataAssembly'>

--- a/lib/entities/component.ts
+++ b/lib/entities/component.ts
@@ -15,11 +15,11 @@ import type {
   TreeNodeV2,
 } from './component-type'
 
-// ExperienceTemplate sys properties (management API shape).
-// Renamed form of Template: sys.type is 'ExperienceTemplate'.
-export type ExperienceTemplateSys = {
+// Component sys properties (management API shape).
+// Renamed form of ComponentType: sys.type is 'Component'.
+export type ComponentSys = {
   id: string
-  type: 'ExperienceTemplate'
+  type: 'Component'
   version: number
   space: Link<'Space'>
   environment: Link<'Environment'>
@@ -38,9 +38,12 @@ export type ExperienceTemplateSys = {
   updatedBy: Link<'User'>
 }
 
-// componentTree uses the renamed TreeNodeV2 nodes.
-export type ExperienceTemplateProps = {
-  sys: ExperienceTemplateSys
+// Main Component props.
+// componentTree uses the renamed TreeNodeV2 nodes and slots use ComponentSlotDefinition.
+// Unlike ComponentType, there is no top-level `source` field — design system source
+// provenance is stored inside `metadata`.
+export type ComponentProps = {
+  sys: ComponentSys
   name: string
   description: string
   viewports: ComponentTypeViewport[]
@@ -52,21 +55,20 @@ export type ExperienceTemplateProps = {
   dataAssemblies?: DataAssemblyLink[]
 }
 
-export type CreateExperienceTemplateProps = Except<ExperienceTemplateProps, 'sys'>
+export type CreateComponentProps = Except<ComponentProps, 'sys'>
 
-export type UpsertExperienceTemplateProps = Except<ExperienceTemplateProps, 'sys'> & {
+export type UpsertComponentProps = Except<ComponentProps, 'sys'> & {
   sys: {
     id: string
-    type: 'ExperienceTemplate'
+    type: 'Component'
     version?: number
   }
 }
 
 // Query options for getMany - cursor-based pagination with typed filter fields
-export type ExperienceTemplateQueryOptions = CursorPaginationParams &
+export type ComponentQueryOptions = CursorPaginationParams &
   ExoQueryFilters & {
     order?: string
   }
 
-export type ExperienceTemplateCollection =
-  ExoCursorPaginatedCollectionProp<ExperienceTemplateProps>
+export type ComponentCollection = ExoCursorPaginatedCollectionProp<ComponentProps>

--- a/lib/entities/experience-fragment.ts
+++ b/lib/entities/experience-fragment.ts
@@ -67,5 +67,4 @@ export type ExperienceFragmentQueryOptions = CursorPaginationParams &
     order?: string
   }
 
-export type ExperienceFragmentCollection =
-  ExoCursorPaginatedCollectionProp<ExperienceFragmentProps>
+export type ExperienceFragmentCollection = ExoCursorPaginatedCollectionProp<ExperienceFragmentProps>

--- a/lib/entities/experience-fragment.ts
+++ b/lib/entities/experience-fragment.ts
@@ -1,0 +1,71 @@
+import type { Except } from 'type-fest'
+import type {
+  CursorPaginationParams,
+  ExoCursorPaginatedCollectionProp,
+  ExoQueryFilters,
+  ExperienceMetadataProps,
+  Link,
+  ResourceLink,
+} from '../common-types'
+import type {
+  ComponentTypeViewport,
+  DimensionedDesignPropertyValue,
+  ExperienceFragmentNode,
+} from './component-type'
+import type { ExperienceContentBindings, InlineExperienceFragmentNode } from './experience'
+
+export type ExperienceFragmentSys = {
+  id: string
+  type: 'ExperienceFragment'
+  version: number
+  space: Link<'Space'>
+  environment: Link<'Environment'>
+  component: ResourceLink<'Contentful:Component'>
+  archivedAt?: string
+  archivedBy?: Link<'User'>
+  archivedVersion?: number
+  createdAt: string
+  updatedAt: string
+  createdBy: Link<'User'>
+  updatedBy: Link<'User'>
+  variant?: string
+  variantType?: string
+  variantDimension?: string
+  publishedAt?: string
+  publishedVersion?: number
+  publishedCounter?: number
+  firstPublishedAt?: string
+  publishedBy?: Link<'User'> | Link<'AppDefinition'>
+}
+
+export type ExperienceFragmentProps = {
+  sys: ExperienceFragmentSys
+  name: string
+  description: string
+  viewports: ComponentTypeViewport[]
+  designProperties: Record<string, DimensionedDesignPropertyValue>
+  contentBindings?: ExperienceContentBindings
+  metadata?: ExperienceMetadataProps
+  slots?: Record<string, Array<ExperienceFragmentNode | InlineExperienceFragmentNode>>
+}
+
+export type CreateExperienceFragmentProps = Except<ExperienceFragmentProps, 'sys'> & {
+  component: ResourceLink<'Contentful:Component'>
+}
+
+export type UpsertExperienceFragmentProps = Omit<ExperienceFragmentProps, 'sys'> & {
+  sys: {
+    id: string
+    type: 'ExperienceFragment'
+    version?: number
+  }
+  component?: ResourceLink<'Contentful:Component'>
+}
+
+export type ExperienceFragmentQueryOptions = CursorPaginationParams &
+  ExoQueryFilters & {
+    order?: string
+  }
+
+export type ExperienceFragmentCollection =
+  ExoCursorPaginatedCollectionProp<ExperienceFragmentProps>

--- a/lib/entities/experience-template.ts
+++ b/lib/entities/experience-template.ts
@@ -68,5 +68,4 @@ export type ExperienceTemplateQueryOptions = CursorPaginationParams &
     order?: string
   }
 
-export type ExperienceTemplateCollection =
-  ExoCursorPaginatedCollectionProp<ExperienceTemplateProps>
+export type ExperienceTemplateCollection = ExoCursorPaginatedCollectionProp<ExperienceTemplateProps>

--- a/lib/entities/experience-template.ts
+++ b/lib/entities/experience-template.ts
@@ -12,7 +12,7 @@ import type {
   ComponentTypeSlotDefinition,
   ComponentTypeViewport,
   DataAssemblyLink,
-  ExperienceTreeNode,
+  TreeNodeV2,
 } from './component-type'
 
 // ExperienceTemplate sys properties (management API shape).
@@ -38,7 +38,7 @@ export type ExperienceTemplateSys = {
   updatedBy: Link<'User'>
 }
 
-// componentTree uses the renamed ExperienceTreeNode nodes.
+// componentTree uses the renamed TreeNodeV2 nodes.
 export type ExperienceTemplateProps = {
   sys: ExperienceTemplateSys
   name: string
@@ -46,7 +46,7 @@ export type ExperienceTemplateProps = {
   viewports: ComponentTypeViewport[]
   contentProperties: ComponentTypeContentProperty[]
   designProperties: ComponentTypeDesignProperty[]
-  componentTree?: ExperienceTreeNode[]
+  componentTree?: TreeNodeV2[]
   slots?: ComponentTypeSlotDefinition[]
   metadata?: ExoMetadataProps
   dataAssemblies?: DataAssemblyLink[]

--- a/lib/entities/experience-template.ts
+++ b/lib/entities/experience-template.ts
@@ -12,17 +12,14 @@ import type {
   ComponentTypeSlotDefinition,
   ComponentTypeViewport,
   DataAssemblyLink,
-  TreeNode,
+  ExperienceTreeNode,
 } from './component-type'
 
-/**
- * @deprecated Use the ExperienceTemplate entity (see `./experience-template`) instead.
- * The Template endpoint is superseded by the ExperienceTemplate endpoint.
- */
-// Template sys properties (management API shape)
-export type TemplateSys = {
+// ExperienceTemplate sys properties (management API shape).
+// Renamed form of Template: sys.type is 'ExperienceTemplate'.
+export type ExperienceTemplateSys = {
   id: string
-  type: 'Template'
+  type: 'ExperienceTemplate'
   version: number
   space: Link<'Space'>
   environment: Link<'Environment'>
@@ -41,34 +38,35 @@ export type TemplateSys = {
   updatedBy: Link<'User'>
 }
 
-// Main TemplateProps — config fields are identical to ComponentType (TemplateConfigSchema extends ComponentTypeConfigSchema upstream)
-export type TemplateProps = {
-  sys: TemplateSys
+// componentTree uses the renamed ExperienceTreeNode nodes.
+export type ExperienceTemplateProps = {
+  sys: ExperienceTemplateSys
   name: string
   description: string
   viewports: ComponentTypeViewport[]
   contentProperties: ComponentTypeContentProperty[]
   designProperties: ComponentTypeDesignProperty[]
-  componentTree?: TreeNode[]
+  componentTree?: ExperienceTreeNode[]
   slots?: ComponentTypeSlotDefinition[]
   metadata?: ExoMetadataProps
   dataAssemblies?: DataAssemblyLink[]
 }
 
-export type CreateTemplateProps = Except<TemplateProps, 'sys'>
+export type CreateExperienceTemplateProps = Except<ExperienceTemplateProps, 'sys'>
 
-export type UpsertTemplateProps = Except<TemplateProps, 'sys'> & {
+export type UpsertExperienceTemplateProps = Except<ExperienceTemplateProps, 'sys'> & {
   sys: {
     id: string
-    type: 'Template'
+    type: 'ExperienceTemplate'
     version?: number
   }
 }
 
 // Query options for getMany - cursor-based pagination with typed filter fields
-export type TemplateQueryOptions = CursorPaginationParams &
+export type ExperienceTemplateQueryOptions = CursorPaginationParams &
   ExoQueryFilters & {
     order?: string
   }
 
-export type TemplateCollection = ExoCursorPaginatedCollectionProp<TemplateProps>
+export type ExperienceTemplateCollection =
+  ExoCursorPaginatedCollectionProp<ExperienceTemplateProps>

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -9,7 +9,7 @@ import type {
 import type {
   ComponentTypeViewport,
   DimensionedDesignPropertyValue,
-  FragmentNode,
+  ExperienceFragmentNode,
 } from './component-type'
 
 export type ExperienceContentBindings = {
@@ -23,7 +23,7 @@ export type ExperienceSys = {
   version: number
   space: Link<'Space'>
   environment: Link<'Environment'>
-  template: ResourceLink<'Contentful:Template'>
+  experienceTemplate: ResourceLink<'Contentful:ExperienceTemplate'>
   createdAt: string
   updatedAt: string
   createdBy: Link<'User'>
@@ -49,7 +49,7 @@ type ExperienceCommonProps = {
   designProperties: Record<string, DimensionedDesignPropertyValue>
   contentBindings?: ExperienceContentBindings
   metadata?: ExperienceMetadataProps
-  slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>
+  slots?: Record<string, Array<ExperienceFragmentNode | InlineExperienceFragmentNode>>
 }
 
 export type ExperienceProps = ExperienceCommonProps & {
@@ -67,7 +67,7 @@ export type ExperienceQueryOptions = CursorPaginationParams &
 export type ExperienceLocalePublishPayload = { add: string[] } | { remove: string[] }
 
 export type CreateExperienceProps = ExperienceCommonProps & {
-  template: ResourceLink<'Contentful:Template'>
+  experienceTemplate: ResourceLink<'Contentful:ExperienceTemplate'>
 }
 
 export type UpsertExperienceProps = ExperienceCommonProps & {
@@ -76,16 +76,16 @@ export type UpsertExperienceProps = ExperienceCommonProps & {
     type: 'Experience'
     version?: number
   }
-  template?: ResourceLink<'Contentful:Template'>
+  experienceTemplate?: ResourceLink<'Contentful:ExperienceTemplate'>
 }
 
-export type InlineFragmentNode = {
+export type InlineExperienceFragmentNode = {
   id: string
-  nodeType: 'InlineFragment'
-  componentType: ResourceLink<'Contentful:ComponentType'>
+  nodeType: 'InlineExperienceFragment'
+  component: ResourceLink<'Contentful:Component'>
   designProperties: Record<string, DimensionedDesignPropertyValue>
   contentBindings?: ExperienceContentBindings
-  slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>
+  slots?: Record<string, Array<ExperienceFragmentNode | InlineExperienceFragmentNode>>
 }
 
 export type ExperienceCollection = ExoCursorPaginatedCollectionProp<ExperienceProps>

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -25,6 +25,10 @@ export type InlineFragmentNode = {
   slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>
 }
 
+/**
+ * @deprecated Use the ExperienceFragment entity (see `./experience-fragment`) instead.
+ * The Fragment endpoint is superseded by the ExperienceFragment endpoint.
+ */
 export type FragmentSys = {
   id: string
   type: 'Fragment'

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -12,7 +12,18 @@ import type {
   DimensionedDesignPropertyValue,
   FragmentNode,
 } from './component-type'
-import type { ExperienceContentBindings, InlineFragmentNode } from './experience'
+import type { ExperienceContentBindings } from './experience'
+
+// Legacy inline node for Fragment slot trees. The Experience entity has migrated to
+// InlineExperienceFragmentNode (see ./experience); Fragment retains the legacy shape.
+export type InlineFragmentNode = {
+  id: string
+  nodeType: 'InlineFragment'
+  componentType: ResourceLink<'Contentful:ComponentType'>
+  designProperties: Record<string, DimensionedDesignPropertyValue>
+  contentBindings?: ExperienceContentBindings
+  slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>
+}
 
 export type FragmentSys = {
   id: string

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -16,6 +16,10 @@ import type { ExperienceContentBindings } from './experience'
 
 // Legacy inline node for Fragment slot trees. The Experience entity has migrated to
 // InlineExperienceFragmentNode (see ./experience); Fragment retains the legacy shape.
+/**
+ * @deprecated Use `InlineExperienceFragmentNode` (see `./experience`) instead.
+ * The Fragment entity is superseded by the ExperienceFragment entity.
+ */
 export type InlineFragmentNode = {
   id: string
   nodeType: 'InlineFragment'
@@ -53,6 +57,10 @@ export type FragmentSys = {
   publishedBy?: Link<'User'> | Link<'AppDefinition'>
 }
 
+/**
+ * @deprecated Use `ExperienceFragmentProps` (see `./experience-fragment`) instead.
+ * The Fragment entity is superseded by the ExperienceFragment entity.
+ */
 export type FragmentProps = {
   sys: FragmentSys
   name: string
@@ -64,10 +72,18 @@ export type FragmentProps = {
   slots?: Record<string, Array<FragmentNode | InlineFragmentNode>>
 }
 
+/**
+ * @deprecated Use `CreateExperienceFragmentProps` (see `./experience-fragment`) instead.
+ * The Fragment entity is superseded by the ExperienceFragment entity.
+ */
 export type CreateFragmentProps = Except<FragmentProps, 'sys'> & {
   componentType: ResourceLink<'Contentful:ComponentType'>
 }
 
+/**
+ * @deprecated Use `UpsertExperienceFragmentProps` (see `./experience-fragment`) instead.
+ * The Fragment entity is superseded by the ExperienceFragment entity.
+ */
 export type UpsertFragmentProps = Omit<FragmentProps, 'sys'> & {
   sys: {
     id: string
@@ -77,9 +93,17 @@ export type UpsertFragmentProps = Omit<FragmentProps, 'sys'> & {
   componentType?: ResourceLink<'Contentful:ComponentType'>
 }
 
+/**
+ * @deprecated Use `ExperienceFragmentQueryOptions` (see `./experience-fragment`) instead.
+ * The Fragment entity is superseded by the ExperienceFragment entity.
+ */
 export type FragmentQueryOptions = CursorPaginationParams &
   ExoQueryFilters & {
     order?: string
   }
 
+/**
+ * @deprecated Use `ExperienceFragmentCollection` (see `./experience-fragment`) instead.
+ * The Fragment entity is superseded by the ExperienceFragment entity.
+ */
 export type FragmentCollection = ExoCursorPaginatedCollectionProp<FragmentProps>

--- a/lib/entities/template.ts
+++ b/lib/entities/template.ts
@@ -15,11 +15,11 @@ import type {
   TreeNode,
 } from './component-type'
 
+// Template sys properties (management API shape)
 /**
  * @deprecated Use the ExperienceTemplate entity (see `./experience-template`) instead.
  * The Template endpoint is superseded by the ExperienceTemplate endpoint.
  */
-// Template sys properties (management API shape)
 export type TemplateSys = {
   id: string
   type: 'Template'
@@ -42,6 +42,10 @@ export type TemplateSys = {
 }
 
 // Main TemplateProps — config fields are identical to ComponentType (TemplateConfigSchema extends ComponentTypeConfigSchema upstream)
+/**
+ * @deprecated Use `ExperienceTemplateProps` (see `./experience-template`) instead.
+ * The Template entity is superseded by the ExperienceTemplate entity.
+ */
 export type TemplateProps = {
   sys: TemplateSys
   name: string
@@ -55,8 +59,16 @@ export type TemplateProps = {
   dataAssemblies?: DataAssemblyLink[]
 }
 
+/**
+ * @deprecated Use `CreateExperienceTemplateProps` (see `./experience-template`) instead.
+ * The Template entity is superseded by the ExperienceTemplate entity.
+ */
 export type CreateTemplateProps = Except<TemplateProps, 'sys'>
 
+/**
+ * @deprecated Use `UpsertExperienceTemplateProps` (see `./experience-template`) instead.
+ * The Template entity is superseded by the ExperienceTemplate entity.
+ */
 export type UpsertTemplateProps = Except<TemplateProps, 'sys'> & {
   sys: {
     id: string
@@ -66,9 +78,17 @@ export type UpsertTemplateProps = Except<TemplateProps, 'sys'> & {
 }
 
 // Query options for getMany - cursor-based pagination with typed filter fields
+/**
+ * @deprecated Use `ExperienceTemplateQueryOptions` (see `./experience-template`) instead.
+ * The Template entity is superseded by the ExperienceTemplate entity.
+ */
 export type TemplateQueryOptions = CursorPaginationParams &
   ExoQueryFilters & {
     order?: string
   }
 
+/**
+ * @deprecated Use `ExperienceTemplateCollection` (see `./experience-template`) instead.
+ * The Template entity is superseded by the ExperienceTemplate entity.
+ */
 export type TemplateCollection = ExoCursorPaginatedCollectionProp<TemplateProps>

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -374,12 +374,15 @@ export type {
   ComponentTypeContentProperty,
   ComponentTypeDesignProperty,
   ComponentTypeSlotDefinition,
+  /** @deprecated Use `TreeNodeV2` instead */
   TreeNode,
+  /** @deprecated Use `ComponentNodeV2` instead */
   ComponentNode,
+  /** @deprecated Use `ExperienceFragmentNode` instead */
   FragmentNode,
   ExperienceFragmentNode,
-  ExperienceComponentNode,
-  ExperienceTreeNode,
+  ComponentNodeV2,
+  TreeNodeV2,
   SlotNode,
 } from './entities/component-type'
 export type {

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -377,6 +377,7 @@ export type {
   TreeNode,
   ComponentNode,
   FragmentNode,
+  ExperienceFragmentNode,
   SlotNode,
 } from './entities/component-type'
 export type {
@@ -394,13 +395,14 @@ export type {
   ReleaseExperienceCollection,
   ReleaseExperienceSys,
   ExperienceContentBindings,
-  InlineFragmentNode,
+  InlineExperienceFragmentNode,
 } from './entities/experience'
 export type {
   FragmentCollection,
   FragmentProps,
   CreateFragmentProps,
   UpsertFragmentProps,
+  InlineFragmentNode,
 } from './entities/fragment'
 export type {
   DataAssemblyCollection,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -378,14 +378,26 @@ export type {
   ComponentNode,
   FragmentNode,
   ExperienceFragmentNode,
+  ExperienceComponentNode,
+  ExperienceTreeNode,
   SlotNode,
 } from './entities/component-type'
 export type {
+  /** @deprecated Use `ExperienceTemplateCollection` instead */
   TemplateCollection,
+  /** @deprecated Use `ExperienceTemplateProps` instead */
   TemplateProps,
+  /** @deprecated Use `CreateExperienceTemplateProps` instead */
   CreateTemplateProps,
+  /** @deprecated Use `UpsertExperienceTemplateProps` instead */
   UpsertTemplateProps,
 } from './entities/template'
+export type {
+  ExperienceTemplateCollection,
+  ExperienceTemplateProps,
+  CreateExperienceTemplateProps,
+  UpsertExperienceTemplateProps,
+} from './entities/experience-template'
 export type {
   ExperienceCollection,
   ExperienceProps,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -366,14 +366,20 @@ export type {
   WorkflowsChangelogQueryOptions,
 } from './entities/workflows-changelog-entry'
 export type {
+  /** @deprecated Use `ComponentCollection` instead */
   ComponentTypeCollection,
+  /** @deprecated Use `ComponentProps` instead */
   ComponentTypeProps,
+  /** @deprecated Use `CreateComponentProps` instead */
   CreateComponentTypeProps,
+  /** @deprecated Use `UpsertComponentProps` instead */
   UpsertComponentTypeProps,
   ComponentTypeViewport,
   ComponentTypeContentProperty,
   ComponentTypeDesignProperty,
+  /** @deprecated Use `ComponentSlotDefinition` instead */
   ComponentTypeSlotDefinition,
+  ComponentSlotDefinition,
   /** @deprecated Use `TreeNodeV2` instead */
   TreeNode,
   /** @deprecated Use `ComponentNodeV2` instead */
@@ -385,6 +391,12 @@ export type {
   TreeNodeV2,
   SlotNode,
 } from './entities/component-type'
+export type {
+  ComponentCollection,
+  ComponentProps,
+  CreateComponentProps,
+  UpsertComponentProps,
+} from './entities/component'
 export type {
   /** @deprecated Use `ExperienceTemplateCollection` instead */
   TemplateCollection,

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -398,12 +398,22 @@ export type {
   InlineExperienceFragmentNode,
 } from './entities/experience'
 export type {
+  /** @deprecated Use `ExperienceFragmentCollection` instead */
   FragmentCollection,
+  /** @deprecated Use `ExperienceFragmentProps` instead */
   FragmentProps,
+  /** @deprecated Use `CreateExperienceFragmentProps` instead */
   CreateFragmentProps,
+  /** @deprecated Use `UpsertExperienceFragmentProps` instead */
   UpsertFragmentProps,
   InlineFragmentNode,
 } from './entities/fragment'
+export type {
+  ExperienceFragmentCollection,
+  ExperienceFragmentProps,
+  CreateExperienceFragmentProps,
+  UpsertExperienceFragmentProps,
+} from './entities/experience-fragment'
 export type {
   DataAssemblyCollection,
   DataAssemblyProps,

--- a/lib/plain/entities/component-type.ts
+++ b/lib/plain/entities/component-type.ts
@@ -11,6 +11,10 @@ import type {
 } from '../../entities/component-type'
 import type { OptionalDefaults } from '../wrappers/wrap'
 
+/**
+ * @deprecated Use {@link ComponentPlainClientAPI} (`client.component`) instead.
+ * The `componentType` endpoint is superseded by the `component` endpoint.
+ */
 export type ComponentTypePlainClientAPI = {
   /**
    * Fetches all component types for a space and environment

--- a/lib/plain/entities/component.ts
+++ b/lib/plain/entities/component.ts
@@ -1,0 +1,163 @@
+import type {
+  GetSpaceEnvironmentParams,
+  GetComponentParams,
+  ExoCursorPaginatedCollectionProp,
+} from '../../common-types'
+import type {
+  ComponentQueryOptions,
+  ComponentProps,
+  CreateComponentProps,
+  UpsertComponentProps,
+} from '../../entities/component'
+import type { OptionalDefaults } from '../wrappers/wrap'
+
+export type ComponentPlainClientAPI = {
+  /**
+   * Fetches all components for a space and environment
+   * @param params the space and environment IDs and query parameters
+   * @param params.query.limit the maximum number of components to return
+   * @param params.query.pageNext cursor token for the next page
+   * @param params.query.pagePrev cursor token for the previous page
+   * @returns a collection of components
+   * @throws if the request fails, or the space or environment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const components = await client.component.getMany({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   query: {
+   *     limit: 10,
+   *   },
+   * });
+   * ```
+   */
+  getMany(
+    params: OptionalDefaults<GetSpaceEnvironmentParams & { query: ComponentQueryOptions }>,
+  ): Promise<ExoCursorPaginatedCollectionProp<ComponentProps>>
+
+  /**
+   * Fetches a single component by ID
+   * @param params the space, environment, and component IDs
+   * @returns the component
+   * @throws if the request fails, or the space, environment, or component is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const component = await client.component.get({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   componentId: '<component_id>',
+   * });
+   * ```
+   */
+  get(params: OptionalDefaults<GetComponentParams>): Promise<ComponentProps>
+
+  /**
+   * Creates a new component
+   * @param params the space and environment IDs
+   * @param rawData the component data to create
+   * @returns the created component
+   * @throws if the request fails
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const component = await client.component.create({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   * }, {
+   *   name: 'My Component',
+   *   description: 'A new component',
+   *   viewports: [],
+   *   contentProperties: [],
+   *   designProperties: [],
+   * });
+   * ```
+   */
+  create(
+    params: OptionalDefaults<GetSpaceEnvironmentParams>,
+    rawData: CreateComponentProps,
+  ): Promise<ComponentProps>
+
+  /**
+   * Upserts a component (creates or updates via PUT)
+   * @param params the space, environment, and component IDs
+   * @param rawData the component data to upsert (include sys.version for updates, omit for creates)
+   * @returns the upserted component
+   * @throws if the request fails
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const current = await client.component.get({ componentId: '<component_id>' });
+   * const updated = await client.component.upsert({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   componentId: '<component_id>',
+   * }, {
+   *   sys: { id: current.sys.id, type: 'Component', version: current.sys.version },
+   *   name: 'Updated Component',
+   *   ...otherFields,
+   * });
+   * ```
+   */
+  upsert(
+    params: OptionalDefaults<GetComponentParams>,
+    rawData: UpsertComponentProps,
+  ): Promise<ComponentProps>
+
+  /**
+   * Deletes a single component
+   * @param params the space, environment, and component IDs
+   * @throws if the request fails, or the component is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * await client.component.delete({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   componentId: '<component_id>',
+   * });
+   * ```
+   */
+  delete(params: OptionalDefaults<GetComponentParams>): Promise<void>
+
+  /**
+   * Publishes a component
+   * @param params the space, environment, and component IDs, and the version number
+   * @returns the published component
+   * @throws if the request fails, or the component is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const component = await client.component.publish({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   componentId: '<component_id>',
+   *   version: <version>,
+   * });
+   * ```
+   */
+  publish(
+    params: OptionalDefaults<GetComponentParams & { version: number }>,
+  ): Promise<ComponentProps>
+
+  /**
+   * Unpublishes a component
+   * @param params the space, environment, and component IDs, and the version number
+   * @returns the unpublished component
+   * @throws if the request fails, or the component is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const component = await client.component.unpublish({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   componentId: '<component_id>',
+   *   version: <version>,
+   * });
+   * ```
+   */
+  unpublish(
+    params: OptionalDefaults<GetComponentParams & { version: number }>,
+  ): Promise<ComponentProps>
+}

--- a/lib/plain/entities/experience-fragment.ts
+++ b/lib/plain/entities/experience-fragment.ts
@@ -1,0 +1,157 @@
+import type {
+  ExoCursorPaginatedCollectionProp,
+  GetExperienceFragmentParams,
+  GetSpaceEnvironmentParams,
+} from '../../common-types'
+import type {
+  CreateExperienceFragmentProps,
+  ExperienceFragmentProps,
+  ExperienceFragmentQueryOptions,
+  UpsertExperienceFragmentProps,
+} from '../../entities/experience-fragment'
+import type { OptionalDefaults } from '../wrappers/wrap'
+
+export type ExperienceFragmentPlainClientAPI = {
+  /**
+   * Fetches all experience fragments for a space and environment
+   * @param params the space, environment IDs and query options (see {@link ExperienceFragmentQueryOptions})
+   * @returns a collection of experience fragments
+   * @throws if the request fails, or the space or environment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const experienceFragments = await client.experienceFragment.getMany({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   query: {
+   *     limit: 10,
+   *   },
+   * });
+   * ```
+   */
+  getMany(
+    params: OptionalDefaults<
+      GetSpaceEnvironmentParams & { query: ExperienceFragmentQueryOptions }
+    >,
+  ): Promise<ExoCursorPaginatedCollectionProp<ExperienceFragmentProps>>
+
+  /**
+   * Fetches a single experience fragment by ID
+   * @param params the space, environment, and experience fragment IDs
+   * @returns the experience fragment
+   * @throws if the request fails, or the space, environment, or experience fragment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const experienceFragment = await client.experienceFragment.get({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   experienceFragmentId: '<experience_fragment_id>',
+   * });
+   * ```
+   */
+  get(params: OptionalDefaults<GetExperienceFragmentParams>): Promise<ExperienceFragmentProps>
+
+  /**
+   * Creates a new experience fragment
+   * @param params the space and environment IDs
+   * @param data the experience fragment data
+   * @returns the created experience fragment
+   * @throws if the request fails, or the space or environment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const experienceFragment = await client.experienceFragment.create({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   * }, {
+   *   name: 'My Experience Fragment',
+   *   description: 'A new experience fragment',
+   *   component: { sys: { type: 'ResourceLink', linkType: 'Contentful:Component', urn: '<component_urn>' } },
+   *   viewports: [],
+   *   designProperties: {},
+   * });
+   * ```
+   */
+  create(
+    params: OptionalDefaults<GetSpaceEnvironmentParams>,
+    data: CreateExperienceFragmentProps,
+  ): Promise<ExperienceFragmentProps>
+
+  /**
+   * Upserts an experience fragment (creates or updates via PUT)
+   * @param params the space, environment, and experience fragment IDs
+   * @param data the experience fragment data to upsert (include sys.version for updates, omit for creates)
+   * @returns the upserted experience fragment
+   * @throws if the request fails, or the space, environment, or experience fragment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const experienceFragment = await client.experienceFragment.upsert({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   experienceFragmentId: '<experience_fragment_id>',
+   * }, experienceFragmentData);
+   * ```
+   */
+  upsert(
+    params: OptionalDefaults<GetExperienceFragmentParams>,
+    data: UpsertExperienceFragmentProps,
+  ): Promise<ExperienceFragmentProps>
+
+  /**
+   * Deletes an experience fragment
+   * @param params the space, environment, and experience fragment IDs
+   * @throws if the request fails, or the space, environment, or experience fragment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * await client.experienceFragment.delete({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   experienceFragmentId: '<experience_fragment_id>',
+   * });
+   * ```
+   */
+  delete(params: OptionalDefaults<GetExperienceFragmentParams>): Promise<void>
+
+  /**
+   * Publishes an experience fragment
+   * @param params the space, environment, and experience fragment IDs, plus the current version
+   * @returns the published experience fragment
+   * @throws if the request fails, or the space, environment, or experience fragment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const experienceFragment = await client.experienceFragment.publish({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   experienceFragmentId: '<experience_fragment_id>',
+   *   version: 1,
+   * });
+   * ```
+   */
+  publish(
+    params: OptionalDefaults<GetExperienceFragmentParams & { version: number }>,
+  ): Promise<ExperienceFragmentProps>
+
+  /**
+   * Unpublishes an experience fragment
+   * @param params the space, environment, and experience fragment IDs, plus the current version
+   * @returns the unpublished experience fragment
+   * @throws if the request fails, or the space, environment, or experience fragment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const experienceFragment = await client.experienceFragment.unpublish({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   experienceFragmentId: '<experience_fragment_id>',
+   *   version: 2,
+   * });
+   * ```
+   */
+  unpublish(
+    params: OptionalDefaults<GetExperienceFragmentParams & { version: number }>,
+  ): Promise<ExperienceFragmentProps>
+}

--- a/lib/plain/entities/experience-fragment.ts
+++ b/lib/plain/entities/experience-fragment.ts
@@ -30,9 +30,7 @@ export type ExperienceFragmentPlainClientAPI = {
    * ```
    */
   getMany(
-    params: OptionalDefaults<
-      GetSpaceEnvironmentParams & { query: ExperienceFragmentQueryOptions }
-    >,
+    params: OptionalDefaults<GetSpaceEnvironmentParams & { query: ExperienceFragmentQueryOptions }>,
   ): Promise<ExoCursorPaginatedCollectionProp<ExperienceFragmentProps>>
 
   /**

--- a/lib/plain/entities/experience-template.ts
+++ b/lib/plain/entities/experience-template.ts
@@ -1,0 +1,160 @@
+import type {
+  ExoCursorPaginatedCollectionProp,
+  GetExperienceTemplateParams,
+  GetSpaceEnvironmentParams,
+} from '../../common-types'
+import type {
+  CreateExperienceTemplateProps,
+  ExperienceTemplateProps,
+  ExperienceTemplateQueryOptions,
+  UpsertExperienceTemplateProps,
+} from '../../entities/experience-template'
+import type { OptionalDefaults } from '../wrappers/wrap'
+
+export type ExperienceTemplatePlainClientAPI = {
+  /**
+   * Fetches all experience templates for a space and environment
+   * @param params the space, environment IDs and query options (see {@link ExperienceTemplateQueryOptions})
+   * @returns a collection of experience templates
+   * @throws if the request fails, or the space or environment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const experienceTemplates = await client.experienceTemplate.getMany({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   query: {
+   *     limit: 10,
+   *   },
+   * });
+   * ```
+   */
+  getMany(
+    params: OptionalDefaults<GetSpaceEnvironmentParams & { query: ExperienceTemplateQueryOptions }>,
+  ): Promise<ExoCursorPaginatedCollectionProp<ExperienceTemplateProps>>
+
+  /**
+   * Fetches a single experience template by ID
+   * @param params the space, environment, and experience template IDs
+   * @returns the experience template
+   * @throws if the request fails, or the space, environment, or experience template is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const experienceTemplate = await client.experienceTemplate.get({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   experienceTemplateId: '<experience_template_id>',
+   * });
+   * ```
+   */
+  get(params: OptionalDefaults<GetExperienceTemplateParams>): Promise<ExperienceTemplateProps>
+
+  /**
+   * Creates a new experience template
+   * @param params the space and environment IDs
+   * @param data the experience template data
+   * @returns the created experience template
+   * @throws if the request fails, or the space or environment is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const experienceTemplate = await client.experienceTemplate.create({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   * }, {
+   *   name: 'My Experience Template',
+   *   description: 'A new experience template',
+   *   viewports: [],
+   *   contentProperties: [],
+   *   designProperties: [],
+   * });
+   * ```
+   */
+  create(
+    params: OptionalDefaults<GetSpaceEnvironmentParams>,
+    data: CreateExperienceTemplateProps,
+  ): Promise<ExperienceTemplateProps>
+
+  /**
+   * Upserts an experience template (creates or updates via PUT)
+   * @param params the space, environment, and experience template IDs
+   * @param data the experience template data to upsert (include sys.version for updates, omit for creates)
+   * @returns the upserted experience template
+   * @throws if the request fails
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const current = await client.experienceTemplate.get({ experienceTemplateId: '<experience_template_id>' });
+   * const updated = await client.experienceTemplate.upsert({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   experienceTemplateId: '<experience_template_id>',
+   * }, {
+   *   sys: { id: current.sys.id, type: 'ExperienceTemplate', version: current.sys.version },
+   *   name: 'Updated Experience Template',
+   *   ...otherFields,
+   * });
+   * ```
+   */
+  upsert(
+    params: OptionalDefaults<GetExperienceTemplateParams>,
+    data: UpsertExperienceTemplateProps,
+  ): Promise<ExperienceTemplateProps>
+
+  /**
+   * Deletes an experience template
+   * @param params the space, environment, and experience template IDs
+   * @throws if the request fails, or the space, environment, or experience template is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * await client.experienceTemplate.delete({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   experienceTemplateId: '<experience_template_id>',
+   * });
+   * ```
+   */
+  delete(params: OptionalDefaults<GetExperienceTemplateParams>): Promise<void>
+
+  /**
+   * Publishes an experience template
+   * @param params the space, environment, and experience template IDs, plus the current version
+   * @returns the published experience template
+   * @throws if the request fails, or the space, environment, or experience template is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const experienceTemplate = await client.experienceTemplate.publish({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   experienceTemplateId: '<experience_template_id>',
+   *   version: 1,
+   * });
+   * ```
+   */
+  publish(
+    params: OptionalDefaults<GetExperienceTemplateParams & { version: number }>,
+  ): Promise<ExperienceTemplateProps>
+
+  /**
+   * Unpublishes an experience template
+   * @param params the space, environment, and experience template IDs, plus the current version
+   * @returns the unpublished experience template
+   * @throws if the request fails, or the space, environment, or experience template is not found
+   * @internal - Experimental endpoint, subject to breaking changes without notice
+   * @example
+   * ```javascript
+   * const experienceTemplate = await client.experienceTemplate.unpublish({
+   *   spaceId: '<space_id>',
+   *   environmentId: '<environment_id>',
+   *   experienceTemplateId: '<experience_template_id>',
+   *   version: 2,
+   * });
+   * ```
+   */
+  unpublish(
+    params: OptionalDefaults<GetExperienceTemplateParams & { version: number }>,
+  ): Promise<ExperienceTemplateProps>
+}

--- a/lib/plain/entities/experience.ts
+++ b/lib/plain/entities/experience.ts
@@ -66,7 +66,7 @@ export type ExperiencePlainClientAPI = {
    * }, {
    *   name: 'My Experience',
    *   description: 'A new experience',
-   *   template: { sys: { type: 'Link', linkType: 'Template', id: '<template_id>' } },
+   *   experienceTemplate: { sys: { type: 'ResourceLink', linkType: 'Contentful:ExperienceTemplate', urn: '<experience_template_urn>' } },
    *   viewports: [],
    *   contentProperties: {},
    *   designProperties: {},

--- a/lib/plain/entities/fragment.ts
+++ b/lib/plain/entities/fragment.ts
@@ -11,6 +11,10 @@ import type {
 } from '../../entities/fragment'
 import type { OptionalDefaults } from '../wrappers/wrap'
 
+/**
+ * @deprecated Use {@link ExperienceFragmentPlainClientAPI} (`client.experienceFragment`) instead.
+ * The `fragment` endpoint is superseded by the `experienceFragment` endpoint.
+ */
 export type FragmentPlainClientAPI = {
   /**
    * Fetches all fragments for a space and environment

--- a/lib/plain/entities/template.ts
+++ b/lib/plain/entities/template.ts
@@ -11,6 +11,10 @@ import type {
 } from '../../entities/template'
 import type { OptionalDefaults } from '../wrappers/wrap'
 
+/**
+ * @deprecated Use {@link ExperienceTemplatePlainClientAPI} (`client.experienceTemplate`) instead.
+ * The `template` endpoint is superseded by the `experienceTemplate` endpoint.
+ */
 export type TemplatePlainClientAPI = {
   /**
    * Fetches all templates for a space and environment

--- a/lib/plain/plain-client-types.ts
+++ b/lib/plain/plain-client-types.ts
@@ -155,6 +155,7 @@ import type { ContentSemanticsIndexPlainClientAPI } from './entities/content-sem
 import type { ComponentTypePlainClientAPI } from './entities/component-type'
 import type { DataAssemblyPlainClientAPI } from './entities/data-assembly'
 import type { ExperiencePlainClientAPI } from './entities/experience'
+import type { ExperienceFragmentPlainClientAPI } from './entities/experience-fragment'
 
 export type PlainClientAPI = {
   raw: {
@@ -731,6 +732,7 @@ export type PlainClientAPI = {
   team: TeamPlainClientAPI
   teamMembership: TeamMembershipPlainClientAPI
   teamSpaceMembership: TeamSpaceMembershipPlainClientAPI
+  /** @deprecated Use `experienceFragment` instead. The `fragment` endpoint is superseded by `experienceFragment`. */
   fragment: FragmentPlainClientAPI
   template: TemplatePlainClientAPI
   uiConfig: UIConfigPlainClientAPI
@@ -740,6 +742,7 @@ export type PlainClientAPI = {
   workflowsChangelog: WorkflowsChangelogPlainClientAPI
   oauthApplication: OAuthApplicationPlainClientAPI
   experience: ExperiencePlainClientAPI
+  experienceFragment: ExperienceFragmentPlainClientAPI
   semanticSearch: SemanticSearchPlainClientAPI
   semanticDuplicates: SemanticDuplicatesPlainClientAPI
   semanticRecommendations: SemanticRecommendationsPlainClientAPI

--- a/lib/plain/plain-client-types.ts
+++ b/lib/plain/plain-client-types.ts
@@ -156,6 +156,7 @@ import type { ComponentTypePlainClientAPI } from './entities/component-type'
 import type { DataAssemblyPlainClientAPI } from './entities/data-assembly'
 import type { ExperiencePlainClientAPI } from './entities/experience'
 import type { ExperienceFragmentPlainClientAPI } from './entities/experience-fragment'
+import type { ExperienceTemplatePlainClientAPI } from './entities/experience-template'
 
 export type PlainClientAPI = {
   raw: {
@@ -734,6 +735,7 @@ export type PlainClientAPI = {
   teamSpaceMembership: TeamSpaceMembershipPlainClientAPI
   /** @deprecated Use `experienceFragment` instead. The `fragment` endpoint is superseded by `experienceFragment`. */
   fragment: FragmentPlainClientAPI
+  /** @deprecated Use `experienceTemplate` instead. The `template` endpoint is superseded by `experienceTemplate`. */
   template: TemplatePlainClientAPI
   uiConfig: UIConfigPlainClientAPI
   userUIConfig: UserUIConfigPlainClientAPI
@@ -743,6 +745,7 @@ export type PlainClientAPI = {
   oauthApplication: OAuthApplicationPlainClientAPI
   experience: ExperiencePlainClientAPI
   experienceFragment: ExperienceFragmentPlainClientAPI
+  experienceTemplate: ExperienceTemplatePlainClientAPI
   semanticSearch: SemanticSearchPlainClientAPI
   semanticDuplicates: SemanticDuplicatesPlainClientAPI
   semanticRecommendations: SemanticRecommendationsPlainClientAPI

--- a/lib/plain/plain-client-types.ts
+++ b/lib/plain/plain-client-types.ts
@@ -153,6 +153,7 @@ import type { SemanticSearchPlainClientAPI } from './entities/semantic-search'
 import type { SemanticSettingsPlainClientAPI } from './entities/semantic-settings'
 import type { ContentSemanticsIndexPlainClientAPI } from './entities/content-semantics-index'
 import type { ComponentTypePlainClientAPI } from './entities/component-type'
+import type { ComponentPlainClientAPI } from './entities/component'
 import type { DataAssemblyPlainClientAPI } from './entities/data-assembly'
 import type { ExperiencePlainClientAPI } from './entities/experience'
 import type { ExperienceFragmentPlainClientAPI } from './entities/experience-fragment'
@@ -289,7 +290,9 @@ export type PlainClientAPI = {
     >
   }
   comment: CommentPlainClientAPI
+  /** @deprecated Use `component` instead. The `componentType` endpoint is superseded by `component`. */
   componentType: ComponentTypePlainClientAPI
+  component: ComponentPlainClientAPI
   dataAssembly: DataAssemblyPlainClientAPI
   concept: ConceptPlainClientAPI
   conceptScheme: ConceptSchemePlainClientAPI

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -247,6 +247,15 @@ export const createPlainClient = (
       publish: wrap(wrapParams, 'ComponentType', 'publish'),
       unpublish: wrap(wrapParams, 'ComponentType', 'unpublish'),
     },
+    component: {
+      getMany: wrap(wrapParams, 'Component', 'getMany'),
+      get: wrap(wrapParams, 'Component', 'get'),
+      create: wrap(wrapParams, 'Component', 'create'),
+      upsert: wrap(wrapParams, 'Component', 'upsert'),
+      delete: wrap(wrapParams, 'Component', 'delete'),
+      publish: wrap(wrapParams, 'Component', 'publish'),
+      unpublish: wrap(wrapParams, 'Component', 'unpublish'),
+    },
     contentType: {
       get: wrap(wrapParams, 'ContentType', 'get'),
       getMany: wrap(wrapParams, 'ContentType', 'getMany'),

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -663,6 +663,15 @@ export const createPlainClient = (
       publish: wrap(wrapParams, 'Experience', 'publish'),
       unpublish: wrap(wrapParams, 'Experience', 'unpublish'),
     },
+    experienceFragment: {
+      getMany: wrap(wrapParams, 'ExperienceFragment', 'getMany'),
+      get: wrap(wrapParams, 'ExperienceFragment', 'get'),
+      create: wrap(wrapParams, 'ExperienceFragment', 'create'),
+      upsert: wrap(wrapParams, 'ExperienceFragment', 'upsert'),
+      delete: wrap(wrapParams, 'ExperienceFragment', 'delete'),
+      publish: wrap(wrapParams, 'ExperienceFragment', 'publish'),
+      unpublish: wrap(wrapParams, 'ExperienceFragment', 'unpublish'),
+    },
     workflowDefinition: {
       get: wrap(wrapParams, 'WorkflowDefinition', 'get'),
       getMany: wrap(wrapParams, 'WorkflowDefinition', 'getMany'),

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -672,6 +672,15 @@ export const createPlainClient = (
       publish: wrap(wrapParams, 'ExperienceFragment', 'publish'),
       unpublish: wrap(wrapParams, 'ExperienceFragment', 'unpublish'),
     },
+    experienceTemplate: {
+      getMany: wrap(wrapParams, 'ExperienceTemplate', 'getMany'),
+      get: wrap(wrapParams, 'ExperienceTemplate', 'get'),
+      create: wrap(wrapParams, 'ExperienceTemplate', 'create'),
+      upsert: wrap(wrapParams, 'ExperienceTemplate', 'upsert'),
+      delete: wrap(wrapParams, 'ExperienceTemplate', 'delete'),
+      publish: wrap(wrapParams, 'ExperienceTemplate', 'publish'),
+      unpublish: wrap(wrapParams, 'ExperienceTemplate', 'unpublish'),
+    },
     workflowDefinition: {
       get: wrap(wrapParams, 'WorkflowDefinition', 'get'),
       getMany: wrap(wrapParams, 'WorkflowDefinition', 'getMany'),

--- a/test/integration/component-integration.test.ts
+++ b/test/integration/component-integration.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
+import { TestDefaults } from '../defaults'
+import { testName, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
+
+describe('Component Integration', { sequential: true }, () => {
+  const client = initPlainClient({
+    spaceId: TestDefaults.spaceId,
+    environmentId: TestDefaults.environmentId,
+  })
+
+  const createdIds: string[] = []
+  let componentId: string
+
+  beforeAll(async () => {
+    await sweepStaleExoEntities(client)
+
+    const created = await client.component.create(
+      {},
+      {
+        name: testName('Component'),
+        description: 'Created by integration test',
+        viewports: [testViewport],
+        contentProperties: [{ id: 'title', name: 'Title', type: 'String', required: false }],
+        designProperties: [{ id: 'color', name: 'Color', type: 'String' }],
+      },
+    )
+    componentId = created.sys.id
+    createdIds.push(componentId)
+  })
+
+  afterAll(async () => {
+    for (const id of createdIds) {
+      try {
+        const latest = await client.component.get({ componentId: id })
+        if (latest.sys.publishedVersion) {
+          await client.component.unpublish({
+            componentId: id,
+            version: latest.sys.version,
+          })
+        }
+        await client.component.delete({ componentId: id })
+      } catch {
+        // entity already deleted or not found
+      }
+    }
+
+    await timeoutToCalmRateLimiting()
+  })
+
+  it('has correct sys fields after creation', async () => {
+    const component = await client.component.get({ componentId })
+
+    expect(component.sys.id).toBeDefined()
+    expect(component.sys.type).toBe('Component')
+    expect(component.sys.version).toBeGreaterThanOrEqual(1)
+    expect(component.sys.createdAt).toBeDefined()
+    expect(component.sys.updatedAt).toBeDefined()
+    expect(component.sys.createdBy).toBeDefined()
+    expect(component.name).toBe(testName('Component'))
+    expect(component.description).toBe('Created by integration test')
+  })
+
+  it('gets a component by ID', async () => {
+    const fetched = await client.component.get({ componentId })
+
+    expect(fetched.sys.id).toBe(componentId)
+    expect(fetched.sys.type).toBe('Component')
+    expect(fetched.contentProperties).toHaveLength(1)
+    expect(fetched.designProperties).toHaveLength(1)
+  })
+
+  it('upserts a component', async () => {
+    const current = await client.component.get({ componentId })
+
+    const { sys, ...body } = current
+    const updated = await client.component.upsert(
+      { componentId },
+      {
+        sys: { id: sys.id, type: 'Component', version: sys.version },
+        ...body,
+        name: testName('Component Updated'),
+      },
+    )
+
+    expect(updated.name).toBe(testName('Component Updated'))
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+  })
+
+  it('lists components with cursor pagination', async () => {
+    const collection = await client.component.getMany({ query: { limit: 10 } })
+
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
+    expect(collection.pages).toBeDefined()
+
+    const found = collection.items.find((item) => item.sys.id === componentId)
+    expect(found).toBeDefined()
+  })
+
+  it('publishes a component', async () => {
+    const current = await client.component.get({ componentId })
+
+    const published = await client.component.publish({
+      componentId,
+      version: current.sys.version,
+    })
+
+    expect(published.sys.publishedVersion).toBeDefined()
+    expect(published.sys.publishedAt).toBeDefined()
+  })
+
+  it('unpublishes a component', async () => {
+    const current = await client.component.get({ componentId })
+
+    const unpublished = await client.component.unpublish({
+      componentId,
+      version: current.sys.version,
+    })
+
+    expect(unpublished.sys.publishedVersion).toBeUndefined()
+  })
+
+  it('rejects creation with missing required fields', async () => {
+    await expect(
+      client.component.create({}, {
+        description: 'Should fail — missing name and viewports',
+        contentProperties: [],
+        designProperties: [],
+      } as any),
+    ).rejects.toThrow()
+  })
+
+  it('rejects delete on a published entity', async () => {
+    const current = await client.component.get({ componentId })
+    if (!current.sys.publishedVersion) {
+      await client.component.publish({
+        componentId,
+        version: current.sys.version,
+      })
+    }
+
+    await expect(client.component.delete({ componentId })).rejects.toThrow()
+
+    const latest = await client.component.get({ componentId })
+    await client.component.unpublish({
+      componentId,
+      version: latest.sys.version,
+    })
+  })
+
+  it('deletes a component', async () => {
+    const current = await client.component.get({ componentId })
+    expect(current.sys.publishedVersion).toBeUndefined()
+
+    await client.component.delete({ componentId })
+
+    await expect(client.component.get({ componentId })).rejects.toThrow()
+
+    const idx = createdIds.indexOf(componentId)
+    if (idx !== -1) createdIds.splice(idx, 1)
+  })
+})

--- a/test/integration/experience-fragment-integration.test.ts
+++ b/test/integration/experience-fragment-integration.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
+import { TestDefaults } from '../defaults'
+import { testName, testViewport, sweepStaleExoEntities, makeResourceLink } from './utils/exo.utils'
+
+describe('ExperienceFragment Integration', { sequential: true }, () => {
+  const client = initPlainClient({
+    spaceId: TestDefaults.spaceId,
+    environmentId: TestDefaults.environmentId,
+  })
+
+  const createdExperienceFragmentIds: string[] = []
+  const createdComponentTypeIds: string[] = []
+  let experienceFragmentId: string
+  let componentTypeId: string
+
+  beforeAll(async () => {
+    await sweepStaleExoEntities(client)
+
+    const ct = await client.componentType.create(
+      {},
+      {
+        name: testName('CT for ExperienceFragment'),
+        description: 'Backing component type for experience fragment integration test',
+        viewports: [testViewport],
+        contentProperties: [],
+        designProperties: [],
+      },
+    )
+    componentTypeId = ct.sys.id
+    createdComponentTypeIds.push(componentTypeId)
+
+    await client.componentType.publish({
+      componentTypeId: componentTypeId,
+      version: ct.sys.version,
+    })
+
+    const ef = await client.experienceFragment.create(
+      {},
+      {
+        name: testName('ExperienceFragment'),
+        description: 'Created by integration test',
+        component: makeResourceLink('Contentful:Component', componentTypeId),
+        viewports: [testViewport],
+        designProperties: {},
+      },
+    )
+    experienceFragmentId = ef.sys.id
+    createdExperienceFragmentIds.push(experienceFragmentId)
+  })
+
+  afterAll(async () => {
+    for (const id of createdExperienceFragmentIds) {
+      try {
+        const latest = await client.experienceFragment.get({ experienceFragmentId: id })
+        if (latest.sys.publishedVersion) {
+          await client.experienceFragment.unpublish({
+            experienceFragmentId: id,
+            version: latest.sys.version,
+          })
+        }
+        await client.experienceFragment.delete({ experienceFragmentId: id })
+      } catch {
+        // entity already deleted or not found
+      }
+    }
+
+    for (const id of createdComponentTypeIds) {
+      try {
+        const latest = await client.componentType.get({ componentTypeId: id })
+        if (latest.sys.publishedVersion) {
+          await client.componentType.unpublish({
+            componentTypeId: id,
+            version: latest.sys.version,
+          })
+        }
+        await client.componentType.delete({ componentTypeId: id })
+      } catch {
+        // entity already deleted or not found
+      }
+    }
+
+    await timeoutToCalmRateLimiting()
+  })
+
+  it('has correct sys fields after creation', async () => {
+    const ef = await client.experienceFragment.get({ experienceFragmentId: experienceFragmentId })
+
+    expect(ef.sys.id).toBeDefined()
+    expect(ef.sys.type).toBe('ExperienceFragment')
+    expect(ef.sys.version).toBeGreaterThanOrEqual(1)
+    expect(ef.sys.createdAt).toBeDefined()
+    expect(ef.sys.updatedAt).toBeDefined()
+    expect(ef.sys.createdBy).toBeDefined()
+    expect(ef.sys.component).toBeDefined()
+    expect(ef.sys.component.sys.type).toBe('ResourceLink')
+    expect(ef.sys.component.sys.linkType).toBe('Contentful:Component')
+    expect(ef.sys.component.sys.urn).toContain(componentTypeId)
+    expect(ef.name).toBe(testName('ExperienceFragment'))
+  })
+
+  it('gets an experience fragment by ID', async () => {
+    const fetched = await client.experienceFragment.get({
+      experienceFragmentId: experienceFragmentId,
+    })
+
+    expect(fetched.sys.id).toBe(experienceFragmentId)
+    expect(fetched.sys.type).toBe('ExperienceFragment')
+  })
+
+  it('upserts an experience fragment', async () => {
+    const current = await client.experienceFragment.get({
+      experienceFragmentId: experienceFragmentId,
+    })
+
+    // Upsert types require minimal sys — full entity sys is not assignable
+    const updated = await client.experienceFragment.upsert(
+      { experienceFragmentId: experienceFragmentId },
+      {
+        ...current,
+        sys: {
+          id: current.sys.id,
+          type: 'ExperienceFragment' as const,
+          version: current.sys.version,
+        },
+        name: testName('ExperienceFragment Updated'),
+      },
+    )
+
+    expect(updated.name).toBe(testName('ExperienceFragment Updated'))
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+  })
+
+  it('lists experience fragments with cursor pagination', async () => {
+    const collection = await client.experienceFragment.getMany({ query: { limit: 10 } })
+
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
+    expect(collection.pages).toBeDefined()
+
+    const found = collection.items.find((item) => item.sys.id === experienceFragmentId)
+    expect(found).toBeDefined()
+  })
+
+  it('publishes an experience fragment', async () => {
+    const current = await client.experienceFragment.get({
+      experienceFragmentId: experienceFragmentId,
+    })
+
+    const published = await client.experienceFragment.publish({
+      experienceFragmentId: experienceFragmentId,
+      version: current.sys.version,
+    })
+
+    expect(published.sys.publishedVersion).toBeDefined()
+    expect(published.sys.publishedAt).toBeDefined()
+  })
+
+  it('unpublishes an experience fragment', async () => {
+    const current = await client.experienceFragment.get({
+      experienceFragmentId: experienceFragmentId,
+    })
+
+    const unpublished = await client.experienceFragment.unpublish({
+      experienceFragmentId: experienceFragmentId,
+      version: current.sys.version,
+    })
+
+    expect(unpublished.sys.publishedVersion).toBeUndefined()
+  })
+
+  it('rejects delete on a published entity', async () => {
+    const current = await client.experienceFragment.get({
+      experienceFragmentId: experienceFragmentId,
+    })
+    if (!current.sys.publishedVersion) {
+      await client.experienceFragment.publish({
+        experienceFragmentId: experienceFragmentId,
+        version: current.sys.version,
+      })
+    }
+
+    await expect(
+      client.experienceFragment.delete({ experienceFragmentId: experienceFragmentId }),
+    ).rejects.toThrow()
+
+    const latest = await client.experienceFragment.get({
+      experienceFragmentId: experienceFragmentId,
+    })
+    await client.experienceFragment.unpublish({
+      experienceFragmentId: experienceFragmentId,
+      version: latest.sys.version,
+    })
+  })
+
+  it('deletes an experience fragment', async () => {
+    const current = await client.experienceFragment.get({
+      experienceFragmentId: experienceFragmentId,
+    })
+    expect(current.sys.publishedVersion).toBeUndefined()
+
+    await client.experienceFragment.delete({ experienceFragmentId: experienceFragmentId })
+
+    await expect(
+      client.experienceFragment.get({ experienceFragmentId: experienceFragmentId }),
+    ).rejects.toThrow()
+
+    const idx = createdExperienceFragmentIds.indexOf(experienceFragmentId)
+    if (idx !== -1) createdExperienceFragmentIds.splice(idx, 1)
+  })
+})

--- a/test/integration/experience-integration.test.ts
+++ b/test/integration/experience-integration.test.ts
@@ -41,7 +41,7 @@ describe('Experience Integration', { sequential: true }, () => {
       {
         name: testName('Experience'),
         description: 'Created by integration test',
-        template: makeResourceLink('Contentful:Template', templateId),
+        experienceTemplate: makeResourceLink('Contentful:ExperienceTemplate', templateId),
         viewports: [testViewport],
         designProperties: {},
       },
@@ -93,9 +93,9 @@ describe('Experience Integration', { sequential: true }, () => {
     expect(exp.sys.createdAt).toBeDefined()
     expect(exp.sys.updatedAt).toBeDefined()
     expect(exp.sys.createdBy).toBeDefined()
-    expect(exp.sys.template.sys.type).toBe('ResourceLink')
-    expect(exp.sys.template.sys.linkType).toBe('Contentful:Template')
-    expect(exp.sys.template.sys.urn).toContain(templateId)
+    expect(exp.sys.experienceTemplate.sys.type).toBe('ResourceLink')
+    expect(exp.sys.experienceTemplate.sys.linkType).toBe('Contentful:ExperienceTemplate')
+    expect(exp.sys.experienceTemplate.sys.urn).toContain(templateId)
     expect(exp.name).toBe(testName('Experience'))
   })
 

--- a/test/integration/experience-template-integration.test.ts
+++ b/test/integration/experience-template-integration.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
+import { TestDefaults } from '../defaults'
+import { testName, testViewport, sweepStaleExoEntities } from './utils/exo.utils'
+
+describe('ExperienceTemplate Integration', { sequential: true }, () => {
+  const client = initPlainClient({
+    spaceId: TestDefaults.spaceId,
+    environmentId: TestDefaults.environmentId,
+  })
+
+  const createdIds: string[] = []
+  let experienceTemplateId: string
+
+  beforeAll(async () => {
+    await sweepStaleExoEntities(client)
+
+    const created = await client.experienceTemplate.create(
+      {},
+      {
+        name: testName('ExperienceTemplate'),
+        description: 'Created by integration test',
+        viewports: [testViewport],
+        contentProperties: [{ id: 'heading', name: 'Heading', type: 'String', required: false }],
+        designProperties: [{ id: 'bgColor', name: 'Background Color', type: 'String' }],
+      },
+    )
+    experienceTemplateId = created.sys.id
+    createdIds.push(experienceTemplateId)
+  })
+
+  afterAll(async () => {
+    for (const id of createdIds) {
+      try {
+        const latest = await client.experienceTemplate.get({ experienceTemplateId: id })
+        if (latest.sys.publishedVersion) {
+          await client.experienceTemplate.unpublish({
+            experienceTemplateId: id,
+            version: latest.sys.version,
+          })
+        }
+        await client.experienceTemplate.delete({ experienceTemplateId: id })
+      } catch {
+        // entity already deleted or not found
+      }
+    }
+
+    await timeoutToCalmRateLimiting()
+  })
+
+  it('has correct sys fields after creation', async () => {
+    const experienceTemplate = await client.experienceTemplate.get({ experienceTemplateId })
+
+    expect(experienceTemplate.sys.id).toBeDefined()
+    expect(experienceTemplate.sys.type).toBe('ExperienceTemplate')
+    expect(experienceTemplate.sys.version).toBeGreaterThanOrEqual(1)
+    expect(experienceTemplate.sys.createdAt).toBeDefined()
+    expect(experienceTemplate.sys.updatedAt).toBeDefined()
+    expect(experienceTemplate.sys.createdBy).toBeDefined()
+    expect(experienceTemplate.name).toBe(testName('ExperienceTemplate'))
+    expect(experienceTemplate.description).toBe('Created by integration test')
+  })
+
+  it('gets an experience template by ID', async () => {
+    const fetched = await client.experienceTemplate.get({ experienceTemplateId })
+
+    expect(fetched.sys.id).toBe(experienceTemplateId)
+    expect(fetched.sys.type).toBe('ExperienceTemplate')
+    expect(fetched.contentProperties).toHaveLength(1)
+    expect(fetched.designProperties).toHaveLength(1)
+  })
+
+  it('upserts an experience template', async () => {
+    const current = await client.experienceTemplate.get({ experienceTemplateId })
+
+    const { sys, ...body } = current
+    const updated = await client.experienceTemplate.upsert(
+      { experienceTemplateId },
+      {
+        sys: { id: sys.id, type: 'ExperienceTemplate', version: sys.version },
+        ...body,
+        name: testName('ExperienceTemplate Updated'),
+      },
+    )
+
+    expect(updated.name).toBe(testName('ExperienceTemplate Updated'))
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+  })
+
+  it('lists experience templates with cursor pagination', async () => {
+    const collection = await client.experienceTemplate.getMany({ query: { limit: 10 } })
+
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
+    expect(collection.pages).toBeDefined()
+
+    const found = collection.items.find((item) => item.sys.id === experienceTemplateId)
+    expect(found).toBeDefined()
+  })
+
+  it('publishes an experience template', async () => {
+    const current = await client.experienceTemplate.get({ experienceTemplateId })
+
+    const published = await client.experienceTemplate.publish({
+      experienceTemplateId,
+      version: current.sys.version,
+    })
+
+    expect(published.sys.publishedVersion).toBeDefined()
+    expect(published.sys.publishedAt).toBeDefined()
+  })
+
+  it('unpublishes an experience template', async () => {
+    const current = await client.experienceTemplate.get({ experienceTemplateId })
+
+    const unpublished = await client.experienceTemplate.unpublish({
+      experienceTemplateId,
+      version: current.sys.version,
+    })
+
+    expect(unpublished.sys.publishedVersion).toBeUndefined()
+  })
+
+  it('rejects delete on a published entity', async () => {
+    const current = await client.experienceTemplate.get({ experienceTemplateId })
+    if (!current.sys.publishedVersion) {
+      await client.experienceTemplate.publish({
+        experienceTemplateId,
+        version: current.sys.version,
+      })
+    }
+
+    await expect(client.experienceTemplate.delete({ experienceTemplateId })).rejects.toThrow()
+
+    const latest = await client.experienceTemplate.get({ experienceTemplateId })
+    await client.experienceTemplate.unpublish({
+      experienceTemplateId,
+      version: latest.sys.version,
+    })
+  })
+
+  it('deletes an experience template', async () => {
+    const current = await client.experienceTemplate.get({ experienceTemplateId })
+    expect(current.sys.publishedVersion).toBeUndefined()
+
+    await client.experienceTemplate.delete({ experienceTemplateId })
+
+    await expect(client.experienceTemplate.get({ experienceTemplateId })).rejects.toThrow()
+
+    const idx = createdIds.indexOf(experienceTemplateId)
+    if (idx !== -1) createdIds.splice(idx, 1)
+  })
+})

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -18,8 +18,11 @@ const EXO_CRN_PREFIX = 'crn:contentful:::experience:spaces/$self/environments/$s
 
 const entityPaths: Record<string, string> = {
   'Contentful:Template': 'templates',
+  'Contentful:ExperienceTemplate': 'experienceTemplates',
   'Contentful:ComponentType': 'componentTypes',
+  'Contentful:Component': 'components',
   'Contentful:Fragment': 'fragments',
+  'Contentful:ExperienceFragment': 'experienceFragments',
   'Contentful:DataAssembly': 'dataAssemblies',
 }
 

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -171,8 +171,36 @@ export async function sweepStaleExoEntities(
     }
   }
 
+  const sweepExperienceFragments = async () => {
+    try {
+      const { items } = await client.experienceFragment.getMany({ query: { limit: 100 } })
+      for (const item of items) {
+        if (item.name.startsWith(TEST_PREFIX) && new Date(item.sys.createdAt) < cutoff) {
+          try {
+            if (item.sys.publishedVersion) {
+              await client.experienceFragment.unpublish({
+                experienceFragmentId: item.sys.id,
+                version: item.sys.version,
+              })
+            }
+            await client.experienceFragment.delete({ experienceFragmentId: item.sys.id })
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    } catch {
+      // ignore if listing fails
+    }
+  }
+
   // Sweep dependents first, then parents
-  await Promise.all([sweepExperiences(), sweepFragments(), sweepDataAssemblies()])
+  await Promise.all([
+    sweepExperiences(),
+    sweepFragments(),
+    sweepExperienceFragments(),
+    sweepDataAssemblies(),
+  ])
   await sweepTemplates()
   await sweepComponentTypes()
 }

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -194,6 +194,29 @@ export async function sweepStaleExoEntities(
     }
   }
 
+  const sweepExperienceTemplates = async () => {
+    try {
+      const { items } = await client.experienceTemplate.getMany({ query: { limit: 100 } })
+      for (const item of items) {
+        if (item.name.startsWith(TEST_PREFIX) && new Date(item.sys.createdAt) < cutoff) {
+          try {
+            if (item.sys.publishedVersion) {
+              await client.experienceTemplate.unpublish({
+                experienceTemplateId: item.sys.id,
+                version: item.sys.version,
+              })
+            }
+            await client.experienceTemplate.delete({ experienceTemplateId: item.sys.id })
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    } catch {
+      // ignore if listing fails
+    }
+  }
+
   // Sweep dependents first, then parents
   await Promise.all([
     sweepExperiences(),
@@ -202,5 +225,6 @@ export async function sweepStaleExoEntities(
     sweepDataAssemblies(),
   ])
   await sweepTemplates()
+  await sweepExperienceTemplates()
   await sweepComponentTypes()
 }

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -217,6 +217,29 @@ export async function sweepStaleExoEntities(
     }
   }
 
+  const sweepComponents = async () => {
+    try {
+      const { items } = await client.component.getMany({ query: { limit: 100 } })
+      for (const item of items) {
+        if (item.name.startsWith(TEST_PREFIX) && new Date(item.sys.createdAt) < cutoff) {
+          try {
+            if (item.sys.publishedVersion) {
+              await client.component.unpublish({
+                componentId: item.sys.id,
+                version: item.sys.version,
+              })
+            }
+            await client.component.delete({ componentId: item.sys.id })
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    } catch {
+      // ignore if listing fails
+    }
+  }
+
   // Sweep dependents first, then parents
   await Promise.all([
     sweepExperiences(),
@@ -227,4 +250,5 @@ export async function sweepStaleExoEntities(
   await sweepTemplates()
   await sweepExperienceTemplates()
   await sweepComponentTypes()
+  await sweepComponents()
 }

--- a/test/unit/adapters/REST/endpoints/component.test.ts
+++ b/test/unit/adapters/REST/endpoints/component.test.ts
@@ -1,0 +1,243 @@
+import { describe, test, expect } from 'vitest'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+
+describe('Rest Component', { concurrent: true }, () => {
+  test('getMany calls correct URL', async () => {
+    const mockResponse = {
+      sys: { type: 'Array' },
+      limit: 100,
+      items: [],
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Component',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          query: {},
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/components',
+        )
+        expect(httpMock.get.mock.calls[0][1].params).to.eql({})
+      })
+  })
+
+  test('getMany passes pagination query parameters', async () => {
+    const mockResponse = {
+      sys: { type: 'Array' },
+      limit: 20,
+      items: [],
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Component',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          query: {
+            limit: 20,
+            pageNext: 'next-page-token',
+          },
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/components',
+        )
+        expect(httpMock.get.mock.calls[0][1].params).to.eql({
+          limit: 20,
+          pageNext: 'next-page-token',
+        })
+      })
+  })
+
+  test('get calls correct URL', async () => {
+    const mockResponse = {
+      sys: { id: 'c123', type: 'Component' },
+      name: 'Test Component',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Component',
+        action: 'get',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          componentId: 'c123',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/components/c123',
+        )
+      })
+  })
+
+  test('create calls correct URL with POST', async () => {
+    const mockResponse = {
+      sys: { id: 'c123', type: 'Component' },
+      name: 'New Component',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Component',
+        action: 'create',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+        },
+        payload: {
+          name: 'New Component',
+          description: 'A new component',
+          viewports: [],
+          contentProperties: [],
+          designProperties: [],
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.post.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/components',
+        )
+        const body = httpMock.post.mock.calls[0][1]
+        expect(body.name).to.eql('New Component')
+      })
+  })
+
+  test('upsert calls correct URL with PUT and X-Contentful-Version header', async () => {
+    const mockResponse = {
+      sys: { id: 'c123', type: 'Component', version: 2 },
+      name: 'Updated Component',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Component',
+        action: 'upsert',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          componentId: 'c123',
+        },
+        payload: {
+          sys: { id: 'c123', type: 'Component', version: 1 },
+          name: 'Updated Component',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/components/c123',
+        )
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
+        const body = httpMock.put.mock.calls[0][1]
+        expect(body.sys).to.be.undefined
+      })
+  })
+
+  test('delete calls correct URL', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: '' }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Component',
+        action: 'delete',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          componentId: 'c123',
+        },
+      })
+      .then(() => {
+        expect(httpMock.delete.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/components/c123',
+        )
+      })
+  })
+
+  test('publish calls correct URL with PUT and X-Contentful-Version header', async () => {
+    const mockResponse = {
+      sys: { id: 'c123', type: 'Component', version: 2, publishedVersion: 1 },
+      name: 'Test Component',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Component',
+        action: 'publish',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          componentId: 'c123',
+          version: 1,
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/components/c123/published',
+        )
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
+      })
+  })
+
+  test('unpublish calls correct URL with DELETE and X-Contentful-Version header', async () => {
+    const mockResponse = {
+      sys: { id: 'c123', type: 'Component', version: 3 },
+      name: 'Test Component',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'Component',
+        action: 'unpublish',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          componentId: 'c123',
+          version: 2,
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.delete.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/components/c123/published',
+        )
+        expect(httpMock.delete.mock.calls[0][1].headers['X-Contentful-Version']).to.eql(2)
+      })
+  })
+})

--- a/test/unit/adapters/REST/endpoints/experience-fragment.test.ts
+++ b/test/unit/adapters/REST/endpoints/experience-fragment.test.ts
@@ -1,11 +1,8 @@
 import { describe, test, expect } from 'vitest'
 import setupRestAdapter from '../helpers/setupRestAdapter'
 
-const ALPHA_HEADER = 'x-contentful-enable-alpha-feature'
-const ALPHA_VALUE = 'new-exo-entity-types'
-
 describe('Rest ExperienceFragment', { concurrent: true }, () => {
-  test('getMany calls correct URL and sends alpha header', async () => {
+  test('getMany calls correct URL', async () => {
     const mockResponse = {
       sys: { type: 'Array' },
       limit: 100,
@@ -28,10 +25,9 @@ describe('Rest ExperienceFragment', { concurrent: true }, () => {
       .then((r) => {
         expect(r).to.eql(mockResponse)
         expect(httpMock.get.mock.calls[0][0]).to.eql(
-          '/spaces/space123/environments/master/experienceFragments',
+          '/spaces/space123/environments/master/experience_fragments',
         )
         expect(httpMock.get.mock.calls[0][1].params).to.eql({})
-        expect(httpMock.get.mock.calls[0][1].headers[ALPHA_HEADER]).to.eql(ALPHA_VALUE)
       })
   })
 
@@ -61,7 +57,7 @@ describe('Rest ExperienceFragment', { concurrent: true }, () => {
       .then((r) => {
         expect(r).to.eql(mockResponse)
         expect(httpMock.get.mock.calls[0][0]).to.eql(
-          '/spaces/space123/environments/master/experienceFragments',
+          '/spaces/space123/environments/master/experience_fragments',
         )
         expect(httpMock.get.mock.calls[0][1].params).to.eql({
           limit: 20,
@@ -70,7 +66,7 @@ describe('Rest ExperienceFragment', { concurrent: true }, () => {
       })
   })
 
-  test('get calls correct URL and sends alpha header', async () => {
+  test('get calls correct URL', async () => {
     const mockResponse = {
       sys: { id: 'ef123', type: 'ExperienceFragment' },
       name: 'Test Experience Fragment',
@@ -92,9 +88,8 @@ describe('Rest ExperienceFragment', { concurrent: true }, () => {
       .then((r) => {
         expect(r).to.eql(mockResponse)
         expect(httpMock.get.mock.calls[0][0]).to.eql(
-          '/spaces/space123/environments/master/experienceFragments/ef123',
+          '/spaces/space123/environments/master/experience_fragments/ef123',
         )
-        expect(httpMock.get.mock.calls[0][1].headers[ALPHA_HEADER]).to.eql(ALPHA_VALUE)
       })
   })
 
@@ -134,11 +129,10 @@ describe('Rest ExperienceFragment', { concurrent: true }, () => {
       .then((r) => {
         expect(r).to.eql(mockResponse)
         expect(httpMock.post.mock.calls[0][0]).to.eql(
-          '/spaces/space123/environments/master/experienceFragments',
+          '/spaces/space123/environments/master/experience_fragments',
         )
         const body = httpMock.post.mock.calls[0][1]
         expect(body.component).to.eql(componentLink)
-        expect(httpMock.post.mock.calls[0][2].headers[ALPHA_HEADER]).to.eql(ALPHA_VALUE)
       })
   })
 
@@ -168,16 +162,15 @@ describe('Rest ExperienceFragment', { concurrent: true }, () => {
       .then((r) => {
         expect(r).to.eql(mockResponse)
         expect(httpMock.put.mock.calls[0][0]).to.eql(
-          '/spaces/space123/environments/master/experienceFragments/ef123',
+          '/spaces/space123/environments/master/experience_fragments/ef123',
         )
         expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
-        expect(httpMock.put.mock.calls[0][2].headers[ALPHA_HEADER]).to.eql(ALPHA_VALUE)
         const body = httpMock.put.mock.calls[0][1]
         expect(body.sys).to.be.undefined
       })
   })
 
-  test('delete calls correct URL and sends alpha header', async () => {
+  test('delete calls correct URL', async () => {
     const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: '' }))
 
     return adapterMock
@@ -193,9 +186,8 @@ describe('Rest ExperienceFragment', { concurrent: true }, () => {
       })
       .then(() => {
         expect(httpMock.delete.mock.calls[0][0]).to.eql(
-          '/spaces/space123/environments/master/experienceFragments/ef123',
+          '/spaces/space123/environments/master/experience_fragments/ef123',
         )
-        expect(httpMock.delete.mock.calls[0][1].headers[ALPHA_HEADER]).to.eql(ALPHA_VALUE)
       })
   })
 
@@ -222,10 +214,9 @@ describe('Rest ExperienceFragment', { concurrent: true }, () => {
       .then((r) => {
         expect(r).to.eql(mockResponse)
         expect(httpMock.put.mock.calls[0][0]).to.eql(
-          '/spaces/space123/environments/master/experienceFragments/ef123/published',
+          '/spaces/space123/environments/master/experience_fragments/ef123/published',
         )
         expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
-        expect(httpMock.put.mock.calls[0][2].headers[ALPHA_HEADER]).to.eql(ALPHA_VALUE)
       })
   })
 
@@ -252,10 +243,9 @@ describe('Rest ExperienceFragment', { concurrent: true }, () => {
       .then((r) => {
         expect(r).to.eql(mockResponse)
         expect(httpMock.delete.mock.calls[0][0]).to.eql(
-          '/spaces/space123/environments/master/experienceFragments/ef123/published',
+          '/spaces/space123/environments/master/experience_fragments/ef123/published',
         )
         expect(httpMock.delete.mock.calls[0][1].headers['X-Contentful-Version']).to.eql(2)
-        expect(httpMock.delete.mock.calls[0][1].headers[ALPHA_HEADER]).to.eql(ALPHA_VALUE)
       })
   })
 })

--- a/test/unit/adapters/REST/endpoints/experience-fragment.test.ts
+++ b/test/unit/adapters/REST/endpoints/experience-fragment.test.ts
@@ -1,0 +1,261 @@
+import { describe, test, expect } from 'vitest'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+
+const ALPHA_HEADER = 'x-contentful-enable-alpha-feature'
+const ALPHA_VALUE = 'new-exo-entity-types'
+
+describe('Rest ExperienceFragment', { concurrent: true }, () => {
+  test('getMany calls correct URL and sends alpha header', async () => {
+    const mockResponse = {
+      sys: { type: 'Array' },
+      limit: 100,
+      items: [],
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceFragment',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          query: {},
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experienceFragments',
+        )
+        expect(httpMock.get.mock.calls[0][1].params).to.eql({})
+        expect(httpMock.get.mock.calls[0][1].headers[ALPHA_HEADER]).to.eql(ALPHA_VALUE)
+      })
+  })
+
+  test('getMany passes pagination query parameters', async () => {
+    const mockResponse = {
+      sys: { type: 'Array' },
+      limit: 20,
+      items: [],
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceFragment',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          query: {
+            limit: 20,
+            pageNext: 'next-page-token',
+          },
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experienceFragments',
+        )
+        expect(httpMock.get.mock.calls[0][1].params).to.eql({
+          limit: 20,
+          pageNext: 'next-page-token',
+        })
+      })
+  })
+
+  test('get calls correct URL and sends alpha header', async () => {
+    const mockResponse = {
+      sys: { id: 'ef123', type: 'ExperienceFragment' },
+      name: 'Test Experience Fragment',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceFragment',
+        action: 'get',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          experienceFragmentId: 'ef123',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experienceFragments/ef123',
+        )
+        expect(httpMock.get.mock.calls[0][1].headers[ALPHA_HEADER]).to.eql(ALPHA_VALUE)
+      })
+  })
+
+  test('create calls correct URL with POST and passes component link', async () => {
+    const mockResponse = {
+      sys: { id: 'ef123', type: 'ExperienceFragment' },
+      name: 'New Experience Fragment',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    const componentLink = {
+      sys: {
+        type: 'ResourceLink',
+        linkType: 'Contentful:Component',
+        urn: 'crn:contentful:::experience:spaces/space123/environments/master/components/ct-abc',
+      },
+    }
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceFragment',
+        action: 'create',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+        },
+        payload: {
+          name: 'New Experience Fragment',
+          description: 'A new experience fragment',
+          component: componentLink,
+          viewports: [],
+          designProperties: {},
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.post.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experienceFragments',
+        )
+        const body = httpMock.post.mock.calls[0][1]
+        expect(body.component).to.eql(componentLink)
+        expect(httpMock.post.mock.calls[0][2].headers[ALPHA_HEADER]).to.eql(ALPHA_VALUE)
+      })
+  })
+
+  test('upsert calls correct URL with PUT and X-Contentful-Version header', async () => {
+    const mockResponse = {
+      sys: { id: 'ef123', type: 'ExperienceFragment', version: 2 },
+      name: 'Updated Experience Fragment',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceFragment',
+        action: 'upsert',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          experienceFragmentId: 'ef123',
+        },
+        payload: {
+          sys: { id: 'ef123', type: 'ExperienceFragment', version: 1 },
+          name: 'Updated Experience Fragment',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experienceFragments/ef123',
+        )
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
+        expect(httpMock.put.mock.calls[0][2].headers[ALPHA_HEADER]).to.eql(ALPHA_VALUE)
+        const body = httpMock.put.mock.calls[0][1]
+        expect(body.sys).to.be.undefined
+      })
+  })
+
+  test('delete calls correct URL and sends alpha header', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: '' }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceFragment',
+        action: 'delete',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          experienceFragmentId: 'ef123',
+        },
+      })
+      .then(() => {
+        expect(httpMock.delete.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experienceFragments/ef123',
+        )
+        expect(httpMock.delete.mock.calls[0][1].headers[ALPHA_HEADER]).to.eql(ALPHA_VALUE)
+      })
+  })
+
+  test('publish calls correct URL with PUT and X-Contentful-Version header', async () => {
+    const mockResponse = {
+      sys: { id: 'ef123', type: 'ExperienceFragment', version: 2, publishedVersion: 1 },
+      name: 'Test Experience Fragment',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceFragment',
+        action: 'publish',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          experienceFragmentId: 'ef123',
+          version: 1,
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experienceFragments/ef123/published',
+        )
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
+        expect(httpMock.put.mock.calls[0][2].headers[ALPHA_HEADER]).to.eql(ALPHA_VALUE)
+      })
+  })
+
+  test('unpublish calls correct URL with DELETE and X-Contentful-Version header', async () => {
+    const mockResponse = {
+      sys: { id: 'ef123', type: 'ExperienceFragment', version: 3 },
+      name: 'Test Experience Fragment',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceFragment',
+        action: 'unpublish',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          experienceFragmentId: 'ef123',
+          version: 2,
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.delete.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experienceFragments/ef123/published',
+        )
+        expect(httpMock.delete.mock.calls[0][1].headers['X-Contentful-Version']).to.eql(2)
+        expect(httpMock.delete.mock.calls[0][1].headers[ALPHA_HEADER]).to.eql(ALPHA_VALUE)
+      })
+  })
+})

--- a/test/unit/adapters/REST/endpoints/experience-template.test.ts
+++ b/test/unit/adapters/REST/endpoints/experience-template.test.ts
@@ -1,0 +1,243 @@
+import { describe, test, expect } from 'vitest'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+
+describe('Rest ExperienceTemplate', { concurrent: true }, () => {
+  test('getMany calls correct URL', async () => {
+    const mockResponse = {
+      sys: { type: 'Array' },
+      limit: 100,
+      items: [],
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceTemplate',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          query: {},
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experience_templates',
+        )
+        expect(httpMock.get.mock.calls[0][1].params).to.eql({})
+      })
+  })
+
+  test('getMany passes pagination query parameters', async () => {
+    const mockResponse = {
+      sys: { type: 'Array' },
+      limit: 20,
+      items: [],
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceTemplate',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          query: {
+            limit: 20,
+            pageNext: 'next-page-token',
+          },
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experience_templates',
+        )
+        expect(httpMock.get.mock.calls[0][1].params).to.eql({
+          limit: 20,
+          pageNext: 'next-page-token',
+        })
+      })
+  })
+
+  test('get calls correct URL', async () => {
+    const mockResponse = {
+      sys: { id: 'et123', type: 'ExperienceTemplate' },
+      name: 'Test Experience Template',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceTemplate',
+        action: 'get',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          experienceTemplateId: 'et123',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experience_templates/et123',
+        )
+      })
+  })
+
+  test('create calls correct URL with POST', async () => {
+    const mockResponse = {
+      sys: { id: 'et123', type: 'ExperienceTemplate' },
+      name: 'New Experience Template',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceTemplate',
+        action: 'create',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+        },
+        payload: {
+          name: 'New Experience Template',
+          description: 'A new experience template',
+          viewports: [],
+          contentProperties: [],
+          designProperties: [],
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.post.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experience_templates',
+        )
+        const body = httpMock.post.mock.calls[0][1]
+        expect(body.name).to.eql('New Experience Template')
+      })
+  })
+
+  test('upsert calls correct URL with PUT and X-Contentful-Version header', async () => {
+    const mockResponse = {
+      sys: { id: 'et123', type: 'ExperienceTemplate', version: 2 },
+      name: 'Updated Experience Template',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceTemplate',
+        action: 'upsert',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          experienceTemplateId: 'et123',
+        },
+        payload: {
+          sys: { id: 'et123', type: 'ExperienceTemplate', version: 1 },
+          name: 'Updated Experience Template',
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experience_templates/et123',
+        )
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
+        const body = httpMock.put.mock.calls[0][1]
+        expect(body.sys).to.be.undefined
+      })
+  })
+
+  test('delete calls correct URL', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: '' }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceTemplate',
+        action: 'delete',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          experienceTemplateId: 'et123',
+        },
+      })
+      .then(() => {
+        expect(httpMock.delete.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experience_templates/et123',
+        )
+      })
+  })
+
+  test('publish calls correct URL with PUT and X-Contentful-Version header', async () => {
+    const mockResponse = {
+      sys: { id: 'et123', type: 'ExperienceTemplate', version: 2, publishedVersion: 1 },
+      name: 'Test Experience Template',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceTemplate',
+        action: 'publish',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          experienceTemplateId: 'et123',
+          version: 1,
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experience_templates/et123/published',
+        )
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(1)
+      })
+  })
+
+  test('unpublish calls correct URL with DELETE and X-Contentful-Version header', async () => {
+    const mockResponse = {
+      sys: { id: 'et123', type: 'ExperienceTemplate', version: 3 },
+      name: 'Test Experience Template',
+    }
+
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ExperienceTemplate',
+        action: 'unpublish',
+        userAgent: 'mocked',
+        params: {
+          spaceId: 'space123',
+          environmentId: 'master',
+          experienceTemplateId: 'et123',
+          version: 2,
+        },
+      })
+      .then((r) => {
+        expect(r).to.eql(mockResponse)
+        expect(httpMock.delete.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/experience_templates/et123/published',
+        )
+        expect(httpMock.delete.mock.calls[0][1].headers['X-Contentful-Version']).to.eql(2)
+      })
+  })
+})

--- a/test/unit/adapters/REST/endpoints/experience.test.ts
+++ b/test/unit/adapters/REST/endpoints/experience.test.ts
@@ -200,7 +200,7 @@ describe('Rest Experience', { concurrent: true }, () => {
       })
   })
 
-  test('create calls correct URL with POST and passes template link', async () => {
+  test('create calls correct URL with POST and passes experienceTemplate link', async () => {
     const mockResponse = {
       sys: { id: 'new-experience-123', type: 'Experience', version: 1 },
       name: 'New Experience',
@@ -211,7 +211,13 @@ describe('Rest Experience', { concurrent: true }, () => {
 
     const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: mockResponse }))
 
-    const templateLink = { sys: { type: 'Link', linkType: 'Template', id: 'tmpl-123' } }
+    const experienceTemplateLink = {
+      sys: {
+        type: 'ResourceLink',
+        linkType: 'Contentful:ExperienceTemplate',
+        urn: 'crn:contentful:::experience:spaces/space123/environments/master/experienceTemplates/tmpl-123',
+      },
+    }
 
     return adapterMock
       .makeRequest({
@@ -225,7 +231,7 @@ describe('Rest Experience', { concurrent: true }, () => {
         payload: {
           name: 'New Experience',
           description: 'A new experience',
-          template: templateLink,
+          experienceTemplate: experienceTemplateLink,
           viewports: [],
           designProperties: {},
         },
@@ -236,7 +242,10 @@ describe('Rest Experience', { concurrent: true }, () => {
           '/spaces/space123/environments/master/experiences',
         )
         const body = httpMock.post.mock.calls[0][1]
-        expect(body.template).to.eql(templateLink)
+        expect(body.experienceTemplate).to.eql(experienceTemplateLink)
+        expect(httpMock.post.mock.calls[0][2].headers['x-contentful-enable-alpha-feature']).to.eql(
+          'new-exo-entity-types',
+        )
       })
   })
 


### PR DESCRIPTION
Aligns the experiences-related management API with the renamed ("new ExO entity types") assemblies contract, and adds a new `experienceFragment` endpoint that deprecates the legacy `fragment` endpoint.

## Experience renames
- `Experience.sys.experienceTemplate` (`ResourceLink<'Contentful:ExperienceTemplate'>`) replaces `sys.template`.
- Experience slot trees use `ExperienceFragmentNode` / `InlineExperienceFragmentNode` (renamed nodes).
- All Experience endpoints send `x-contentful-enable-alpha-feature: new-exo-entity-types`.

## New `experienceFragment` endpoint
- New `ExperienceFragment` entity + REST endpoint at `/experienceFragments`, separate from `/fragments`.
- Uses the renamed shape: `sys.component` (`ResourceLink<'Contentful:Component'>`), `sys.type: 'ExperienceFragment'`, renamed slot nodes.
- Sends the `new-exo-entity-types` alpha header on every endpoint.
- Full wiring parity with Fragment/Experience: entity types, REST adapter + registration, plain client API + assembly, `common-types` overloads / adapter map / params, and type re-exports.

## Deprecations
- The `fragment` endpoint, `FragmentPlainClientAPI`, `FragmentSys`, and the `Fragment*` exported types are marked `@deprecated` in favor of `experienceFragment` / `ExperienceFragment*`.

## Scope notes (per feedback)
Limited to renames of surface the SDK already exposed. Excludes net-new surface: references, optimization variants, bulk actions, parameters, automationTags, template-urn filter, and the contentBindings shape divergence.

## Tests
- Unit: 893 passing (8 new ExperienceFragment adapter tests asserting URLs + alpha header).
- Types: 28 passing; `tsc --noEmit` clean; ESLint 0 errors.
- Added `experience-fragment-integration.test.ts` and an `exo.utils` sweep helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR aligns the experiences-related management API with the renamed ExO entity contract by adding three new entity endpoints (Component, ExperienceFragment, ExperienceTemplate) with full type definitions, REST adapters, and plain client APIs. The legacy entities (Fragment, Template, ComponentType) are marked as deprecated. The Experience endpoint now sends the `x-contentful-enable-alpha-feature: new-exo-entity-types` header on all operations.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds new Component entity at `/components` endpoint with sys.type='Component' using TreeNodeV2 (with renamed `component` link to Contentful:Component), replacing ComponentType. Includes REST adapter, plain client API (client.component), type definitions, and 8 unit tests validating URL construction and HTTP behavior.</li>

<li>Adds new ExperienceFragment entity at `/experience_fragments` endpoint with sys.type='ExperienceFragment' and sys.component (ResourceLink<Contentful:Component>), sending the new-exo-entity-types alpha header. Provides full parity with Fragment: REST adapter, plain client API (client.experienceFragment), common-types overloads, and integration tests.</li>

<li>Adds new ExperienceTemplate entity at `/experience_templates` endpoint with sys.type='ExperienceTemplate' replacing the legacy Template endpoint. Uses TreeNodeV2 component trees with ComponentSlotDefinition slots, and updates all Experience operations to pass the new alpha feature header.</li>

<li>Renames Experience entity fields: `sys.template` → `sys.experienceTemplate` (ResourceLink<Contentful:ExperienceTemplate>), slot node types `FragmentNode` → `ExperienceFragmentNode` and `InlineFragmentNode` → `InlineExperienceFragmentNode` with componentType → component link type changes.</li>

<li>Marks legacy Fragment, Template, and ComponentType entities with @deprecated JSDoc annotations pointing to new ExperienceFragment, ExperienceTemplate, and Component replacements respectively.</li>

</ul>
</details>

</div>