### PR TITLE
docs: add AGENTS.md, ARCHITECTURE.md and first decision record [DX-1310]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,146 @@
+# AGENTS.md
+
+Operating notes for coding agents working in `contentful-management.js`, the
+JavaScript/TypeScript SDK for Contentful's Content Management API (CMA).
+
+Read [ARCHITECTURE.md](ARCHITECTURE.md) before changing anything under `lib/`.
+Human-facing contribution rules live in [CONTRIBUTING.md](CONTRIBUTING.md); the
+public API is documented in [README.md](README.md) and breaking changes in
+[MIGRATION.md](MIGRATION.md).
+
+## Ground rules
+
+- This is a published npm package (`contentful-management`) with a large
+  installed base. Anything that changes an exported type or a method signature
+  is a breaking change for consumers, and breaking changes belong in a major
+  release documented in `MIGRATION.md`.
+- The version in `package.json` is literally
+  `0.0.0-determined-by-semantic-release`. Never hand-edit it, and never edit
+  `CHANGELOG.md` — both are owned by semantic-release.
+- Do not touch `dist/`. It is build output and is not committed.
+- The legacy chained client is deprecated (see
+  `docs/ADRs/2026-08-25-default-to-plain-client.md`). Add new endpoints to the
+  plain client only, unless a ticket explicitly asks for legacy parity.
+
+## Environment
+
+- Node `>=20` per `package.json` `engines`; `.nvmrc` pins `v22` and CI runs
+  Node 22.
+- `npm ci` to install. `.npmrc` sets `ignore-scripts=true`, so dependency
+  lifecycle scripts do not run on install.
+- `husky` installs a `pre-commit` hook that runs `lint-staged`, which applies
+  `prettier --write` and `eslint --fix` to staged `lib/**` and `test/**`
+  `.js`/`.ts` files, and `prettier --write` to staged `*.md` files.
+
+## Commands
+
+All of these are npm scripts defined in `package.json`. Do not invent commands.
+
+| Task                   | Command                                                |
+| ---------------------- | ------------------------------------------------------ |
+| Build all bundles      | `npm run build`                                        |
+| Type declarations only | `npm run build:types`                                  |
+| Lint                   | `npm run lint` (`npm run lint:fix` to autofix)         |
+| Format check           | `npm run format:check` (`npm run format:fix` to write) |
+| Unit tests             | `npm run test:unit`                                    |
+| Unit tests + coverage  | `npm run test:unit:cover`                              |
+| Type-level tests       | `npm run test:types`                                   |
+| Bundle size budget     | `npm run test:size`                                    |
+| Everything             | `npm test`                                             |
+
+`npm run test:unit` is the loop to use while developing. It is fast, hermetic,
+and needs no credentials — `vitest.setup.unit.ts` mocks `createHttpClient` from
+`contentful-sdk-core`, so no HTTP leaves the machine.
+
+### Tests that need credentials
+
+`npm run test:integration` and `npm run test:demo-projects` run against a real
+Contentful organization. Per `.github/workflows/`, both need
+`CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN` and `CONTENTFUL_ORGANIZATION_ID`, and
+the integration suite additionally needs `TASKS_APP_DEFINITION_ID`. If you do
+not have those, do not attempt these suites — CI runs them on the PR.
+`npm run test:browser` additionally downloads Playwright browsers.
+
+Vitest projects are declared in `vitest.workspace.js`: `unit`, `types`,
+`integration`, `output`, `browser-unit`, `browser-integration`. Select one with
+`npx vitest --project <name> --run`.
+
+## Where things live
+
+- `lib/index.ts` — the only public entry point. `createClient` lives here.
+- `lib/plain/` — the plain (default) client. `plain-client.ts` builds the
+  method tree, `plain-client-types.ts` is its public type, `wrappers/wrap.ts`
+  turns an `(entityType, action)` pair into a callable.
+- `lib/adapters/REST/endpoints/` — one module per entity, holding the actual URL
+  and HTTP verb. This is where the CMA is really called. `raw.ts` holds the
+  verb helpers, `index.ts` is the registry.
+- `lib/common-types.ts` — the `MRActions` map that types every
+  `(entityType, action)` pair, plus the `MakeRequest` overload list. Large
+  (~3.6k lines) and central; every new endpoint touches it.
+- `lib/entities/*.ts` — entity prop/`sys` types. Older entities also export
+  `wrap*` helpers and a `create*Api` used by the legacy client; newer ones are
+  types-only.
+- `lib/create-*-api.ts` — the legacy chained client's scoped surfaces
+  (space, environment, entry, organization, app definition, …).
+- `lib/export-types.ts` — the public type barrel re-exported from `index.ts`.
+- `test/unit/` — unit tests mirroring `lib/`. `test/integration/` — live CMA
+  tests. `test/output-integration/` — consumes the built package from
+  `dist/` as a real dependency.
+
+## Adding a CMA endpoint
+
+The file set below is what real feature commits touch. For a complete worked
+example, see the design tokens commit: `git show --stat 3b36240`.
+
+1. `lib/entities/<entity>.ts` — props, `sys`, create/update payload, query
+   types.
+2. `lib/common-types.ts` — add the entity/action entries to `MRActions` and the
+   matching `MakeRequest` overloads. Without this the call is not typed and
+   `wrap` will not accept it.
+3. `lib/adapters/REST/endpoints/<entity>.ts` — implement each action against
+   `raw.get/post/put/patch/del`. Export `del`, not `delete`; `make-request.ts`
+   maps the `delete` action to `del`.
+4. `lib/adapters/REST/endpoints/index.ts` — register the module. `makeRequest`
+   resolves `endpoints[entityType][action]` and throws
+   `Error('Unknown endpoint')` if it is missing.
+5. `lib/plain/entities/<entity>.ts` — the typed public surface, with TSDoc and
+   an `@example`. Wrap params in `OptionalDefaults<>` so client `defaults` stay
+   optional.
+6. `lib/plain/plain-client-types.ts` and `lib/plain/plain-client.ts` — add the
+   key and its `wrap(wrapParams, '<Entity>', '<action>')` entries.
+7. `lib/export-types.ts` — export the new public types.
+8. `test/unit/adapters/REST/endpoints/<entity>.test.ts` — assert URL, verb, and
+   headers. Add an integration test only if the endpoint can be exercised
+   against a real space.
+
+## Commits, PRs, releases
+
+- Conventional Commits, enforced by semantic-release's commit-analyzer.
+  `feat:` → minor, `fix:` → patch, `build(deps):` → patch (configured in the
+  `release.releaseRules` block of `package.json`), `feat!:`/`BREAKING CHANGE:`
+  → major. `chore:` and `docs:` release nothing.
+- Include the Jira key in the subject, matching existing history:
+  `feat: add ExO entity support [DX-796] (#3034)`.
+- Releasable branches are `master`, `beta`, `canary`, `dev`, and maintenance
+  branches matching `+([0-9])?(.{+([0-9]),x}).x`. A merge to `master` publishes
+  to npm and republishes the typedoc site — treat `master` as live.
+- The default branch is `master`, not `main`. Open PRs against `master`.
+- CI (`.github/workflows/main.yaml`) chains `build` → `check` →
+  `test-demo-projects` → `test-integration` → `release`. The `check` job runs
+  lint, format check, unit tests with coverage, and the size limit.
+
+## Gotchas
+
+- `npm run test:size` enforces a `177 kB` limit on `dist/cjs/index.cjs`
+  (`size-limit` block in `package.json`). Adding a dependency can fail CI here.
+- `__VERSION__` is injected by rollup at build time. Unit tests get it from
+  `vitest.setup.ts`; referencing it elsewhere needs the same treatment.
+- `lib/**` forbids implicit type imports —
+  `@typescript-eslint/consistent-type-imports` is an `error`. Use
+  `import type`.
+- Enums must be re-exported with a value `export {}` in `lib/index.ts`;
+  `export type *` strips their runtime value. See the comment above the
+  `WorkflowStepPermission*` exports.
+- `CONTRIBUTING.md` and `SETUP.md` still describe the pre-v12 toolchain (Babel,
+  Karma, webpack, `standard`, `index.js`/`browser.js` entry points). The real
+  toolchain is rollup + vitest + eslint + prettier. Trust `package.json`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,194 @@
+# Architecture
+
+`contentful-management.js` is the JavaScript/TypeScript SDK for Contentful's
+Content Management API (CMA). It is published to npm as
+`contentful-management` and ships ESM, CommonJS, browser IIFE, and `.d.ts`
+outputs from a single TypeScript source tree in `lib/`.
+
+This document describes how the source is organised and how a call travels from
+user code to the CMA. For contribution mechanics see
+[CONTRIBUTING.md](CONTRIBUTING.md); for agent-oriented working notes see
+[AGENTS.md](AGENTS.md).
+
+## Request path
+
+Every CMA call, on either client surface, funnels through the same four stages:
+
+```
+user code
+  │
+  ├─ createClient()                      lib/index.ts
+  │    builds the user-agent, creates the adapter, picks a client surface
+  │
+  ├─ plain client  (default)             lib/plain/plain-client.ts
+  │    or legacy chained client          lib/create-contentful-api.ts
+  │        both call a single `makeRequest(opts)` closure
+  │
+  ├─ Adapter.makeRequest                 lib/adapters/REST/rest-adapter.ts
+  │    axios instance from contentful-sdk-core (rate limiting, retries)
+  │
+  └─ endpoint lookup                     lib/adapters/REST/make-request.ts
+       endpoints[entityType][action] → lib/adapters/REST/endpoints/<entity>.ts
+       → raw.get / post / put / patch / del → HTTPS to api.contentful.com
+```
+
+The narrow waist is `makeRequest`. Clients never see axios, URLs, or HTTP
+verbs; they only produce a `MakeRequestOptions` object
+(`{ entityType, action, params, payload, headers, userAgent }`, defined in
+`lib/common-types.ts`). `make-request.ts` resolves that pair against the
+`endpoints` registry and throws `Error('Unknown endpoint')` when the entity or
+action is not registered. Because `delete` is a reserved word, endpoint modules
+export `del` and `make-request.ts` rewrites the `delete` action to `del`.
+
+## Two client surfaces
+
+`createClient` in `lib/index.ts` returns one of two shapes, selected by the
+second argument:
+
+- **Plain client** (`{ type: 'plain' }` or no options) — the default. A flat
+  tree of `client.<entity>.<action>(params, payload)` methods returning plain
+  JSON objects. Built in `lib/plain/plain-client.ts`; its public type is
+  `PlainClientAPI` in `lib/plain/plain-client-types.ts`.
+- **Legacy chained client** (`{ type: 'legacy' }`) — deprecated. Returns
+  entity objects that carry their own methods (`space.getEnvironment()` →
+  `environment.getEntries()` → `entry.update()`). It logs a deprecation warning
+  on construction. See
+  [docs/ADRs/2026-08-25-default-to-plain-client.md](docs/ADRs/2026-08-25-default-to-plain-client.md).
+
+The two surfaces are also distinguishable server-side: the `X-Contentful-User-Agent`
+header reports `contentful-management-plain.js` for the plain client and
+`contentful-management.js` for the legacy one.
+
+### Plain client
+
+`lib/plain/wrappers/wrap.ts` holds the whole mechanism. Calling
+`wrap(wrapParams, entityType, action)` returns a function that merges the
+client-level `defaults` into the caller's `params` and hands the result to
+`makeRequest`. So `plain-client.ts` is almost entirely declarative:
+
+```ts
+designToken: {
+  getMany: wrap(wrapParams, 'DesignToken', 'getMany'),
+  get: wrap(wrapParams, 'DesignToken', 'get'),
+  // …
+}
+```
+
+Types do the real work. `MRActions` in `lib/common-types.ts` maps every
+`entityType → action → { params, payload, headers, return }`, and `WrapFn`
+derives each method's arity and signature from that entry. `OptionalDefaults<T>`
+makes the fields that can come from client `defaults` (`spaceId`,
+`environmentId`, `organizationId`, `releaseId`, `releaseSchemaVersion`)
+optional at the call site. Type-level tests for this live in
+`lib/plain/wrappers/wrap.test-d.ts` and run under `npm run test:types`.
+
+`lib/plain/` also carries the pagination and state helpers exported from
+`index.ts`: `as-iterator.ts` (`asIterator`), `pagination-helper.ts`
+(`fetchAll`), and `checks.ts` (`isDraft`, `isPublished`, `isUpdated`).
+
+### Legacy chained client
+
+`lib/create-contentful-api.ts` builds the root object, and the scoped surfaces
+live in the sibling `lib/create-*-api.ts` files — `create-space-api.ts`,
+`create-environment-api.ts`, `create-entry-api.ts`,
+`create-organization-api.ts`, `create-app-definition-api.ts`,
+`create-environment-template-api.ts`, `create-ui-config-api.ts`,
+`create-user-ui-config-api.ts`.
+
+Entity objects are built by `wrap*` functions in `lib/entities/*.ts`, which
+attach methods to the raw API payload via
+`lib/enhance-with-methods.ts`. That helper defines methods as
+non-enumerable/non-writable properties, so `JSON.stringify` and cloning of an
+entity yield just the data. `lib/common-utils.ts` provides the collection
+equivalents (`wrapCollection`, `wrapCursorPaginatedCollection`).
+
+## Directory map
+
+| Path                                       | Contents                                                                                                   |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `lib/index.ts`                             | Public entry point: `createClient`, re-exports, enum exports                                               |
+| `lib/common-types.ts`                      | `MRActions`, `MakeRequest` overloads, `Adapter`, shared param/collection types (~3.6k lines)               |
+| `lib/common-utils.ts`                      | Collection wrappers, cursor-pagination normalisation                                                       |
+| `lib/create-adapter.ts`                    | Returns a caller-supplied `apiAdapter`, else a new `RestAdapter`                                           |
+| `lib/adapters/REST/rest-adapter.ts`        | `RestAdapter`: axios instance, default hosts, CMA content type                                             |
+| `lib/adapters/REST/make-request.ts`        | Entity/action → endpoint dispatch                                                                          |
+| `lib/adapters/REST/endpoints/`             | 93 modules: one per entity, plus `raw.ts` (HTTP verbs), `http.ts`, `utils.ts`, and the `index.ts` registry |
+| `lib/entities/`                            | 91 entity type definitions; older ones also hold `wrap*` and `create*Api` for the legacy client            |
+| `lib/plain/`                               | Plain client, its types, `wrap`, iterators and pagination helpers                                          |
+| `lib/plain/entities/`                      | 67 per-entity plain API type modules with TSDoc examples, plus `space.test-d.ts`                           |
+| `lib/create-*-api.ts`                      | Legacy chained client surfaces                                                                             |
+| `lib/methods/`                             | Cross-entity helpers: `action.ts`, `release-action.ts`, `content-type.ts`, `utils.ts`                      |
+| `lib/constants/editor-interface-defaults/` | Default control/editor/sidebar widget definitions, exported as `editorInterfaceDefaults`                   |
+| `lib/upload-http-client.ts`                | Clones the axios instance against `upload.contentful.com` with a longer timeout                            |
+| `lib/export-types.ts`                      | Public type barrel re-exported by `index.ts`                                                               |
+
+## Pluggable adapter
+
+`lib/create-adapter.ts` accepts either `RestAdapterParams` (an `accessToken`,
+optional `host`/`hostUpload`) or `AdapterParams` (`{ apiAdapter }`), typed as a
+mutually exclusive `XOR` in `ClientOptions`. Anything implementing
+`Adapter { makeRequest }` can replace the REST transport.
+
+This is what lets Contentful apps use the SDK without a management token: the
+App SDK passes `sdk.cmaAdapter` as `apiAdapter`, and requests are proxied
+through the host web app with the app's own permissions (see the App Framework
+section of `README.md`). It is also how unit tests avoid the network.
+
+`RestAdapter` itself delegates to `createHttpClient` from `contentful-sdk-core`,
+which supplies rate-limit handling and retries; the SDK does not implement
+those itself.
+
+## Build
+
+`rollup.config.mjs` emits five outputs from the single input `lib/index.ts`:
+
+| Output                      | Format  | Notes                                               |
+| --------------------------- | ------- | --------------------------------------------------- |
+| `dist/esm/index.mjs`        | ESM     | `preserveModules`, dependencies external            |
+| `dist/cjs/index.cjs`        | CJS     | Single bundle, `interop: 'auto'`                    |
+| `dist/types/`               | `.d.ts` | Declarations only                                   |
+| `dist/browser/index.js`     | IIFE    | Global `contentfulManagement`, dependencies bundled |
+| `dist/browser/index.min.js` | IIFE    | The above, terser-minified                          |
+
+The browser builds deliberately set `external: []` and alias `axios` to its
+browser build and `process` to `process/browser`, polyfilling only `util`. The
+ESM and CJS builds do not bundle dependencies. `package.json` `exports` gates
+the public surface to `.` and `./types`; deep imports into `dist/` are not
+supported. Target is ES2021 (`tsconfig.json`), with the supported browser floor
+in the `browserslist` field.
+
+## Testing
+
+Vitest, with projects declared in `vitest.workspace.js`:
+
+- `unit` — 122 test files under `test/unit/`, mirroring `lib/`. Hermetic:
+  `vitest.setup.unit.ts` mocks `createHttpClient`, and `test/unit/mocks/`
+  supplies entity fixtures, an HTTP double, and a `makeRequest` double.
+  `test/unit/test-creators/` holds shared assertions for the repeated
+  instance/static entity method shapes.
+- `types` — `*.test-d.ts` files inside `lib/`, run with `typecheck.enabled`.
+- `integration` — 68 test files under `test/integration/` against a real
+  Contentful organization; serialised (`maxWorkers: 1`) with long timeouts.
+- `output` — `test/output-integration/{node,browser}`, standalone projects that
+  consume the build artifacts to prove they actually load. The node project
+  installs the package as a `file:` dependency; the browser project copies
+  `dist/browser/index.min.js` into a served page and drives it with puppeteer.
+- `browser-unit` / `browser-integration` — the same suites under Playwright
+  Chromium.
+
+## Release
+
+semantic-release owns versioning. `package.json` keeps the literal version
+`0.0.0-determined-by-semantic-release`; the real number is derived from
+Conventional Commit messages at publish time, and `CHANGELOG.md` is generated
+by `@semantic-release/changelog`.
+
+`.github/workflows/main.yaml` runs `build` → `check` → `test-demo-projects` →
+`test-integration` → `release`. `release.yaml` retrieves a GitHub token from
+HashiCorp Vault, runs `npm run semantic-release`, and on `master` also runs
+`npm run docs:publish` to regenerate the typedoc reference site. Releasable
+branches are `master`, `beta` (channel `beta`), `canary`, `dev` (channel
+`dev`), and maintenance branches matching `+([0-9])?(.{+([0-9]),x}).x`.
+
+`npm run test:size` enforces a 177 kB budget on `dist/cjs/index.cjs` via
+`size-limit`, so bundle growth is a release-blocking signal.

