### PR TITLE
feat: update ExO comments endpoints [CFISO-3436]

### DIFF
--- a/lib/adapters/REST/endpoints/comment.ts
+++ b/lib/adapters/REST/endpoints/comment.ts
@@ -45,7 +45,7 @@ function getParentPlural(parentEntityType: CommentParentEntityType) {
     case 'Experience':
       return 'experiences'
     case 'ExperienceFragment':
-      return 'fragments'
+      return 'experience_fragments'
     case 'Component':
       return 'components'
     case 'ExperienceTemplate':

--- a/lib/adapters/REST/endpoints/comment.ts
+++ b/lib/adapters/REST/endpoints/comment.ts
@@ -44,12 +44,12 @@ function getParentPlural(parentEntityType: CommentParentEntityType) {
       return 'workflows'
     case 'Experience':
       return 'experiences'
-    case 'Fragment':
+    case 'ExperienceFragment':
       return 'fragments'
-    case 'ComponentType':
-      return 'component_types'
-    case 'Template':
-      return 'templates'
+    case 'Component':
+      return 'components'
+    case 'ExperienceTemplate':
+      return 'experience_templates'
   }
 }
 

--- a/lib/adapters/REST/endpoints/task.ts
+++ b/lib/adapters/REST/endpoints/task.ts
@@ -32,12 +32,12 @@ function getParentPlural(parentEntityType: TaskParentEntityType): TaskParentEnti
       return 'entries'
     case 'Experience':
       return 'experiences'
-    case 'Fragment':
-      return 'fragments'
-    case 'Template':
-      return 'templates'
-    case 'ComponentType':
-      return 'component_types'
+    case 'ExperienceFragment':
+      return 'experience_fragments'
+    case 'ExperienceTemplate':
+      return 'experience_templates'
+    case 'Component':
+      return 'components'
   }
 }
 

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -28,9 +28,9 @@ export type CommentParentEntityType =
   | 'Entry'
   | 'Workflow'
   | 'Experience'
-  | 'Fragment'
-  | 'ComponentType'
-  | 'Template'
+  | 'ExperienceFragment'
+  | 'Component'
+  | 'ExperienceTemplate'
 
 type NonWorkflowCommentParentEntityType = Exclude<CommentParentEntityType, 'Workflow'>
 
