### PR TITLE
feat: add release fragment methods [AIS-140]

### DIFF
--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -54,6 +54,7 @@ import * as ReleaseAsset from './release-asset'
 import * as ReleaseEntry from './release-entry'
 import * as ReleaseAction from './release-action'
 import * as ReleaseExperience from './release-experience'
+import * as ReleaseFragment from './release-fragment'
 import * as Resource from './resource'
 import * as ResourceProvider from './resource-provider'
 import * as ResourceType from './resource-type'
@@ -147,6 +148,7 @@ export default {
   ReleaseEntry,
   ReleaseAction,
   ReleaseExperience,
+  ReleaseFragment,
   Resource,
   ResourceProvider,
   ResourceType,

--- a/lib/adapters/REST/endpoints/release-fragment.ts
+++ b/lib/adapters/REST/endpoints/release-fragment.ts
@@ -1,0 +1,88 @@
+import type { RawAxiosRequestHeaders } from 'axios'
+import type { AxiosInstance } from 'contentful-sdk-core'
+import copy from 'fast-copy'
+import type { GetManyReleaseFragmentParams, GetReleaseFragmentParams } from '../../../common-types'
+import type {
+  CreateReleaseFragmentProps,
+  ReleaseFragment,
+  ReleaseFragmentCollection,
+  ReleaseFragmentQueryOptions,
+  UpsertReleaseFragmentProps,
+} from '../../../entities/fragment'
+import type { RestEndpoint } from '../types'
+import * as raw from './raw'
+import { ExperienceAlphaHeaders } from './experience'
+
+const getBaseUrl = (params: GetManyReleaseFragmentParams) =>
+  `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/fragments`
+
+export const getMany: RestEndpoint<'ReleaseFragment', 'getMany'> = (
+  http: AxiosInstance,
+  params: GetManyReleaseFragmentParams & { query: ReleaseFragmentQueryOptions },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.get<ReleaseFragmentCollection>(http, getBaseUrl(params), {
+    params: params.query,
+    headers: {
+      ...ExperienceAlphaHeaders,
+      ...headers,
+    },
+  })
+}
+
+export const get: RestEndpoint<'ReleaseFragment', 'get'> = (
+  http: AxiosInstance,
+  params: GetReleaseFragmentParams,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.get<ReleaseFragment>(http, getBaseUrl(params) + `/${params.fragmentId}`, {
+    headers: {
+      ...ExperienceAlphaHeaders,
+      ...headers,
+    },
+  })
+}
+
+export const create: RestEndpoint<'ReleaseFragment', 'create'> = (
+  http: AxiosInstance,
+  params: GetManyReleaseFragmentParams,
+  rawData: CreateReleaseFragmentProps,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  const data = copy(rawData)
+  return raw.post<ReleaseFragment>(http, getBaseUrl(params), data, {
+    headers: {
+      ...ExperienceAlphaHeaders,
+      ...headers,
+    },
+  })
+}
+
+export const upsert: RestEndpoint<'ReleaseFragment', 'upsert'> = (
+  http: AxiosInstance,
+  params: GetReleaseFragmentParams,
+  rawData: UpsertReleaseFragmentProps,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  const { sys, ...body } = copy(rawData)
+  return raw.put<ReleaseFragment>(http, getBaseUrl(params) + `/${params.fragmentId}`, body, {
+    headers: {
+      ...ExperienceAlphaHeaders,
+      ...(sys.version !== undefined && {
+        'X-Contentful-Version': sys.version,
+      }),
+      ...headers,
+    },
+  })
+}
+
+export const del: RestEndpoint<'ReleaseFragment', 'delete'> = (
+  http: AxiosInstance,
+  params: GetReleaseFragmentParams,
+) => {
+  return raw.del(http, getBaseUrl(params) + `/${params.fragmentId}`, {
+    headers: {
+      ...ExperienceAlphaHeaders,
+    },
+  })
+}

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -77,7 +77,12 @@ import type {
   CreateFragmentProps,
   FragmentProps,
   FragmentQueryOptions,
+  CreateReleaseFragmentProps,
+  ReleaseFragment,
+  ReleaseFragmentCollection,
+  ReleaseFragmentQueryOptions,
   UpsertFragmentProps,
+  UpsertReleaseFragmentProps,
 } from './entities/fragment'
 import type {
   CreateTemplateProps,
@@ -2670,6 +2675,30 @@ export type MRActions = {
       return: void
     }
   }
+  ReleaseFragment: {
+    getMany: {
+      params: GetManyReleaseFragmentParams & { query: ReleaseFragmentQueryOptions }
+      return: ReleaseFragmentCollection
+    }
+    get: {
+      params: GetReleaseFragmentParams
+      return: ReleaseFragment
+    }
+    create: {
+      params: GetManyReleaseFragmentParams
+      payload: CreateReleaseFragmentProps
+      return: ReleaseFragment
+    }
+    upsert: {
+      params: GetReleaseFragmentParams
+      payload: UpsertReleaseFragmentProps
+      return: ReleaseFragment
+    }
+    delete: {
+      params: GetReleaseFragmentParams
+      return: void
+    }
+  }
   Role: {
     get: { params: GetSpaceParams & { roleId: string }; return: RoleProps }
     getMany: { params: GetSpaceParams & QueryParams; return: CollectionProp<RoleProps> }
@@ -3430,6 +3459,9 @@ export type GetDesignTokenParams = GetSpaceEnvironmentParams & { designTokenId: 
 /** @internal */
 export type GetFragmentParams = GetSpaceEnvironmentParams & { fragmentId: string }
 /** @internal */
+export type GetManyReleaseFragmentParams = GetSpaceEnvironmentParams & { releaseId: string }
+/** @internal */
+export type GetReleaseFragmentParams = GetManyReleaseFragmentParams & { fragmentId: string }
 export type GetTemplateParams = GetSpaceEnvironmentParams & { templateId: string }
 /** @internal */
 export type GetExperienceTemplateParams = GetSpaceEnvironmentParams & {

--- a/lib/entities/fragment.ts
+++ b/lib/entities/fragment.ts
@@ -107,3 +107,22 @@ export type FragmentQueryOptions = CursorPaginationParams &
  * The Fragment entity is superseded by the ExperienceFragment entity.
  */
 export type FragmentCollection = ExoCursorPaginatedCollectionProp<FragmentProps>
+
+export type ReleaseFragmentQueryOptions = FragmentQueryOptions
+
+export type CreateReleaseFragmentProps = CreateFragmentProps
+
+export type UpsertReleaseFragmentProps = UpsertFragmentProps
+
+export type ReleaseFragmentSys = Omit<
+  FragmentSys,
+  'variant' | 'variantType' | 'variantDimension'
+> & {
+  release: Link<'Release'>
+}
+
+export type ReleaseFragment = Omit<FragmentProps, 'sys'> & {
+  sys: ReleaseFragmentSys
+}
+
+export type ReleaseFragmentCollection = ExoCursorPaginatedCollectionProp<ReleaseFragment>

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -449,6 +449,12 @@ export type {
   /** @deprecated Use `UpsertExperienceFragmentProps` instead */
   UpsertFragmentProps,
   InlineFragmentNode,
+  ReleaseFragment,
+  ReleaseFragmentCollection,
+  ReleaseFragmentSys,
+  ReleaseFragmentQueryOptions,
+  CreateReleaseFragmentProps,
+  UpsertReleaseFragmentProps,
 } from './entities/fragment'
 export type {
   ExperienceFragmentCollection,

--- a/lib/plain/entities/release-fragment.test-d.ts
+++ b/lib/plain/entities/release-fragment.test-d.ts
@@ -1,0 +1,33 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type {
+  CreateReleaseFragmentProps,
+  ReleaseFragment,
+  ReleaseFragmentCollection,
+  UpsertReleaseFragmentProps,
+} from '../../entities/fragment'
+import type { ReleaseFragmentPlainClientAPI } from './release-fragment'
+
+describe('ReleaseFragmentPlainClientAPI', () => {
+  it('exposes all release fragment methods with the expected types', () => {
+    void ((client: ReleaseFragmentPlainClientAPI) => {
+      const params = {
+        spaceId: 'space-id',
+        environmentId: 'environment-id',
+        releaseId: 'release-id',
+      }
+      const fragmentParams = { ...params, fragmentId: 'fragment-id' }
+      const createPayload = {} as CreateReleaseFragmentProps
+      const upsertPayload = {} as UpsertReleaseFragmentProps
+
+      expectTypeOf(client.getMany({ ...params, query: {} })).toEqualTypeOf<
+        Promise<ReleaseFragmentCollection>
+      >()
+      expectTypeOf(client.get(fragmentParams)).toEqualTypeOf<Promise<ReleaseFragment>>()
+      expectTypeOf(client.create(params, createPayload)).toEqualTypeOf<Promise<ReleaseFragment>>()
+      expectTypeOf(client.upsert(fragmentParams, upsertPayload)).toEqualTypeOf<
+        Promise<ReleaseFragment>
+      >()
+      expectTypeOf(client.delete(fragmentParams)).toEqualTypeOf<Promise<void>>()
+    })
+  })
+})

--- a/lib/plain/entities/release-fragment.ts
+++ b/lib/plain/entities/release-fragment.ts
@@ -1,0 +1,47 @@
+import type {
+  ExoCursorPaginatedCollectionProp,
+  GetManyReleaseFragmentParams,
+  GetReleaseFragmentParams,
+} from '../../common-types'
+import type {
+  CreateReleaseFragmentProps,
+  ReleaseFragment,
+  ReleaseFragmentQueryOptions,
+  UpsertReleaseFragmentProps,
+} from '../../entities/fragment'
+import type { OptionalDefaults } from '../wrappers/wrap'
+
+export type ReleaseFragmentPlainClientAPI = {
+  /**
+   * Fetches all Fragments belonging to a Release.
+   */
+  getMany(
+    params: OptionalDefaults<GetManyReleaseFragmentParams & { query: ReleaseFragmentQueryOptions }>,
+  ): Promise<ExoCursorPaginatedCollectionProp<ReleaseFragment>>
+
+  /**
+   * Fetches a single Fragment belonging to a Release.
+   */
+  get(params: OptionalDefaults<GetReleaseFragmentParams>): Promise<ReleaseFragment>
+
+  /**
+   * Creates a Fragment in a Release.
+   */
+  create(
+    params: OptionalDefaults<GetManyReleaseFragmentParams>,
+    rawData: CreateReleaseFragmentProps,
+  ): Promise<ReleaseFragment>
+
+  /**
+   * Upserts a Fragment in a Release.
+   */
+  upsert(
+    params: OptionalDefaults<GetReleaseFragmentParams>,
+    rawData: UpsertReleaseFragmentProps,
+  ): Promise<ReleaseFragment>
+
+  /**
+   * Deletes a Fragment from a Release.
+   */
+  delete(params: OptionalDefaults<GetReleaseFragmentParams>): Promise<void>
+}

--- a/lib/plain/plain-client-types.ts
+++ b/lib/plain/plain-client-types.ts
@@ -160,6 +160,7 @@ import type { ExperiencePlainClientAPI } from './entities/experience'
 import type { ExperienceFragmentPlainClientAPI } from './entities/experience-fragment'
 import type { ExperienceTemplatePlainClientAPI } from './entities/experience-template'
 import type { ReleaseExperiencePlainClientAPI } from './entities/release-experience'
+import type { ReleaseFragmentPlainClientAPI } from './entities/release-fragment'
 
 export type PlainClientAPI = {
   raw: {
@@ -753,6 +754,7 @@ export type PlainClientAPI = {
   releaseExperience: ReleaseExperiencePlainClientAPI
   experienceFragment: ExperienceFragmentPlainClientAPI
   experienceTemplate: ExperienceTemplatePlainClientAPI
+  releaseFragment: ReleaseFragmentPlainClientAPI
   semanticSearch: SemanticSearchPlainClientAPI
   semanticDuplicates: SemanticDuplicatesPlainClientAPI
   semanticRecommendations: SemanticRecommendationsPlainClientAPI

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -705,6 +705,13 @@ export const createPlainClient = (
       publish: wrap(wrapParams, 'ExperienceTemplate', 'publish'),
       unpublish: wrap(wrapParams, 'ExperienceTemplate', 'unpublish'),
     },
+    releaseFragment: {
+      getMany: wrap(wrapParams, 'ReleaseFragment', 'getMany'),
+      get: wrap(wrapParams, 'ReleaseFragment', 'get'),
+      create: wrap(wrapParams, 'ReleaseFragment', 'create'),
+      upsert: wrap(wrapParams, 'ReleaseFragment', 'upsert'),
+      delete: wrap(wrapParams, 'ReleaseFragment', 'delete'),
+    },
     workflowDefinition: {
       get: wrap(wrapParams, 'WorkflowDefinition', 'get'),
       getMany: wrap(wrapParams, 'WorkflowDefinition', 'getMany'),

--- a/test/integration/release-fragment-integration.test.ts
+++ b/test/integration/release-fragment-integration.test.ts
@@ -92,7 +92,7 @@ describe('ReleaseFragment Integration', { sequential: true }, () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('has correct sys fields after creation', async () => {
+  it('gets a release fragment by ID with the expected sys fields', async () => {
     const fragment = await client.releaseFragment.get({ releaseId, fragmentId: releaseFragmentId })
 
     expect(fragment.sys.id).toBe(releaseFragmentId)
@@ -104,16 +104,6 @@ describe('ReleaseFragment Integration', { sequential: true }, () => {
     expect(fragment.sys.componentType.sys.linkType).toBe('Contentful:ComponentType')
     expect(fragment.sys.componentType.sys.urn).toContain(componentTypeId)
     expect(fragment.name).toBe(testName('ReleaseFragment'))
-  })
-
-  it('gets a release fragment by ID', async () => {
-    const fetched = await client.releaseFragment.get({
-      releaseId,
-      fragmentId: releaseFragmentId,
-    })
-
-    expect(fetched.sys.id).toBe(releaseFragmentId)
-    expect(fetched.sys.release.sys.id).toBe(releaseId)
   })
 
   it('lists release fragments with cursor pagination', async () => {

--- a/test/integration/release-fragment-integration.test.ts
+++ b/test/integration/release-fragment-integration.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
+import { TestDefaults } from '../defaults'
+import { makeResourceLink, sweepStaleExoEntities, testName, testViewport } from './utils/exo.utils'
+
+describe('ReleaseFragment Integration', { sequential: true }, () => {
+  const client = initPlainClient({
+    spaceId: TestDefaults.spaceId,
+    environmentId: TestDefaults.environmentId,
+  })
+
+  const createdReleaseFragmentIds: string[] = []
+  let releaseId: string
+  let componentTypeId: string
+  let releaseFragmentId: string
+
+  beforeAll(async () => {
+    await sweepStaleExoEntities(client)
+
+    const componentType = await client.componentType.create(
+      {},
+      {
+        name: testName('ComponentType for ReleaseFragment'),
+        description: 'Backing component type for release fragment integration test',
+        viewports: [testViewport],
+        contentProperties: [],
+        designProperties: [],
+      },
+    )
+    componentTypeId = componentType.sys.id
+
+    await client.componentType.publish({
+      componentTypeId,
+      version: componentType.sys.version,
+    })
+
+    const release = await client.release.create(
+      {},
+      {
+        title: testName('Release for Fragment'),
+        entities: { sys: { type: 'Array' }, items: [] },
+      },
+    )
+    releaseId = release.sys.id
+
+    const created = await client.releaseFragment.create(
+      { releaseId },
+      {
+        name: testName('ReleaseFragment'),
+        description: 'Created by integration test',
+        componentType: makeResourceLink('Contentful:ComponentType', componentTypeId),
+        viewports: [testViewport],
+        designProperties: {},
+      },
+    )
+    releaseFragmentId = created.sys.id
+    createdReleaseFragmentIds.push(releaseFragmentId)
+  })
+
+  afterAll(async () => {
+    for (const id of createdReleaseFragmentIds) {
+      try {
+        await client.releaseFragment.delete({ releaseId, fragmentId: id })
+      } catch {
+        // entity already deleted or not found
+      }
+    }
+
+    if (releaseId) {
+      try {
+        await client.release.delete({ releaseId })
+      } catch {
+        // release already deleted or not found
+      }
+    }
+
+    if (componentTypeId) {
+      try {
+        const latest = await client.componentType.get({ componentTypeId })
+        if (latest.sys.publishedVersion) {
+          await client.componentType.unpublish({
+            componentTypeId,
+            version: latest.sys.version,
+          })
+        }
+        await client.componentType.delete({ componentTypeId })
+      } catch {
+        // entity already deleted or not found
+      }
+    }
+
+    await timeoutToCalmRateLimiting()
+  })
+
+  it('has correct sys fields after creation', async () => {
+    const fragment = await client.releaseFragment.get({ releaseId, fragmentId: releaseFragmentId })
+
+    expect(fragment.sys.id).toBe(releaseFragmentId)
+    expect(fragment.sys.type).toBe('Fragment')
+    expect(fragment.sys.version).toBeGreaterThanOrEqual(1)
+    expect(fragment.sys.release.sys.type).toBe('Link')
+    expect(fragment.sys.release.sys.linkType).toBe('Release')
+    expect(fragment.sys.release.sys.id).toBe(releaseId)
+    expect(fragment.sys.componentType.sys.linkType).toBe('Contentful:ComponentType')
+    expect(fragment.sys.componentType.sys.urn).toContain(componentTypeId)
+    expect(fragment.name).toBe(testName('ReleaseFragment'))
+  })
+
+  it('gets a release fragment by ID', async () => {
+    const fetched = await client.releaseFragment.get({
+      releaseId,
+      fragmentId: releaseFragmentId,
+    })
+
+    expect(fetched.sys.id).toBe(releaseFragmentId)
+    expect(fetched.sys.release.sys.id).toBe(releaseId)
+  })
+
+  it('lists release fragments with cursor pagination', async () => {
+    const collection = await client.releaseFragment.getMany({
+      releaseId,
+      query: { limit: 10 },
+    })
+
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
+    expect(collection.pages).toBeDefined()
+    expect(collection.items.find((item) => item.sys.id === releaseFragmentId)).toBeDefined()
+  })
+
+  it('upserts a release fragment', async () => {
+    const current = await client.releaseFragment.get({ releaseId, fragmentId: releaseFragmentId })
+    const { sys, ...body } = current
+
+    const updated = await client.releaseFragment.upsert(
+      { releaseId, fragmentId: releaseFragmentId },
+      {
+        sys: { id: sys.id, type: 'Fragment', version: sys.version },
+        ...body,
+        name: testName('ReleaseFragment Updated'),
+      },
+    )
+
+    expect(updated.name).toBe(testName('ReleaseFragment Updated'))
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+  })
+
+  it('deletes a release fragment', async () => {
+    await client.releaseFragment.delete({ releaseId, fragmentId: releaseFragmentId })
+    await expect(
+      client.releaseFragment.get({ releaseId, fragmentId: releaseFragmentId }),
+    ).rejects.toThrow()
+
+    const index = createdReleaseFragmentIds.indexOf(releaseFragmentId)
+    if (index !== -1) createdReleaseFragmentIds.splice(index, 1)
+  })
+})

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -282,6 +282,25 @@ export async function sweepStaleExoEntities(
           }
 
           try {
+            const { items: releaseFragments } = await client.releaseFragment.getMany({
+              releaseId: release.sys.id,
+              query: { limit: 100 },
+            })
+            for (const fragment of releaseFragments) {
+              try {
+                await client.releaseFragment.delete({
+                  releaseId: release.sys.id,
+                  fragmentId: fragment.sys.id,
+                })
+              } catch {
+                // best-effort cleanup
+              }
+            }
+          } catch {
+            // ignore if listing release fragments fails
+          }
+
+          try {
             await client.release.delete({ releaseId: release.sys.id })
           } catch {
             // best-effort cleanup

--- a/test/unit/adapters/REST/endpoints/release-fragment.test.ts
+++ b/test/unit/adapters/REST/endpoints/release-fragment.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from 'vitest'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+
+const releaseParams = {
+  spaceId: 'space123',
+  environmentId: 'master',
+  releaseId: 'release123',
+}
+
+const fragmentResponse = {
+  sys: {
+    id: 'fragment123',
+    type: 'Fragment',
+    version: 1,
+    release: { sys: { type: 'Link', linkType: 'Release', id: 'release123' } },
+  },
+  name: 'Release Fragment',
+  description: 'A fragment in a release',
+  viewports: [],
+  designProperties: {},
+}
+
+describe('Rest ReleaseFragment', () => {
+  test('getMany calls the release-scoped URL and passes query parameters', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(
+      Promise.resolve({ data: { sys: { type: 'Array' }, limit: 100, items: [] } }),
+    )
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseFragment',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          ...releaseParams,
+          query: { limit: 20, pageNext: 'next-page-token' },
+        },
+      })
+      .then(() => {
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/release123/fragments',
+        )
+        expect(httpMock.get.mock.calls[0][1].params).to.eql({
+          limit: 20,
+          pageNext: 'next-page-token',
+        })
+        expect(httpMock.get.mock.calls[0][1].headers['x-contentful-enable-alpha-feature']).to.eql(
+          'new-exo-entity-types',
+        )
+      })
+  })
+
+  test('get calls the release-scoped URL', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: fragmentResponse }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseFragment',
+        action: 'get',
+        userAgent: 'mocked',
+        params: { ...releaseParams, fragmentId: 'fragment123' },
+      })
+      .then((result) => {
+        expect(result).to.eql(fragmentResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/release123/fragments/fragment123',
+        )
+      })
+  })
+
+  test('create calls the release-scoped URL with POST', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: fragmentResponse }))
+    const payload = {
+      name: 'Release Fragment',
+      description: 'A fragment in a release',
+      viewports: [],
+      designProperties: {},
+      componentType: {
+        sys: {
+          type: 'ResourceLink',
+          linkType: 'Contentful:ComponentType',
+          urn: 'crn:contentful:::component-type/component123',
+        },
+      },
+    }
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseFragment',
+        action: 'create',
+        userAgent: 'mocked',
+        params: releaseParams,
+        payload,
+      })
+      .then((result) => {
+        expect(result).to.eql(fragmentResponse)
+        expect(httpMock.post.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/release123/fragments',
+        )
+        expect(httpMock.post.mock.calls[0][1]).to.eql(payload)
+      })
+  })
+
+  test('upsert calls the release-scoped URL and sends the version header', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: fragmentResponse }))
+    const payload = {
+      sys: { id: 'fragment123', type: 'Fragment', version: 2 },
+      name: 'Updated Release Fragment',
+      description: 'An updated fragment in a release',
+      viewports: [],
+      designProperties: {},
+    }
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseFragment',
+        action: 'upsert',
+        userAgent: 'mocked',
+        params: { ...releaseParams, fragmentId: 'fragment123' },
+        payload,
+      })
+      .then(() => {
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/release123/fragments/fragment123',
+        )
+        expect(httpMock.put.mock.calls[0][1].sys).to.be.undefined
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(2)
+      })
+  })
+
+  test('delete calls the release-scoped URL', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: {} }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseFragment',
+        action: 'delete',
+        userAgent: 'mocked',
+        params: { ...releaseParams, fragmentId: 'fragment123' },
+      })
+      .then(() => {
+        expect(httpMock.delete.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/release123/fragments/fragment123',
+        )
+      })
+  })
+})