--- a/docs/ADRs/2026-08-25-default-to-plain-client.md
+++ b/docs/ADRs/2026-08-25-default-to-plain-client.md
@@ -1,0 +1,103 @@
+# Default `createClient` to the plain client and deprecate the chained client
+
+- **Date:** 2026-08-25
+- **Status:** Accepted — shipped in v12
+- **Evidence:**
+  - commit `84a3431` — "feat!: v12 major release [DX-455]" (PR #2936), which
+    contains the sub-commits "chore: deprecate waterfall client [DX-674]"
+    (PR #2865) and "feat!: Default to plain client instead of waterfall client
+    [DX-690]" (PR #2867)
+  - current state of `lib/index.ts`
+  - `MIGRATION.md`, section "Default client changed from nested to plain"
+  - `README.md`, section "Legacy Client Interface"
+
+> This record was written on 2026-08-25 from the commit history and the
+> shipped code. It documents an existing decision rather than a new one. The
+> rationale below is drawn from the migration guide, the README, and the code
+> itself; it is a reconstruction, not a contemporaneous account.
+
+## Context
+
+The SDK has carried two client surfaces since before v12:
+
+- The **chained** client (called "nested", "legacy", or "waterfall" in
+  different places in the repo) reads and writes as a sequence of nested
+  requests — `client.getSpace(id)` → `space.getEnvironment(id)` →
+  `environment.getEntries()`. Each returned object is an entity carrying its
+  own methods, attached via `lib/enhance-with-methods.ts`.
+- The **plain** client exposes one flat namespace,
+  `client.<entity>.<action>(params)`, returning plain JSON objects. It is built
+  declaratively in `lib/plain/plain-client.ts` on top of
+  `lib/plain/wrappers/wrap.ts`, and typed from the `MRActions` map in
+  `lib/common-types.ts`.
+
+Both surfaces sit on the same `makeRequest` waist and the same
+`lib/adapters/REST/endpoints/` modules, so the difference is ergonomics and
+types, not transport.
+
+Keeping both as first-class options had costs the repo can still show:
+
+- Reaching a nested resource required awaiting intermediate requests the caller
+  did not want. The README states the plain client's benefit as "the ability to
+  reach any possible CMA endpoint without the necessity to call any async
+  functions beforehand", and calls that out as especially important for
+  non-linear code such as front-end applications.
+- Chained-client results are entity objects with non-enumerable methods, so
+  serialising them cleanly needs `toPlainObject`. Plain-client results are
+  already plain data.
+- Only the plain client can be scoped at construction time via `defaults`
+  (`spaceId`, `environmentId`, `organizationId`, …), applied by `wrap`.
+- Every new entity had to be wired into two surfaces. The chained client needs
+  a `wrap*`/`create*Api` pair in `lib/entities/` plus placement in the right
+  `lib/create-*-api.ts` scope; the plain client needs one line per action.
+- `@contentful/app-sdk@4` integration assumes the plain shape: apps pass
+  `sdk.cmaAdapter` as `apiAdapter` together with `defaults`.
+
+v12 was already a breaking release (ESM/CJS rebuild, Node 20 floor, ES2021
+target), which made it the point at which the default could be changed without
+an extra major.
+
+## Decision
+
+1. `createClient(options)` and `createClient(options, { type: 'plain' })`
+   return `PlainClientAPI`. The plain client is the default.
+2. The chained client is available only by explicitly passing
+   `{ type: 'legacy' }`. That overload is marked `@deprecated` in `lib/index.ts`
+   and logs a `console.warn` on construction stating it will be removed in the
+   next major version.
+3. The two surfaces are distinguishable in telemetry: the
+   `X-Contentful-User-Agent` header reports `contentful-management-plain.js`
+   for the plain client and `contentful-management.js` for the legacy one.
+4. New CMA endpoints are added to the plain client. The chained client is not
+   extended as a matter of course — see Consequences for the exceptions that
+   have landed since.
+
+## Consequences
+
+- Existing code calling `createClient({ accessToken })` and expecting nested
+  entity objects breaks on upgrade to v12 and must pass `{ type: 'legacy' }`.
+  This is documented in `MIGRATION.md` under "Default client changed from
+  nested to plain", alongside the related renames (`DefaultParams` →
+  `PlainClientDefaultParams`, removal of `ClientParams`).
+- Consumers pinned to the chained client have a bounded runway: it is scheduled
+  for removal in the next major, and every legacy client construction emits a
+  console warning until then.
+- The two surfaces have already diverged, though not uniformly. The
+  Experiences (ExO) entity family added after v12 — component types,
+  experiences, experience fragments, experience templates, fragments, data
+  assemblies, design tokens (commits `f3eaed9`, `3b36240`, `cc86f6f`) — is
+  plain-only: e.g. `lib/entities/design-token.ts` is types-only, with no
+  `wrap*` or `create*Api` helper, and `designToken` appears in
+  `lib/plain/plain-client.ts` but in none of the `lib/create-*-api.ts` files.
+  Other post-v12 additions were still wired into both surfaces, such as space
+  add-ons (`2f94b76`, which touches `lib/create-organization-api.ts`). So
+  "use the legacy client" is not a general escape hatch — coverage there
+  depends on the entity, and newer ExO endpoints are not reachable from it at
+  all.
+- Adding an endpoint is now a single-surface change, which is why the checklist
+  in `AGENTS.md` describes only the plain path.
+- The chained-client machinery (`lib/create-*-api.ts`, `enhance-with-methods.ts`,
+  and the `wrap*`/`create*Api` halves of `lib/entities/`) still ships in the
+  bundle and still counts against the 177 kB `size-limit` budget on
+  `dist/cjs/index.cjs`. Removing it in the next major will shrink the shipped
+  bundle.

--- a/docs/ADRs/README.md
+++ b/docs/ADRs/README.md
@@ -1,0 +1,6 @@
+# Architectural Decision Records
+
+Records of significant architectural decisions in this repository. Each file is
+named `YYYY-MM-DD-<kebab-case-title>.md`, dated when the record was written.
+
+- [2026-08-25 — Default `createClient` to the plain client and deprecate the chained client](2026-08-25-default-to-plain-client.md)


### PR DESCRIPTION
Closes the AI harness readiness gaps for this repo (DX-1310, parent DX-1296).

## Controls closed

| Control | Status |
| --- | --- |
| `AGENTS.md` at repo root | added (124 non-blank lines) |
| `ARCHITECTURE.md` at repo root | added (159 non-blank lines) |
| decision record under `docs/ADRs/` | added (90 non-blank lines) |
| `CONTRIBUTING.md` | already passing — **untouched** |

## Files

- `AGENTS.md` — working notes for coding agents: the real npm scripts from
  `package.json`, which suites are hermetic vs. which need Contentful
  credentials, the file-by-file checklist for adding a CMA endpoint (derived
  from real feature commits), semantic-release and branch rules, and
  repo-specific gotchas.
- `ARCHITECTURE.md` — the request path from `createClient` through the
  `makeRequest` waist to `lib/adapters/REST/endpoints/`, the two client
  surfaces, the pluggable `Adapter`, the five rollup outputs, the vitest
  project layout, and the release flow.
- `docs/ADRs/2026-08-25-default-to-plain-client.md` — decision record for
  defaulting `createClient` to the plain client and deprecating the chained
  client.
- `docs/ADRs/README.md` — one-line index of the record.

## ADR reconstruction disclosure

The ADR documents a decision that was made in v12, not a new one. It is a
**reconstruction written after the fact**, and says so in a callout at the top
of the file. The rationale is drawn from `MIGRATION.md`, `README.md`, and the
code, and the record cites its evidence:

- commit `84a3431` — "feat!: v12 major release [DX-455]" (#2936), containing
  the sub-commits "chore: deprecate waterfall client [DX-674]" (#2865) and
  "feat!: Default to plain client instead of waterfall client [DX-690]" (#2867)
- the current `createClient` overloads in `lib/index.ts`
- `MIGRATION.md` § "Default client changed from nested to plain"
- `README.md` § "Legacy Client Interface"
- the post-v12 divergence between the two surfaces: the ExO entity family
  (`f3eaed9`, `3b36240`, `cc86f6f`) is plain-only, while space add-ons
  (`2f94b76`) were still wired into `lib/create-organization-api.ts`

## Notes for reviewers

- Docs only. No source, build, config, or `.gitignore` changes. No installs,
  builds, or test suites were run.
- `docs:` commit type, so this does not trigger a semantic-release.
- While reading the repo I noticed `CONTRIBUTING.md` and `SETUP.md` still
  describe the pre-v12 toolchain (Babel, Karma, webpack, `standard`,
  `index.js`/`browser.js` entry points) and reference npm scripts that no
  longer exist. I did not touch either file — `CONTRIBUTING.md` already passes
  the control and refreshing it is out of scope here. `AGENTS.md` calls the
  discrepancy out so agents trust `package.json` instead. Worth a follow-up
  ticket.


[DX-455]: https://contentful.atlassian.net/browse/DX-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