@@ -134,7 +134,8 @@ type CommentApi = {
 export interface Comment extends CommentProps, DefaultElements<CommentProps>, CommentApi {}
 
 export interface RichTextComment
-  extends Omit<CommentProps, 'body'>,
+  extends
+    Omit<CommentProps, 'body'>,
     RichTextCommentProps,
     DefaultElements<CommentProps>,
     CommentApi {}

--- a/lib/entities/comment.ts
+++ b/lib/entities/comment.ts
@@ -134,8 +134,7 @@ type CommentApi = {
 export interface Comment extends CommentProps, DefaultElements<CommentProps>, CommentApi {}
 
 export interface RichTextComment
-  extends
-    Omit<CommentProps, 'body'>,
+  extends Omit<CommentProps, 'body'>,
     RichTextCommentProps,
     DefaultElements<CommentProps>,
     CommentApi {}

--- a/lib/entities/task.ts
+++ b/lib/entities/task.ts
@@ -18,16 +18,16 @@ export type TaskStatus = 'active' | 'resolved'
 export type TaskParentEntityType =
   | 'Entry'
   | 'Experience'
-  | 'Fragment'
-  | 'Template'
-  | 'ComponentType'
+  | 'ExperienceFragment'
+  | 'ExperienceTemplate'
+  | 'Component'
 
 export type TaskParentEntityPath =
   | 'entries'
   | 'experiences'
-  | 'fragments'
-  | 'templates'
-  | 'component_types'
+  | 'experience_fragments'
+  | 'experience_templates'
+  | 'components'
 
 export type TaskSysProps = Pick<
   BasicMetaSysProps,

--- a/lib/plain/entities/task.ts
+++ b/lib/plain/entities/task.ts
@@ -98,12 +98,12 @@ export type TaskPlainClientAPI = {
    *   }
    * );
    *
-   * const fragmentTask = await client.task.create(
+   * const experienceFragmentTask = await client.task.create(
    *   {
    *     spaceId: '<space_id>',
    *     environmentId: '<environment_id>',
-   *     parentEntityType: 'Fragment',
-   *     parentEntityId: '<fragment_id>',
+   *     parentEntityType: 'ExperienceFragment',
+   *     parentEntityId: '<experience_fragment_id>',
    *   },
    *   {
    *     body: "Review Translation",
@@ -152,12 +152,12 @@ export type TaskPlainClientAPI = {
    *   }
    * );
    *
-   * const templateTask = await client.task.update(
+   * const experienceTemplateTask = await client.task.update(
    *   {
    *     spaceId: '<space_id>',
    *     environmentId: '<environment_id>',
-   *     parentEntityType: 'Template',
-   *     parentEntityId: '<template_id>',
+   *     parentEntityType: 'ExperienceTemplate',
+   *     parentEntityId: '<experience_template_id>',
    *     taskId: '<task_id>',
    *   },
    *   {
@@ -196,8 +196,8 @@ export type TaskPlainClientAPI = {
    * await client.task.delete({
    *   spaceId: '<space_id>',
    *   environmentId: '<environment_id>',
-   *   parentEntityType: 'ComponentType',
-   *   parentEntityId: '<component_type_id>',
+   *   parentEntityType: 'Component',
+   *   parentEntityId: '<component_id>',
    *   taskId: '<task_id>',
    *   version: 1,
    * });

--- a/test/unit/adapters/REST/endpoints/comment.test.ts
+++ b/test/unit/adapters/REST/endpoints/comment.test.ts
@@ -20,9 +20,9 @@ describe('Rest Comment', { concurrent: true }, () => {
 
   test.each([
     ['Experience', 'experiences'],
-    ['Fragment', 'fragments'],
-    ['ComponentType', 'component_types'],
-    ['Template', 'templates'],
+    ['ExperienceFragment', 'experience_fragments'],
+    ['Component', 'components'],
+    ['ExperienceTemplate', 'experience_templates'],
   ] as const)('getMany supports %s comments', (parentEntityType, path) => {
     const httpMock = request('getMany', {
       spaceId: 'space',
@@ -44,14 +44,14 @@ describe('Rest Comment', { concurrent: true }, () => {
     const httpMock = request(action, {
       spaceId: 'space',
       environmentId: 'env',
-      parentEntityType: 'ComponentType',
-      parentEntityId: 'component-type',
+      parentEntityType: 'Component',
+      parentEntityId: 'component',
       commentId: 'comment',
       version: 1,
     })
 
     expect(httpMock[method].mock.calls[0][0]).toBe(
-      `/spaces/space/environments/env/component_types/component-type/comments${suffix}`,
+      `/spaces/space/environments/env/components/component/comments${suffix}`,
     )
   })
 })

--- a/test/unit/adapters/REST/endpoints/task.test.ts
+++ b/test/unit/adapters/REST/endpoints/task.test.ts
@@ -36,9 +36,9 @@ describe('Rest Task', { concurrent: true }, () => {
 
   test.each([
     ['Experience', 'experiences'],
-    ['Fragment', 'fragments'],
-    ['Template', 'templates'],
-    ['ComponentType', 'component_types'],
+    ['ExperienceFragment', 'experience_fragments'],
+    ['ExperienceTemplate', 'experience_templates'],
+    ['Component', 'components'],
   ] as const)('getMany supports %s tasks', (parentEntityType, path) => {
     const httpMock = request('getMany', {
       spaceId: 'space',
@@ -61,14 +61,14 @@ describe('Rest Task', { concurrent: true }, () => {
     const httpMock = request(action, {
       spaceId: 'space',
       environmentId: 'env',
-      parentEntityType: 'ComponentType',
-      parentEntityId: 'component-type',
+      parentEntityType: 'Component',
+      parentEntityId: 'component',
       taskId: 'task',
       version: 2,
     })
 
     expect(httpMock[method].mock.calls[0][0]).toBe(
-      `/spaces/space/environments/env/component_types/component-type/tasks${suffix}`,
+      `/spaces/space/environments/env/components/component/tasks${suffix}`,
     )
   })
 

--- a/test/unit/entities/task.test.ts
+++ b/test/unit/entities/task.test.ts
@@ -61,7 +61,7 @@ describe('Entity Task', () => {
 
   test('Task parent entity typing supports ExO entities', () => {
     expectTypeOf<TaskProps['sys']['parentEntity']>().toEqualTypeOf<
-      Link<'Entry' | 'Experience' | 'Fragment' | 'Template' | 'ComponentType'>
+      Link<'Entry' | 'Experience' | 'ExperienceFragment' | 'ExperienceTemplate' | 'Component'>
     >()
   })
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.
-->

## Summary

As part of the renaming effort, comments need to communicate with new endpoints.

## Description

Changes the pluralized ExO enum to reflect the new names.

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes (it would be for ExO, but it's in an alpha phase) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR updates the Contentful Management SDK to rename ExO (Experience Optimization) entity types to match the new backend naming convention. The changes update `CommentParentEntityType` and `TaskParentEntityType` union types, replacing legacy names ('Fragment', 'Template', 'ComponentType') with new standardized names ('ExperienceFragment', 'ExperienceTemplate', 'Component') across both comments and tasks APIs.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Renamed entity types in `CommentParentEntityType` and `TaskParentEntityType`: 'Fragment' → 'ExperienceFragment', 'ComponentType' → 'Component', 'Template' → 'ExperienceTemplate' in lib/entities/comment.ts, lib/entities/task.ts, and lib/plain/entities/task.ts</li>

<li>Updated endpoint path mappings in REST adapter: 'fragments' → 'experience_fragments', 'component_types' → 'components', 'templates' → 'experience_templates' in lib/adapters/REST/endpoints/comment.ts and lib/adapters/REST/endpoints/task.ts</li>

<li>Updated corresponding test cases in comment.test.ts and task.test.ts to verify the new entity type names and endpoint paths function correctly</li>

</ul>
</details>

</div>