### PR TITLE
chore: install Tasks app in task integration test setup

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -7,6 +7,8 @@ on:
         required: true
       CONTENTFUL_ORGANIZATION_ID:
         required: true
+      TASKS_APP_DEFINITION_ID:
+        required: true
 
 jobs:
   test-integration:
@@ -41,3 +43,4 @@ jobs:
         env:
           CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN: ${{ secrets.CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN }}
           CONTENTFUL_ORGANIZATION_ID: ${{ secrets.CONTENTFUL_ORGANIZATION_ID }}
+          TASKS_APP_DEFINITION_ID: ${{ secrets.TASKS_APP_DEFINITION_ID }}

--- a/test/integration/task-integration.test.ts
+++ b/test/integration/task-integration.test.ts
@@ -9,6 +9,11 @@ import {
 } from '../helpers'
 import type { Space, Environment, Entry, Task, Link } from '../../lib/export-types'
 
+const TASKS_APP_DEFINITION_ID = process.env.TASKS_APP_DEFINITION_ID
+if (!TASKS_APP_DEFINITION_ID) {
+  throw new Error('TASKS_APP_DEFINITION_ID is required')
+}
+
 describe('Task API', () => {
   let space: Space
   let environment: Environment
@@ -25,6 +30,9 @@ describe('Task API', () => {
     space = await createTestSpace(defaultClient, 'Task')
     environment = await space.createEnvironment({ name: 'Task Testing Environment' })
     await waitForEnvironmentToBeReady(space, environment)
+    // Tasks must be explicitly installed per-environment; it is not installed by default
+    // on newly created spaces/environments (see CFISO-3416).
+    await environment.createAppInstallation(TASKS_APP_DEFINITION_ID, {}, { acceptAllTerms: true })
     const contentType = await environment.createContentType({ name: 'Content Type', fields: [] })
     await contentType.publish()
     entry = await environment.createEntry(contentType.sys.id, { fields: {} })


### PR DESCRIPTION
## Summary
- `test/integration/task-integration.test.ts` creates a brand-new space/environment per run and never installed the Tasks app on it, since this was never previously required.
- [CFISO-3416](https://contentful.atlassian.net/browse/CFISO-3416) ([comments-api#8625](https://github.com/contentful/comments-api/pull/8625)) shipped a new guard requiring the Tasks app to be installed in the target space/environment before a Task can be created. It rolled out to production shortly before this test started failing CI on `master` and every open PR with `AccessDenied: The Tasks app must be installed in this environment before tasks can be created.`
- Fix: explicitly install the Tasks app on the test environment in `beforeAll`, before creating any tasks — makes the test self-sufficient instead of depending on any pre-existing app installation. The app's Definition ID is read from a new `TASKS_APP_DEFINITION_ID` CI secret (wired through `test-integration.yaml`) rather than hardcoded, since it isn't publicly documented.

## Test plan
- [x] Verified on a throwaway branch off latest `master` — `test-integration` job: both Task API tests pass (`Gets tasks`, `Creates, updates, deletes task`)
- [x] `TASKS_APP_DEFINITION_ID` secret added to repo/org settings
- [x] `test-integration` passes on this PR

Generated with [Claude Code](https://claude.com/claude-code)

[CFISO-3416]: https://contentful.atlassian.net/browse/CFISO-3416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