### PR TITLE
feat: add release experience methods [AIS-140]

### DIFF
--- a/lib/adapters/REST/endpoints/experience.ts
+++ b/lib/adapters/REST/endpoints/experience.ts
@@ -19,7 +19,7 @@ const getBaseUrl = (params: GetSpaceEnvironmentParams) =>
 // Opts into the renamed ("new ExO entity types") Experience shape: sys.experienceTemplate
 // instead of sys.template, and ExperienceFragment slot nodes. The renamed family shares the
 // `/experiences` URLs with the legacy routes and is discriminated server-side on this header.
-const ExperienceAlphaHeaders = {
+export const ExperienceAlphaHeaders = {
   'x-contentful-enable-alpha-feature': 'new-exo-entity-types',
 }
 

--- a/lib/adapters/REST/endpoints/index.ts
+++ b/lib/adapters/REST/endpoints/index.ts
@@ -53,6 +53,7 @@ import * as Release from './release'
 import * as ReleaseAsset from './release-asset'
 import * as ReleaseEntry from './release-entry'
 import * as ReleaseAction from './release-action'
+import * as ReleaseExperience from './release-experience'
 import * as Resource from './resource'
 import * as ResourceProvider from './resource-provider'
 import * as ResourceType from './resource-type'
@@ -145,6 +146,7 @@ export default {
   ReleaseAsset,
   ReleaseEntry,
   ReleaseAction,
+  ReleaseExperience,
   Resource,
   ResourceProvider,
   ResourceType,

--- a/lib/adapters/REST/endpoints/release-experience.ts
+++ b/lib/adapters/REST/endpoints/release-experience.ts
@@ -1,0 +1,91 @@
+import type { RawAxiosRequestHeaders } from 'axios'
+import type { AxiosInstance } from 'contentful-sdk-core'
+import copy from 'fast-copy'
+import type {
+  GetManyReleaseExperienceParams,
+  GetReleaseExperienceParams,
+} from '../../../common-types'
+import type {
+  CreateExperienceProps,
+  ReleaseExperience,
+  ReleaseExperienceCollection,
+  ReleaseExperienceQueryOptions,
+  UpsertExperienceProps,
+} from '../../../entities/experience'
+import type { RestEndpoint } from '../types'
+import * as raw from './raw'
+import { ExperienceAlphaHeaders } from './experience'
+
+const getBaseUrl = (params: GetManyReleaseExperienceParams) =>
+  `/spaces/${params.spaceId}/environments/${params.environmentId}/releases/${params.releaseId}/experiences`
+
+export const getMany: RestEndpoint<'ReleaseExperience', 'getMany'> = (
+  http: AxiosInstance,
+  params: GetManyReleaseExperienceParams & { query: ReleaseExperienceQueryOptions },
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.get<ReleaseExperienceCollection>(http, getBaseUrl(params), {
+    params: params.query,
+    headers: {
+      ...ExperienceAlphaHeaders,
+      ...headers,
+    },
+  })
+}
+
+export const get: RestEndpoint<'ReleaseExperience', 'get'> = (
+  http: AxiosInstance,
+  params: GetReleaseExperienceParams,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  return raw.get<ReleaseExperience>(http, getBaseUrl(params) + `/${params.experienceId}`, {
+    headers: {
+      ...ExperienceAlphaHeaders,
+      ...headers,
+    },
+  })
+}
+
+export const create: RestEndpoint<'ReleaseExperience', 'create'> = (
+  http: AxiosInstance,
+  params: GetManyReleaseExperienceParams,
+  rawData: CreateExperienceProps,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  const data = copy(rawData)
+  return raw.post<ReleaseExperience>(http, getBaseUrl(params), data, {
+    headers: {
+      ...ExperienceAlphaHeaders,
+      ...headers,
+    },
+  })
+}
+
+export const upsert: RestEndpoint<'ReleaseExperience', 'upsert'> = (
+  http: AxiosInstance,
+  params: GetReleaseExperienceParams,
+  rawData: UpsertExperienceProps,
+  headers?: RawAxiosRequestHeaders,
+) => {
+  const { sys, ...body } = copy(rawData)
+  return raw.put<ReleaseExperience>(http, getBaseUrl(params) + `/${params.experienceId}`, body, {
+    headers: {
+      ...ExperienceAlphaHeaders,
+      ...(sys.version !== undefined && {
+        'X-Contentful-Version': sys.version,
+      }),
+      ...headers,
+    },
+  })
+}
+
+export const del: RestEndpoint<'ReleaseExperience', 'delete'> = (
+  http: AxiosInstance,
+  params: GetReleaseExperienceParams,
+) => {
+  return raw.del(http, getBaseUrl(params) + `/${params.experienceId}`, {
+    headers: {
+      ...ExperienceAlphaHeaders,
+    },
+  })
+}

--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -87,10 +87,15 @@ import type {
 } from './entities/template'
 import type {
   CreateExperienceProps,
+  CreateReleaseExperienceProps,
   UpsertExperienceProps,
+  UpsertReleaseExperienceProps,
   ExperienceLocalePublishPayload,
   ExperienceProps,
   ExperienceQueryOptions,
+  ReleaseExperience,
+  ReleaseExperienceCollection,
+  ReleaseExperienceQueryOptions,
 } from './entities/experience'
 import type {
   CreateExperienceFragmentProps,
@@ -2641,6 +2646,30 @@ export type MRActions = {
       return: Collection<ReleaseAction, ReleaseActionProps>
     }
   }
+  ReleaseExperience: {
+    getMany: {
+      params: GetManyReleaseExperienceParams & { query: ReleaseExperienceQueryOptions }
+      return: ReleaseExperienceCollection
+    }
+    get: {
+      params: GetReleaseExperienceParams
+      return: ReleaseExperience
+    }
+    create: {
+      params: GetManyReleaseExperienceParams
+      payload: CreateReleaseExperienceProps
+      return: ReleaseExperience
+    }
+    upsert: {
+      params: GetReleaseExperienceParams
+      payload: UpsertReleaseExperienceProps
+      return: ReleaseExperience
+    }
+    delete: {
+      params: GetReleaseExperienceParams
+      return: void
+    }
+  }
   Role: {
     get: { params: GetSpaceParams & { roleId: string }; return: RoleProps }
     getMany: { params: GetSpaceParams & QueryParams; return: CollectionProp<RoleProps> }
@@ -3435,6 +3464,10 @@ export type GetFunctionLogParams = GetManyFunctionLogParams & { logId: string }
 export type GetOrganizationParams = { organizationId: string }
 /** @internal */
 export type GetReleaseParams = ReleaseEnvironmentParams & { releaseId: string }
+/** @internal */
+export type GetManyReleaseExperienceParams = GetSpaceEnvironmentParams & { releaseId: string }
+/** @internal */
+export type GetReleaseExperienceParams = GetManyReleaseExperienceParams & { experienceId: string }
 /** @internal */
 export type GetReleaseAssetParams = GetSpaceEnvironmentParams & {
   releaseId: string

--- a/lib/entities/experience.ts
+++ b/lib/entities/experience.ts
@@ -62,6 +62,12 @@ export type ExperienceQueryOptions = CursorPaginationParams &
     order?: string
   }
 
+export type ReleaseExperienceQueryOptions = ExperienceQueryOptions
+
+export type CreateReleaseExperienceProps = CreateExperienceProps
+
+export type UpsertReleaseExperienceProps = UpsertExperienceProps
+
 // Locale-based publish payload — add or remove specific locales.
 // Omit the payload entirely for a full publish (all locales).
 export type ExperienceLocalePublishPayload = { add: string[] } | { remove: string[] }

--- a/lib/export-types.ts
+++ b/lib/export-types.ts
@@ -433,6 +433,9 @@ export type {
   ReleaseExperience,
   ReleaseExperienceCollection,
   ReleaseExperienceSys,
+  ReleaseExperienceQueryOptions,
+  CreateReleaseExperienceProps,
+  UpsertReleaseExperienceProps,
   ExperienceContentBindings,
   InlineExperienceFragmentNode,
 } from './entities/experience'

--- a/lib/plain/entities/release-experience.test-d.ts
+++ b/lib/plain/entities/release-experience.test-d.ts
@@ -1,0 +1,35 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type {
+  CreateReleaseExperienceProps,
+  ReleaseExperience,
+  ReleaseExperienceCollection,
+  UpsertReleaseExperienceProps,
+} from '../../entities/experience'
+import type { ReleaseExperiencePlainClientAPI } from './release-experience'
+
+describe('ReleaseExperiencePlainClientAPI', () => {
+  it('exposes the release-scoped Experience methods with the expected types', () => {
+    void ((client: ReleaseExperiencePlainClientAPI) => {
+      const releaseParams = {
+        spaceId: 'space-id',
+        environmentId: 'environment-id',
+        releaseId: 'release-id',
+      }
+      const experienceParams = { ...releaseParams, experienceId: 'experience-id' }
+      const createPayload = {} as CreateReleaseExperienceProps
+      const upsertPayload = {} as UpsertReleaseExperienceProps
+
+      expectTypeOf(
+        client.getMany({ ...releaseParams, query: { limit: 10 } }),
+      ).resolves.toEqualTypeOf<ReleaseExperienceCollection>()
+      expectTypeOf(client.get(experienceParams)).resolves.toEqualTypeOf<ReleaseExperience>()
+      expectTypeOf(
+        client.create(releaseParams, createPayload),
+      ).resolves.toEqualTypeOf<ReleaseExperience>()
+      expectTypeOf(
+        client.upsert(experienceParams, upsertPayload),
+      ).resolves.toEqualTypeOf<ReleaseExperience>()
+      expectTypeOf(client.delete(experienceParams)).resolves.toEqualTypeOf<void>()
+    })
+  })
+})

--- a/lib/plain/entities/release-experience.ts
+++ b/lib/plain/entities/release-experience.ts
@@ -1,0 +1,49 @@
+import type {
+  GetManyReleaseExperienceParams,
+  GetReleaseExperienceParams,
+  ExoCursorPaginatedCollectionProp,
+} from '../../common-types'
+import type {
+  CreateReleaseExperienceProps,
+  ReleaseExperience,
+  ReleaseExperienceQueryOptions,
+  UpsertReleaseExperienceProps,
+} from '../../entities/experience'
+import type { OptionalDefaults } from '../wrappers/wrap'
+
+export type ReleaseExperiencePlainClientAPI = {
+  /**
+   * Fetches all Experiences belonging to a Release.
+   */
+  getMany(
+    params: OptionalDefaults<
+      GetManyReleaseExperienceParams & { query: ReleaseExperienceQueryOptions }
+    >,
+  ): Promise<ExoCursorPaginatedCollectionProp<ReleaseExperience>>
+
+  /**
+   * Fetches a single Experience belonging to a Release.
+   */
+  get(params: OptionalDefaults<GetReleaseExperienceParams>): Promise<ReleaseExperience>
+
+  /**
+   * Creates an Experience in a Release.
+   */
+  create(
+    params: OptionalDefaults<GetManyReleaseExperienceParams>,
+    rawData: CreateReleaseExperienceProps,
+  ): Promise<ReleaseExperience>
+
+  /**
+   * Upserts an Experience in a Release.
+   */
+  upsert(
+    params: OptionalDefaults<GetReleaseExperienceParams>,
+    rawData: UpsertReleaseExperienceProps,
+  ): Promise<ReleaseExperience>
+
+  /**
+   * Deletes an Experience from a Release.
+   */
+  delete(params: OptionalDefaults<GetReleaseExperienceParams>): Promise<void>
+}

--- a/lib/plain/plain-client-types.ts
+++ b/lib/plain/plain-client-types.ts
@@ -159,6 +159,7 @@ import type { DesignTokenPlainClientAPI } from './entities/design-token'
 import type { ExperiencePlainClientAPI } from './entities/experience'
 import type { ExperienceFragmentPlainClientAPI } from './entities/experience-fragment'
 import type { ExperienceTemplatePlainClientAPI } from './entities/experience-template'
+import type { ReleaseExperiencePlainClientAPI } from './entities/release-experience'
 
 export type PlainClientAPI = {
   raw: {
@@ -749,6 +750,7 @@ export type PlainClientAPI = {
   workflowsChangelog: WorkflowsChangelogPlainClientAPI
   oauthApplication: OAuthApplicationPlainClientAPI
   experience: ExperiencePlainClientAPI
+  releaseExperience: ReleaseExperiencePlainClientAPI
   experienceFragment: ExperienceFragmentPlainClientAPI
   experienceTemplate: ExperienceTemplatePlainClientAPI
   semanticSearch: SemanticSearchPlainClientAPI

--- a/lib/plain/plain-client.ts
+++ b/lib/plain/plain-client.ts
@@ -680,6 +680,13 @@ export const createPlainClient = (
       publish: wrap(wrapParams, 'Experience', 'publish'),
       unpublish: wrap(wrapParams, 'Experience', 'unpublish'),
     },
+    releaseExperience: {
+      getMany: wrap(wrapParams, 'ReleaseExperience', 'getMany'),
+      get: wrap(wrapParams, 'ReleaseExperience', 'get'),
+      create: wrap(wrapParams, 'ReleaseExperience', 'create'),
+      upsert: wrap(wrapParams, 'ReleaseExperience', 'upsert'),
+      delete: wrap(wrapParams, 'ReleaseExperience', 'delete'),
+    },
     experienceFragment: {
       getMany: wrap(wrapParams, 'ExperienceFragment', 'getMany'),
       get: wrap(wrapParams, 'ExperienceFragment', 'get'),

--- a/test/integration/release-experience-integration.test.ts
+++ b/test/integration/release-experience-integration.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { initPlainClient, timeoutToCalmRateLimiting } from '../helpers'
+import { TestDefaults } from '../defaults'
+import { makeResourceLink, sweepStaleExoEntities, testName, testViewport } from './utils/exo.utils'
+
+describe('ReleaseExperience Integration', { sequential: true }, () => {
+  const client = initPlainClient({
+    spaceId: TestDefaults.spaceId,
+    environmentId: TestDefaults.environmentId,
+  })
+
+  const createdReleaseExperienceIds: string[] = []
+  let releaseId: string
+  let experienceTemplateId: string
+  let releaseExperienceId: string
+
+  beforeAll(async () => {
+    await sweepStaleExoEntities(client)
+
+    const experienceTemplate = await client.experienceTemplate.create(
+      {},
+      {
+        name: testName('Template for ReleaseExperience'),
+        description: 'Backing template for release experience integration test',
+        viewports: [testViewport],
+        contentProperties: [],
+        designProperties: [],
+      },
+    )
+    experienceTemplateId = experienceTemplate.sys.id
+
+    await client.experienceTemplate.publish({
+      experienceTemplateId,
+      version: experienceTemplate.sys.version,
+    })
+
+    const release = await client.release.create(
+      {},
+      {
+        title: testName('Release for Experience'),
+        entities: { sys: { type: 'Array' }, items: [] },
+      },
+    )
+    releaseId = release.sys.id
+
+    const created = await client.releaseExperience.create(
+      { releaseId },
+      {
+        name: testName('ReleaseExperience'),
+        description: 'Created by integration test',
+        experienceTemplate: makeResourceLink('Contentful:ExperienceTemplate', experienceTemplateId),
+        viewports: [testViewport],
+        designProperties: {},
+      },
+    )
+    releaseExperienceId = created.sys.id
+    createdReleaseExperienceIds.push(releaseExperienceId)
+  })
+
+  afterAll(async () => {
+    for (const id of createdReleaseExperienceIds) {
+      try {
+        await client.releaseExperience.delete({ releaseId, experienceId: id })
+      } catch {
+        // entity already deleted or not found
+      }
+    }
+
+    if (releaseId) {
+      try {
+        await client.release.delete({ releaseId })
+      } catch {
+        // release already deleted or not found
+      }
+    }
+
+    if (experienceTemplateId) {
+      try {
+        const latest = await client.experienceTemplate.get({ experienceTemplateId })
+        if (latest.sys.publishedVersion) {
+          await client.experienceTemplate.unpublish({
+            experienceTemplateId,
+            version: latest.sys.version,
+          })
+        }
+        await client.experienceTemplate.delete({ experienceTemplateId })
+      } catch {
+        // entity already deleted or not found
+      }
+    }
+
+    await timeoutToCalmRateLimiting()
+  })
+
+  it('has correct sys fields after creation', async () => {
+    const experience = await client.releaseExperience.get({
+      releaseId,
+      experienceId: releaseExperienceId,
+    })
+
+    expect(experience.sys.id).toBe(releaseExperienceId)
+    expect(experience.sys.type).toBe('Experience')
+    expect(experience.sys.version).toBeGreaterThanOrEqual(1)
+    expect(experience.sys.release.sys.type).toBe('Link')
+    expect(experience.sys.release.sys.linkType).toBe('Release')
+    expect(experience.sys.release.sys.id).toBe(releaseId)
+    expect(experience.sys.experienceTemplate.sys.linkType).toBe('Contentful:ExperienceTemplate')
+    expect(experience.sys.experienceTemplate.sys.urn).toContain(experienceTemplateId)
+    expect(experience.name).toBe(testName('ReleaseExperience'))
+  })
+
+  it('gets a release experience by ID', async () => {
+    const fetched = await client.releaseExperience.get({
+      releaseId,
+      experienceId: releaseExperienceId,
+    })
+
+    expect(fetched.sys.id).toBe(releaseExperienceId)
+    expect(fetched.sys.release.sys.id).toBe(releaseId)
+  })
+
+  it('lists release experiences with cursor pagination', async () => {
+    const collection = await client.releaseExperience.getMany({
+      releaseId,
+      query: { limit: 10 },
+    })
+
+    expect(collection.items.length).toBeGreaterThanOrEqual(1)
+    expect(collection.pages).toBeDefined()
+    expect(collection.items.find((item) => item.sys.id === releaseExperienceId)).toBeDefined()
+  })
+
+  it('upserts a release experience', async () => {
+    const current = await client.releaseExperience.get({
+      releaseId,
+      experienceId: releaseExperienceId,
+    })
+    const { sys, ...body } = current
+
+    const updated = await client.releaseExperience.upsert(
+      { releaseId, experienceId: releaseExperienceId },
+      {
+        sys: { id: sys.id, type: 'Experience', version: sys.version },
+        ...body,
+        name: testName('ReleaseExperience Updated'),
+      },
+    )
+
+    expect(updated.name).toBe(testName('ReleaseExperience Updated'))
+    expect(updated.sys.version).toBeGreaterThan(current.sys.version)
+  })
+
+  it('deletes a release experience', async () => {
+    await client.releaseExperience.delete({ releaseId, experienceId: releaseExperienceId })
+    await expect(
+      client.releaseExperience.get({ releaseId, experienceId: releaseExperienceId }),
+    ).rejects.toThrow()
+
+    const index = createdReleaseExperienceIds.indexOf(releaseExperienceId)
+    if (index !== -1) createdReleaseExperienceIds.splice(index, 1)
+  })
+})

--- a/test/integration/release-experience-integration.test.ts
+++ b/test/integration/release-experience-integration.test.ts
@@ -92,7 +92,7 @@ describe('ReleaseExperience Integration', { sequential: true }, () => {
     await timeoutToCalmRateLimiting()
   })
 
-  it('has correct sys fields after creation', async () => {
+  it('gets a release experience by ID with the expected sys fields', async () => {
     const experience = await client.releaseExperience.get({
       releaseId,
       experienceId: releaseExperienceId,
@@ -107,16 +107,6 @@ describe('ReleaseExperience Integration', { sequential: true }, () => {
     expect(experience.sys.experienceTemplate.sys.linkType).toBe('Contentful:ExperienceTemplate')
     expect(experience.sys.experienceTemplate.sys.urn).toContain(experienceTemplateId)
     expect(experience.name).toBe(testName('ReleaseExperience'))
-  })
-
-  it('gets a release experience by ID', async () => {
-    const fetched = await client.releaseExperience.get({
-      releaseId,
-      experienceId: releaseExperienceId,
-    })
-
-    expect(fetched.sys.id).toBe(releaseExperienceId)
-    expect(fetched.sys.release.sys.id).toBe(releaseId)
   })
 
   it('lists release experiences with cursor pagination', async () => {

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -257,7 +257,44 @@ export async function sweepStaleExoEntities(
     }
   }
 
+  const sweepReleases = async () => {
+    try {
+      const { items } = await client.release.query({ query: { limit: 100 } })
+      for (const release of items) {
+        if (release.title.startsWith(TEST_PREFIX) && new Date(release.sys.createdAt) < cutoff) {
+          try {
+            const { items: releaseExperiences } = await client.releaseExperience.getMany({
+              releaseId: release.sys.id,
+              query: { limit: 100 },
+            })
+            for (const experience of releaseExperiences) {
+              try {
+                await client.releaseExperience.delete({
+                  releaseId: release.sys.id,
+                  experienceId: experience.sys.id,
+                })
+              } catch {
+                // best-effort cleanup
+              }
+            }
+          } catch {
+            // ignore if listing release experiences fails
+          }
+
+          try {
+            await client.release.delete({ releaseId: release.sys.id })
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    } catch {
+      // ignore if listing releases fails
+    }
+  }
+
   // Sweep dependents first, then parents
+  await sweepReleases()
   await Promise.all([
     sweepExperiences(),
     sweepFragments(),

--- a/test/unit/adapters/REST/endpoints/release-experience.test.ts
+++ b/test/unit/adapters/REST/endpoints/release-experience.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from 'vitest'
+import setupRestAdapter from '../helpers/setupRestAdapter'
+
+const releaseParams = {
+  spaceId: 'space123',
+  environmentId: 'master',
+  releaseId: 'release123',
+}
+
+const experienceResponse = {
+  sys: {
+    id: 'experience123',
+    type: 'Experience',
+    version: 1,
+    release: { sys: { type: 'Link', linkType: 'Release', id: 'release123' } },
+  },
+  name: 'Release Experience',
+  description: 'An experience in a release',
+  viewports: [],
+  designProperties: {},
+}
+
+describe('Rest ReleaseExperience', () => {
+  test('getMany calls the release-scoped URL and passes query parameters', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(
+      Promise.resolve({ data: { sys: { type: 'Array' }, limit: 100, items: [] } }),
+    )
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseExperience',
+        action: 'getMany',
+        userAgent: 'mocked',
+        params: {
+          ...releaseParams,
+          query: { limit: 20, pageNext: 'next-page-token' },
+        },
+      })
+      .then(() => {
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/release123/experiences',
+        )
+        expect(httpMock.get.mock.calls[0][1].params).to.eql({
+          limit: 20,
+          pageNext: 'next-page-token',
+        })
+        expect(httpMock.get.mock.calls[0][1].headers['x-contentful-enable-alpha-feature']).to.eql(
+          'new-exo-entity-types',
+        )
+      })
+  })
+
+  test('get calls the release-scoped URL', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(
+      Promise.resolve({ data: experienceResponse }),
+    )
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseExperience',
+        action: 'get',
+        userAgent: 'mocked',
+        params: { ...releaseParams, experienceId: 'experience123' },
+      })
+      .then((result) => {
+        expect(result).to.eql(experienceResponse)
+        expect(httpMock.get.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/release123/experiences/experience123',
+        )
+      })
+  })
+
+  test('create calls the release-scoped URL with POST', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(
+      Promise.resolve({ data: experienceResponse }),
+    )
+    const payload = {
+      name: 'Release Experience',
+      description: 'An experience in a release',
+      viewports: [],
+      designProperties: {},
+      experienceTemplate: {
+        sys: {
+          type: 'ResourceLink',
+          linkType: 'Contentful:ExperienceTemplate',
+          urn: 'crn:contentful:::experience-template/template123',
+        },
+      },
+    }
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseExperience',
+        action: 'create',
+        userAgent: 'mocked',
+        params: releaseParams,
+        payload,
+      })
+      .then((result) => {
+        expect(result).to.eql(experienceResponse)
+        expect(httpMock.post.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/release123/experiences',
+        )
+        expect(httpMock.post.mock.calls[0][1]).to.eql(payload)
+      })
+  })
+
+  test('upsert calls the release-scoped URL and sends the version header', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(
+      Promise.resolve({ data: experienceResponse }),
+    )
+    const payload = {
+      sys: { id: 'experience123', type: 'Experience', version: 2 },
+      name: 'Updated Release Experience',
+      description: 'An updated experience in a release',
+      viewports: [],
+      designProperties: {},
+    }
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseExperience',
+        action: 'upsert',
+        userAgent: 'mocked',
+        params: { ...releaseParams, experienceId: 'experience123' },
+        payload,
+      })
+      .then(() => {
+        expect(httpMock.put.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/release123/experiences/experience123',
+        )
+        expect(httpMock.put.mock.calls[0][1].sys).to.be.undefined
+        expect(httpMock.put.mock.calls[0][2].headers['X-Contentful-Version']).to.eql(2)
+      })
+  })
+
+  test('delete calls the release-scoped URL', async () => {
+    const { httpMock, adapterMock } = setupRestAdapter(Promise.resolve({ data: {} }))
+
+    return adapterMock
+      .makeRequest({
+        entityType: 'ReleaseExperience',
+        action: 'delete',
+        userAgent: 'mocked',
+        params: { ...releaseParams, experienceId: 'experience123' },
+      })
+      .then(() => {
+        expect(httpMock.delete.mock.calls[0][0]).to.eql(
+          '/spaces/space123/environments/master/releases/release123/experiences/experience123',
+        )
+      })
+  })
+})


### PR DESCRIPTION
[AIS-140](https://contentful.atlassian.net/browse/AIS-140)\n\n## Summary\n- Add release-scoped Experience getMany, get, create, upsert, and delete methods.\n- Reuse the ExO alpha header and expose public/plain-client types and endpoint coverage.\n\n## Test plan\n- [x] npm run test:unit (921 tests)\n- [x] npm run test:types (30 tests)\n- [x] npm run build:types\n- [x] npm run lint\n\nGenerated with [Codex](https://Codex.com/Codex)

[AIS-140]: https://contentful.atlassian.net/browse/AIS-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This change simplifies the Release Experience integration test suite by consolidating duplicate retrieval coverage into one more descriptive test. The resulting test retains the relevant system-field and relationship assertions while eliminating an unnecessary second API request.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Consolidates duplicate release Experience get-by-ID coverage in release-experience-integration.test.ts, retaining assertions for the Experience identity, version, release link, template link, and name.</li>

<li>Removes the redundant retrieval test and its additional API call without changing the release Experience client implementation or its runtime behavior.</li>

</ul>
</details>

</div>