### PR DESCRIPTION
[AIS-140](https://contentful.atlassian.net/browse/AIS-140)

## Summary
- Add release-scoped Fragment `getMany`, `get`, `create`, `upsert`, and `delete` methods.
- Expose release Fragment types and plain-client wiring using the established ExO alpha-header pattern.
- Release Fragments do not include publish/unpublish methods in the generated contract.

## Test plan
- [x] `npm run test:unit` (921 tests)
- [x] `npm run test:types` (30 tests)
- [x] `npm run build:types`
- [x] `npm run lint`

Generated with [Codex](https://Codex.com/Codex)

[AIS-140]: https://contentful.atlassian.net/browse/AIS-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds release-scoped Fragment management to the REST and plain client APIs. It extends the public type surface and validates the new operations with compile-time and endpoint-level tests, while following the existing ExO alpha-header convention.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds getMany, get, create, upsert, and delete REST handlers in release-fragment.ts, routing requests to release-specific Fragment endpoints and applying the ExO alpha header.</li>

<li>Introduces ReleaseFragment types and action contracts in fragment.ts and common-types.ts, including release-linked system metadata and collection/query aliases.</li>

<li>Exposes the releaseFragment plain-client namespace through plain-client-types.ts and plain-client.ts, with wrapper wiring for all five supported operations and no publish or unpublish methods.</li>

<li>Adds endpoint tests in release-fragment.test.ts and type assertions in release-fragment.test-d.ts covering URL construction, query and payload forwarding, alpha/version headers, return types, and deletion.</li>

</ul>
</details>

</div>